### PR TITLE
Set MTU

### DIFF
--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -254,6 +254,8 @@ pub struct MqttOptions {
     tls_client_config: Option<Arc<ClientConfig>>,
 
     conn_timeout: u64,
+    /// mtu
+    mtu: Option<usize>,
 }
 
 impl MqttOptions {
@@ -283,6 +285,7 @@ impl MqttOptions {
             key_type: Key::RSA,
             tls_client_config: None,
             conn_timeout: 5,
+            mtu: Some(1500),
         }
     }
 
@@ -491,6 +494,17 @@ impl MqttOptions {
     /// get timeout in secs
     pub fn timeout(&self) -> u64 {
         self.conn_timeout
+    }
+
+    /// set MTU. Perform a Ping test to determine most optimal MTU
+    pub fn set_mtu(&mut self, mtu: usize) -> &mut Self {
+        self.mtu = Some(mtu);
+        self
+    }
+
+    /// get mtu
+    pub fn get_mtu(&self) -> Option<usize> {
+        self.mtu
     }
 }
 

--- a/rumqttc/src/tls.rs
+++ b/rumqttc/src/tls.rs
@@ -39,6 +39,8 @@ pub async fn tls_connect(options: &MqttOptions) -> Result<TlsStream<TcpStream>, 
         config.clone()
     } else {
         let mut config = ClientConfig::new();
+        // If Client config is provided by User, then its their responsibilty.
+        config.set_mtu(&options.get_mtu());
 
         // Add ca to root store if the connection is TLS
         // NOTE: Adding DER file isn't feasible as some of the chain information


### PR DESCRIPTION
`RUSTLS` sets `MTU` to maximum possible size. This will cause `TLS` error if we send a payload greater than `MTU` of network.

A default value of 1500 is set as recommended by `Cisco` although a ping test is recommended to determine the best `MTU` for a set up.

References

1.[ Ref 1](https://blog.cloudflare.com/path-mtu-discovery-in-practice/)
2. [Ref 2 ](https://community.cisco.com/t5/other-network-architecture/why-the-mtu-size-is-1500/m-p/105422/highlight/true#M35328)
3. [Ref 3](https://networkdirection.net/articles/network-theory/mtu-and-mss/use-ping-to-find-the-mtu/)
4. [Ref 4](https://www.igvita.com/2013/10/24/optimizing-tls-record-size-and-buffering-latency/)


fixes #110 