### PR TITLE
Change return type of rumqttc event loop

### DIFF
--- a/benchmarks/rumqttasyncqos0.rs
+++ b/benchmarks/rumqttasyncqos0.rs
@@ -1,4 +1,4 @@
-use rumqttc::{self, EventLoop, Incoming, MqttOptions, PublishRaw, QoS, Request};
+use rumqttc::{self, Event, EventLoop, Incoming, MqttOptions, PublishRaw, QoS, Request};
 use std::error::Error;
 use std::time::{Duration, Instant};
 
@@ -37,15 +37,9 @@ pub async fn start(id: &str, payload_size: usize, count: usize) -> Result<(), Bo
     });
 
     let start = Instant::now();
-    'main: loop {
-        let (notifications, _) = eventloop.poll().await?;
-        for notification in notifications {
-            match notification {
-                Incoming::PingResp => break 'main,
-                _notification => {
-                    continue;
-                }
-            };
+    loop {
+        if let Event::Incoming(Incoming::PingResp) = eventloop.poll().await? {
+            break;
         }
     }
 

--- a/rumqttc/examples/asyncpubsub.rs
+++ b/rumqttc/examples/asyncpubsub.rs
@@ -1,7 +1,7 @@
 use async_channel::Sender;
 use tokio::{task, time};
 
-use rumqttc::{self, EventLoop, MqttOptions, Publish, QoS, Request, Subscribe};
+use rumqttc::{self, Event, EventLoop, MqttOptions, Publish, QoS, Request, Subscribe};
 use std::error::Error;
 use std::time::Duration;
 
@@ -21,8 +21,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     });
 
     loop {
-        let (incoming, outgoing) = eventloop.poll().await?;
-        println!("Incoming = {:?}, Outgoing = {:?}", incoming, outgoing);
+        match eventloop.poll().await? {
+            Event::Incoming(i) => println!("Incoming = {:?}", i),
+            Event::Outgoing(o) => println!("Outgoing = {:?}", o),
+        }
     }
 }
 

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -1,7 +1,7 @@
 //! This module offers a high level synchronous abstraction to async eventloop.
 //! Uses channels internally to get `Requests` and send `Notifications`
 
-use crate::{ConnectionError, EventLoop, Incoming, MqttOptions, Outgoing, Request};
+use crate::{ConnectionError, Event, EventLoop, MqttOptions, Request};
 
 use async_channel::{SendError, Sender};
 use mqtt4bytes::*;
@@ -137,7 +137,7 @@ pub struct Iter<'a> {
 }
 
 impl<'a> Iterator for Iter<'a> {
-    type Item = Result<(Option<Incoming>, Option<Outgoing>), ConnectionError>;
+    type Item = Result<Event, ConnectionError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let f = self.connection.eventloop.poll();

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -87,7 +87,7 @@ mod tls;
 
 pub use async_channel::{SendError, Sender, TrySendError};
 pub use client::{Client, ClientError, Connection};
-pub use eventloop::{ConnectionError, EventLoop};
+pub use eventloop::{ConnectionError, Event, EventLoop};
 #[cfg(feature = "passthrough")]
 pub use framed::Network;
 pub use mqtt4bytes::*;


### PR DESCRIPTION
Hi!
First of all, thank you all for working on this very nice mqtt library. Looking through the code I was a little bit surprised by the choice that the rumqttc eventloop yielded
```rust
Result<(Option<Incoming>, Option<Outgoing>), ConnectionError>.
```
which made it non-obvious if it could be the case that both an incoming and an outgoing event would be available at the same time and/or if it might be possible that there might be no event at all. This pull request changes the return type to
```rust
Result<Event, ConnectionError>
```
where the event is just
```rust
pub enum Event {
    Incoming(Incoming),
    Outgoing(Outgoing),
}
```
However, since I'm not familiar with this code, there might be a good reason for the previous design choice, so please don't feel pressured to accept this pull request.