### PR TITLE
Fix compilation error in state.rs

### DIFF
--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -75,7 +75,7 @@ impl MqttState {
             // index 0 is wasted as 0 not a valid packet id
             outgoing_pub: vec![None; max_inflight as usize + 1],
             outgoing_rel: vec![None; max_inflight as usize + 1],
-            incoming_pub: vec![None; u16::MAX as usize + 1],
+            incoming_pub: vec![None; std::u16::MAX as usize + 1],
         }
     }
 


### PR DESCRIPTION
This PR fixes a compilation error in the the `rumqttc` crate on the `master` branch:

```
error[E0599]: no associated item named `MAX` found for type `u16` in the current scope
  --> /home/dwagner/.cargo/git/checkouts/rumqtt-5c5ad7136a67b3df/b57ffbf/rumqttc/src/state.rs:78:43
   |
78 |             incoming_pub: vec![None; u16::MAX as usize + 1],
   |                                           ^^^ associated item not found in `u16`
   |
help: you are looking for the module in `std`, not the primitive type
   |
78 |             incoming_pub: vec![None; std::u16::MAX as usize + 1],

```

I used the following compiler
```
$ rustc --version
rustc 1.41.0
```