### PR TITLE
Make console optional.

### DIFF
--- a/rumqttd/src/consolelink.rs
+++ b/rumqttd/src/consolelink.rs
@@ -40,7 +40,12 @@ impl ConsoleLink {
 #[tokio::main(worker_threads = 1)]
 pub async fn start(console: Arc<ConsoleLink>) {
     let config_console = console.clone();
-    let port = config_console.config.console.port;
+    let port = config_console
+        .config
+        .console
+        .as_ref()
+        .expect("Console should only be started if it is configured")
+        .port;
     let config = warp::path!("node" / "config").map(move || {
         let config = config_console.config.clone();
         warp::reply::json(&config)

--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -74,7 +74,7 @@ pub struct Config {
     pub servers: HashMap<String, ServerSettings>,
     pub cluster: Option<HashMap<String, MeshSettings>>,
     pub replicator: Option<ConnectionSettings>,
-    pub console: ConsoleSettings,
+    pub console: Option<ConsoleSettings>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -180,10 +180,13 @@ impl Broker {
             })?;
         }
 
-        // run console in current thread
-        let console = ConsoleLink::new(self.config.clone(), self.router_tx.clone());
-        let console = Arc::new(console);
-        consolelink::start(console);
+        // Run console in current thread, if it is configured.
+        if self.config.console.is_some() {
+            let console = ConsoleLink::new(self.config.clone(), self.router_tx.clone());
+            let console = Arc::new(console);
+            consolelink::start(console);
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
If no `[console]` section is provided in the config then the console server will not be started. This allows a more minimal configuration when the console is not needed.