### PR TITLE
Fix compilation on Windows once more

### DIFF
--- a/rumqttd/Cargo.toml
+++ b/rumqttd/Cargo.toml
@@ -32,7 +32,6 @@ pretty_env_logger = "0.4"
 bytes = "1.0"
 prost = "0.6"
 warp = "0.2"
-pprof = { version = "0.3", features = ["flamegraph", "protobuf"] }
 ctrlc = "=3.1"
 futures-util = "0.3.8"
 

--- a/rumqttd/Cargo.toml
+++ b/rumqttd/Cargo.toml
@@ -37,3 +37,4 @@ futures-util = "0.3.8"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = "0.3"
+pprof = { version = "0.3", features = ["flamegraph", "protobuf"] }

--- a/rumqttd/src/bin.rs
+++ b/rumqttd/src/bin.rs
@@ -3,10 +3,6 @@ use std::path::PathBuf;
 use std::thread;
 
 use librumqttd::{Broker, Config};
-use pprof::ProfilerGuard;
-use prost::Message;
-use std::fs::File;
-use std::io::Write;
 use std::process::exit;
 
 #[cfg(not(target_env = "msvc"))]
@@ -30,9 +26,7 @@ fn main() {
     let commandline: CommandLine = argh::from_env();
     let config: Config = confy::load_path(commandline.config).unwrap();
 
-    let _guard = pprof::ProfilerGuard::new(100).unwrap();
     ctrlc::set_handler(move || {
-        // profile("rumqttd.pb", &guard);
         exit(0);
     })
     .expect("Error setting Ctrl-C handler");
@@ -41,15 +35,4 @@ fn main() {
     let thread = thread.spawn(move || Broker::new(config).start()).unwrap();
 
     println!("{:?}", thread.join());
-}
-
-fn _profile(name: &str, guard: &ProfilerGuard) {
-    if let Ok(report) = guard.report().build() {
-        let mut file = File::create(name).unwrap();
-        let profile = report.pprof().unwrap();
-
-        let mut content = Vec::new();
-        profile.encode(&mut content).unwrap();
-        file.write_all(&content).unwrap();
-    };
 }


### PR DESCRIPTION
**Woop-woop!** That's the sound of da *Windows* police!

The [`pprof` crate](https://lib.rs/crates/pprof) is unfortunately [not compatible with Windows](https://github.com/tikv/pprof-rs/issues/9) as of now, and thus its inclusion prevents the library from being built even if the relevant code is never accessed. It is only "used" in [`rumqttd/src/bin.rs`](https://github.com/bytebeamio/rumqtt/blob/master/rumqttd/src/bin.rs), and even then it really isn't, so it is not what you would necessarily call [essential](https://i.imgur.com/0WXFHtw.png).

This change simply gets rid of the offending piece of code and its dependency. Rejoice, for this lets the library be built on Windows once more!