### PR TITLE
Clean up AsyncClient a bit

### DIFF
--- a/benchmarks/rumqttasync.rs
+++ b/benchmarks/rumqttasync.rs
@@ -24,7 +24,7 @@ pub async fn start(id: &str, payload_size: usize, count: usize) -> Result<(), Bo
     mqttoptions.set_inflight(100);
     mqttoptions.set_max_request_batch(10);
 
-    let (mut client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
     task::spawn(async move {
         for _i in 0..count {
             let payload = vec![0; payload_size];

--- a/benchmarks/rumqttasyncqos0.rs
+++ b/benchmarks/rumqttasyncqos0.rs
@@ -24,7 +24,7 @@ pub async fn start(id: &str, payload_size: usize, count: usize) -> Result<(), Bo
     mqttoptions.set_inflight(100);
     mqttoptions.set_max_request_batch(10);
 
-    let (mut client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
     task::spawn(async move {
         for _i in 0..count {
             let payload = vec![0; payload_size];

--- a/rumqttc/examples/asyncpubsub.rs
+++ b/rumqttc/examples/asyncpubsub.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 }
 
-async fn requests(mut client: AsyncClient) {
+async fn requests(client: AsyncClient) {
     client
         .subscribe("hello/world", QoS::AtMostOnce)
         .await

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -22,7 +22,7 @@ pub enum ClientError {
 
 /// `AsyncClient` to communicate with MQTT `Eventloop`
 /// This is cloneable and can be used to asynchronously Publish, Subscribe.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct AsyncClient {
     request_tx: Sender<Request>,
     cancel_tx: Sender<()>,

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -45,7 +45,7 @@ impl AsyncClient {
 
     /// Sends a MQTT Publish to the eventloop
     pub async fn publish<S, V>(
-        &mut self,
+        &self,
         topic: S,
         qos: QoS,
         retain: bool,
@@ -63,11 +63,7 @@ impl AsyncClient {
     }
 
     /// Sends a MQTT Subscribe to the eventloop
-    pub async fn subscribe<S: Into<String>>(
-        &mut self,
-        topic: S,
-        qos: QoS,
-    ) -> Result<(), ClientError> {
+    pub async fn subscribe<S: Into<String>>(&self, topic: S, qos: QoS) -> Result<(), ClientError> {
         let subscribe = Subscribe::new(topic.into(), qos);
         let request = Request::Subscribe(subscribe);
         self.request_tx.send(request).await?;
@@ -75,7 +71,7 @@ impl AsyncClient {
     }
 
     /// Sends a MQTT Unsubscribe to the eventloop
-    pub async fn unsubscribe<S: Into<String>>(&mut self, topic: S) -> Result<(), ClientError> {
+    pub async fn unsubscribe<S: Into<String>>(&self, topic: S) -> Result<(), ClientError> {
         let unsubscribe = Unsubscribe::new(topic.into());
         let request = Request::Unsubscribe(unsubscribe);
         self.request_tx.send(request).await?;
@@ -83,14 +79,14 @@ impl AsyncClient {
     }
 
     /// Sends a MQTT disconnect to the eventloop
-    pub async fn disconnect(&mut self) -> Result<(), ClientError> {
+    pub async fn disconnect(&self) -> Result<(), ClientError> {
         let request = Request::Disconnect;
         self.request_tx.send(request).await?;
         Ok(())
     }
 
     /// Stops the eventloop right away
-    pub async fn cancel(&mut self) -> Result<(), ClientError> {
+    pub async fn cancel(&self) -> Result<(), ClientError> {
         self.cancel_tx.send(()).await?;
         Ok(())
     }


### PR DESCRIPTION
Deriving `Debug` is useful as it may be included in other structs which want to derive `Debug`. The various methods don't need a mutable reference to self as the `async_channel::Sender` is threadsafe.