### PR TITLE
Update tokio-compat-02 too.

### DIFF
--- a/rumqttd/Cargo.toml
+++ b/rumqttd/Cargo.toml
@@ -22,7 +22,7 @@ rumqttlog = { path = "../rumqttlog", version = "0.4"}
 mqttbytes = { path = "../mqttbytes", version = "0.1" }
 tokio = { version = "1.0", features = ["full"] }
 tokio-rustls = "0.22"
-tokio-compat-02 = "0.1"
+tokio-compat-02 = "0.2"
 serde = { version = "1", features = ["derive"] }
 log = "0.4"
 thiserror = "1"


### PR DESCRIPTION
I missed this in the Tokio 1.0 update (#219). It didn't cause any problems in the tests or anything I tried, but it might be an issue somewhere.