### PR TITLE
Specify correct version of crates within this repository.

### DIFF
--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -16,7 +16,7 @@ tokio = { version = "0.2", features = ["full"] }
 bytes = "0.5"
 webpki = "0.21"
 tokio-rustls = "0.14"
-mqtt4bytes = { path = "../mqtt4bytes", version = "0.1"}
+mqtt4bytes = { path = "../mqtt4bytes", version = "0.1.8"}
 pollster = "0.2"
 async-channel = "1.4"
 log = "0.4"

--- a/rumqttd/Cargo.toml
+++ b/rumqttd/Cargo.toml
@@ -18,8 +18,8 @@ name = "rumqttd"
 path = "src/bin.rs"
 
 [dependencies]
-rumqttlog = { path = "../rumqttlog", version = "0.1"}
-mqtt4bytes = { path = "../mqtt4bytes", version = "0.1" }
+rumqttlog = { path = "../rumqttlog", version = "0.1.3"}
+mqtt4bytes = { path = "../mqtt4bytes", version = "0.1.8" }
 tokio = { version = "=0.2.22", features = ["full"]}
 serde = { version = "1", features = ["derive"] }
 log = "0.4"

--- a/rumqttlog/Cargo.toml
+++ b/rumqttlog/Cargo.toml
@@ -12,7 +12,7 @@ byteorder = "1"
 memmap = "0.7"
 bytes = "0.5"
 confy = "0.4"
-mqtt4bytes = { path = "../mqtt4bytes", version = "0.1" }
+mqtt4bytes = { path = "../mqtt4bytes", version = "0.1.8" }
 tokio = { version = "0.2", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"


### PR DESCRIPTION
Otherwise other people who update their dependency on e.g. rumqttc but
have a Cargo.lock with an old version of mqtt4bytes already will get
build failures.