### PR TITLE
Make rumqttd Config struct fields public.

### DIFF
--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -69,12 +69,12 @@ type Id = usize;
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct Config {
-    id: usize,
-    router: rumqttlog::Config,
-    servers: HashMap<String, ServerSettings>,
-    cluster: Option<HashMap<String, MeshSettings>>,
-    replicator: Option<ConnectionSettings>,
-    console: ConsoleSettings,
+    pub id: usize,
+    pub router: rumqttlog::Config,
+    pub servers: HashMap<String, ServerSettings>,
+    pub cluster: Option<HashMap<String, MeshSettings>>,
+    pub replicator: Option<ConnectionSettings>,
+    pub console: ConsoleSettings,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
This is consistent with the rest of the settings structs, and allows the configuration to be created programmatically rather than read from a file, which is useful when embedding the broker in another application or test.