### PR TITLE
client: Move websocket support behind a Cargo feature

### DIFF
--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -9,15 +9,20 @@ edition = "2018"
 keywords = ["mqtt", "iot", "coap", "http"]
 categories = ["network-programming"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+websocket = ["async-tungstenite", "ws_stream_tungstenite"]
 
 [dependencies]
 tokio = { version = "1.0", features = ["full"] }
 bytes = "1.0"
 webpki = "0.21"
 tokio-rustls = "0.22"
-async-tungstenite = { version = "0.11.0", default-features = false, features = ["tokio-rustls"] }
-ws_stream_tungstenite = { version = "0.4.0", default-features = false, features = ["tokio_io"] }
+async-tungstenite = { version = "0.11.0", default-features = false, features = ["tokio-rustls"], optional = true }
+ws_stream_tungstenite = { version = "0.4.0", default-features = false, features = ["tokio_io"], optional = true }
 mqttbytes = { path = "../mqttbytes", version = "0.1" }
 pollster = "0.2"
 async-channel = "1.5"

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -94,6 +94,7 @@
 //! One workaround, which only works under *nix/BSD-like systems, is to add an
 //! entry to wherever your DNS resolver looks (e.g. `/etc/hosts`) for the bare IP
 //! address and use that name in your code.
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[macro_use]
 extern crate log;
@@ -190,7 +191,11 @@ impl From<Unsubscribe> for Request {
 pub enum Transport {
     Tcp,
     Tls(TlsConfiguration),
+    #[cfg(feature = "websocket")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "websocket")))]
     Ws,
+    #[cfg(feature = "websocket")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "websocket")))]
     Wss(TlsConfiguration),
 }
 
@@ -226,11 +231,15 @@ impl Transport {
     }
 
     /// Use websockets as transport
+    #[cfg(feature = "websocket")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "websocket")))]
     pub fn ws() -> Self {
         Self::Ws
     }
 
     /// Use secure websockets with tls as transport
+    #[cfg(feature = "websocket")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "websocket")))]
     pub fn wss(
         ca: Vec<u8>,
         client_auth: Option<(Vec<u8>, Key)>,
@@ -245,6 +254,8 @@ impl Transport {
         Self::wss_with_config(config)
     }
 
+    #[cfg(feature = "websocket")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "websocket")))]
     pub fn wss_with_config(tls_config: TlsConfiguration) -> Self {
         Self::Wss(tls_config)
     }
@@ -521,6 +532,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "websocket")]
     fn no_scheme() {
         let mut _mqtt_opts = MqttOptions::new("client_a", "a3f8czas.iot.eu-west-1.amazonaws.com/mqtt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=MyCreds%2F20201001%2Feu-west-1%2Fiotdevicegateway%2Faws4_request&X-Amz-Date=20201001T130812Z&X-Amz-Expires=7200&X-Amz-Signature=9ae09b49896f44270f2707551581953e6cac71a4ccf34c7c3415555be751b2d1&X-Amz-SignedHeaders=host", 443);
 


### PR DESCRIPTION
I haven't added the new `websocket` feature to the default features, if you want I can update the PR to do that.

Resolves #226.