### PR TITLE
Handle PubRel in outgoing packets

### DIFF
--- a/rumqttc/src/framed.rs
+++ b/rumqttc/src/framed.rs
@@ -259,6 +259,7 @@ fn outgoing(packet: &Request) -> Outgoing {
             Outgoing::PubAcks(out)
         }
         Request::PubRec(pubrec) => Outgoing::PubRec(pubrec.pkid),
+        Request::PubRel(pubrel) => Outgoing::PubRel(pubrel.pkid),
         Request::PubComp(pubcomp) => Outgoing::PubComp(pubcomp.pkid),
         Request::Subscribe(subscribe) => Outgoing::Subscribe(subscribe.pkid),
         Request::Unsubscribe(unsubscribe) => Outgoing::Unsubscribe(unsubscribe.pkid),

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -126,6 +126,8 @@ pub enum Outgoing {
     PubAcks(Vec<u16>),
     /// PubRec packet
     PubRec(u16),
+    /// PubRel packet
+    PubRel(u16),
     /// PubComp packet
     PubComp(u16),
     /// Ping request packet


### PR DESCRIPTION
PubRel was missing in possible outgoing packets and would panic the program
when publishing with QoS2