### PR TITLE
Added a check on topics containing newline characters

### DIFF
--- a/mqtt4bytes/src/lib.rs
+++ b/mqtt4bytes/src/lib.rs
@@ -32,6 +32,7 @@ pub enum Error {
     BoundaryCrossed,
     MalformedRemainingLength,
     InsufficientBytes(usize),
+    InvalidTopic,
 }
 
 /// Encapsulates all MQTT packet types

--- a/mqtt4bytes/src/packets/publish.rs
+++ b/mqtt4bytes/src/packets/publish.rs
@@ -287,5 +287,21 @@ mod test {
             ]
         );
     }
-}
 
+    #[test]
+    fn topic_no_newline() {
+        let publish = Publish {
+            dup: false,
+            qos: QoS::AtMostOnce,
+            retain: false,
+            topic: "a\nb".to_owned(),
+            pkid: 0,
+            payload: Bytes::from(vec![0xE1, 0xE2, 0xE3, 0xE4]),
+        };
+        let mut buf = BytesMut::new();
+        let result = publish.write(&mut buf);
+
+        let err = result.expect_err("Cannot write a topic with a newline");
+        assert_eq!(err, crate::Error::InvalidTopic);
+    }
+}

--- a/mqtt4bytes/src/packets/publish.rs
+++ b/mqtt4bytes/src/packets/publish.rs
@@ -88,6 +88,9 @@ impl Publish {
     }
 
     pub fn write(&self, payload: &mut BytesMut) -> Result<usize, Error> {
+        if self.topic.contains(|c| c == '\n' || c == '\r') {
+            return Err(Error::InvalidTopic);
+        }
         let dup = self.dup as u8;
         let qos = self.qos as u8;
         let retain = self.retain as u8;


### PR DESCRIPTION
Ran into an issue where my topic accidentally had a newline character. rumqttc handled this by disconnecting and not logging any errors.
