### PR TITLE
Expose outgoing topics in public API on publish, subscribe and unsubscribe

### DIFF
--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -121,12 +121,12 @@ pub type Incoming = Packet;
 /// Current outgoing activity on the eventloop
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum Outgoing {
-    /// Publish packet with packet identifier. 0 implies QoS 0
-    Publish(u16),
-    /// Subscribe packet with packet identifier
-    Subscribe(u16),
-    /// Unsubscribe packet with packet identifier
-    Unsubscribe(u16),
+    /// Publish packet with packet identifier and topics. 0 implies QoS 0
+    Publish(u16, Vec<String>),
+    /// Subscribe packet with packet identifier and topics
+    Subscribe(u16, Vec<String>),
+    /// Unsubscribe packet with packet identifier and topics
+    Unsubscribe(u16, Vec<String>),
     /// PubAck packet
     PubAck(u16),
     /// PubRec packet

--- a/rumqttc/tests/broker.rs
+++ b/rumqttc/tests/broker.rs
@@ -285,13 +285,19 @@ impl Network {
 
 fn outgoing(packet: &Packet) -> Outgoing {
     match packet {
-        Packet::Publish(publish) => Outgoing::Publish(publish.pkid),
+        Packet::Publish(publish) => Outgoing::Publish(publish.pkid, vec![publish.topic.clone()]),
         Packet::PubAck(puback) => Outgoing::PubAck(puback.pkid),
         Packet::PubRec(pubrec) => Outgoing::PubRec(pubrec.pkid),
         Packet::PubRel(pubrel) => Outgoing::PubRel(pubrel.pkid),
         Packet::PubComp(pubcomp) => Outgoing::PubComp(pubcomp.pkid),
-        Packet::Subscribe(subscribe) => Outgoing::Subscribe(subscribe.pkid),
-        Packet::Unsubscribe(unsubscribe) => Outgoing::Unsubscribe(unsubscribe.pkid),
+        Packet::Subscribe(subscribe) => Outgoing::Subscribe(
+            subscribe.pkid,
+            subscribe.filters.iter().map(|f| f.path.clone()).collect()
+        ),
+        Packet::Unsubscribe(unsubscribe) => Outgoing::Unsubscribe(
+            unsubscribe.pkid,
+            unsubscribe.topics.clone()
+        ),
         Packet::PingReq => Outgoing::PingReq,
         Packet::PingResp => Outgoing::PingResp,
         Packet::Disconnect => Outgoing::Disconnect,

--- a/rumqttc/tests/reliability.rs
+++ b/rumqttc/tests/reliability.rs
@@ -356,7 +356,7 @@ async fn packet_id_collisions_are_detected_and_flow_control_is_applied() {
         println!("Poll = {:?}", event);
 
         match event {
-            Ok(Event::Outgoing(Outgoing::Publish(ack))) => {
+            Ok(Event::Outgoing(Outgoing::Publish(ack, _))) => {
                 if ack == 1 {
                     assert_eq!(start.elapsed().as_secs(), 5)
                 }


### PR DESCRIPTION
This provides enough information for the topic and pkid to be linked together as they are outgoing, so code monitoring the events from the EventLoop can link together the pkid on incoming PubAck, SubAck and UnsubAck packets with the topic from the outgoing packet, so it can respond to errors for particular topics as needed. See https://github.com/bytebeamio/rumqtt/issues/206 for context.