### PR TITLE
Move keepalive_timeout assignment (fix panic)

### DIFF
--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -475,6 +475,26 @@ mod test {
     }
 
     #[tokio::test]
+    async fn unsuccessful_connection_should_not_panic_on_ping() {
+        task::spawn(async move {
+            let _broker = Broker::new(1880, false).await;
+            time::delay_for(Duration::from_secs(5)).await;
+        });
+
+        time::delay_for(Duration::from_secs(1)).await;
+        let options = MqttOptions::new("dummy", "127.0.0.1", 1880);
+        let mut eventloop = EventLoop::new(options, 5);
+
+        for _ in 0..2 {
+            let some_event = time::delay_for(Duration::from_secs(1));
+            select! {
+                _ = some_event => {}
+                _poll = eventloop.poll() => {}
+            }
+        }
+    }
+
+    #[tokio::test]
     async fn connection_should_timeout_on_time() {
         task::spawn(async move {
             let _broker = Broker::new(1880, false).await;

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -123,11 +123,10 @@ impl EventLoop {
     #[must_use = "Eventloop should be iterated over a loop to make progress"]
     pub async fn poll(&mut self) -> Result<Event, ConnectionError> {
         if self.network.is_none() {
-            let connack = self.connect_or_cancel().await?;
-
             if self.keepalive_timeout.is_none() {
                 self.keepalive_timeout = Some(time::delay_for(self.options.keep_alive));
             }
+            let connack = self.connect_or_cancel().await?;
 
             return Ok(Event::Incoming(connack));
         }


### PR DESCRIPTION
I use rumqttc in a context, where the `event_loop.poll()` is made inside another `tokio::select!` in a `loop` and where it is therefore possible that another future finishes this select first before a mqtt connection could be completely established (wrong credentials in my case). 

The next call to the `event_loop.poll()` seems to have the `self.network` being `Some()` and thus we have the following:
- the first `connect_or_cancel()` seem not to have returned
- `self.keepalive_timeout` is therefore still `None`
- `self.select()` is being called from `poll()`, resulting in 
- - `_ = self.keepalive_timeout.as_mut().unwrap()` to panic as it is still `None`

I simply moved the part where the `self.keepalive_timeout` is enforced above the `connect_or_cancel()` and - at least for me - the panics are gone. 