### PR TITLE
Rumqttc/no panics and improved performance

### DIFF
--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -29,6 +29,7 @@ async-channel = "1.5"
 log = "0.4"
 thiserror = "1.0.21"
 http = "^0.2"
+fixedbitset = "0.3"
 
 [dev-dependencies]
 pretty_env_logger = "0.4"

--- a/rumqttc/src/ds.rs
+++ b/rumqttc/src/ds.rs
@@ -1,0 +1,155 @@
+//! Data structures to track outgoing `Publish` messages as well as a set of `pkid`s.
+
+use crate::Publish;
+
+/// Uses a bucket list for storage with `pkid` as index into it.
+#[derive(Debug, Clone)]
+pub struct OutgoingPublishBucketList {
+    vec: Vec<Option<Publish>>,
+    len: usize,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct OutOfBounds(pub u16);
+
+impl OutgoingPublishBucketList {
+    pub fn with_limit(max_pkid: u16) -> Self {
+        Self {
+            vec: vec![None; max_pkid as usize + 1],
+            len: 0,
+        }
+    }
+
+    /// Returns the number of `Some(Publish)` items in the bucket list.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Removes all items from the list and inserts the `Some` items into `vec` after mapping with
+    /// `map`.
+    pub fn drain_into<T>(&mut self, vec: &mut Vec<T>, map: impl Fn(Publish) -> T) {
+        for opt in self.vec.iter_mut() {
+            if let Some(v) = opt.take() {
+                vec.push(map(v));
+            }
+        }
+        self.len = 0;
+    }
+
+    /// Inserts `value` into the bucket list returning the previous value, unless the `pkid` is out
+    /// of bounds.
+    ///
+    /// Returns `Err(OutOfBounds)` in case the `pkid` of the Publish is out of bounds.
+    pub fn insert(&mut self, value: Publish) -> Result<Option<Publish>, OutOfBounds> {
+        let index = value.pkid as usize;
+        if let Some(elem) = self.vec.get_mut(index) {
+            let old = elem.take();
+            *elem = Some(value);
+            if old.is_none() {
+                self.len += 1;
+            }
+            Ok(old)
+        } else {
+            Err(OutOfBounds(value.pkid))
+        }
+    }
+
+    /// Removes the bucket at index `pkid` returning it's value.
+    ///
+    /// Returns `Err(OutOfBounds)` if `pkid` is out of bounds.
+    pub fn remove(&mut self, pkid: u16) -> Result<Option<Publish>, OutOfBounds> {
+        if let Some(elem) = self.vec.get_mut(pkid as usize) {
+            let old = elem.take();
+            if old.is_some() {
+                self.len -= 1;
+            }
+            Ok(old)
+        } else {
+            Err(OutOfBounds(pkid))
+        }
+    }
+
+    /// Returns a reference to the Publish paket with `pkid`.
+    ///
+    /// Returns `Err(OutOfBounds)` if `pkid` is out of bounds.
+    pub fn get(&self, pkid: u16) -> Result<Option<&Publish>, OutOfBounds> {
+        self.vec
+            .get(pkid as usize)
+            .ok_or(OutOfBounds(pkid))
+            .map(Option::as_ref)
+    }
+}
+
+/// A `set` of `pkid`'s.
+///
+/// Uses a bitset to determine if a `pkid` is in use or not.
+#[derive(Debug, Clone)]
+pub struct PkidSet {
+    set: fixedbitset::FixedBitSet,
+    len: usize,
+}
+
+impl PkidSet {
+    pub fn full_range() -> Self {
+        Self::with_limit(std::u16::MAX)
+    }
+
+    pub fn with_limit(max_pkid: u16) -> Self {
+        Self {
+            set: fixedbitset::FixedBitSet::with_capacity(max_pkid as usize + 1),
+            len: 0,
+        }
+    }
+
+    /// Returns the number of `pkid`'s in the set.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn drain_into<T>(&mut self, vec: &mut Vec<T>, map: impl Fn(u16) -> T) {
+        for pkid in self.set.ones() {
+            vec.push(map(pkid as u16));
+        }
+        self.clear();
+    }
+
+    /// Empties the bitset.
+    pub fn clear(&mut self) {
+        self.set.clear();
+        self.len = 0;
+    }
+
+    /// Inserts `pkid` into the set returning the previous value.
+    pub fn insert(&mut self, pkid: u16) -> Result<bool, OutOfBounds> {
+        let index = pkid as usize;
+        if index < self.set.len() {
+            let old = self.set.put(index);
+            if old == false {
+                self.len += 1;
+            }
+            Ok(old)
+        } else {
+            Err(OutOfBounds(pkid))
+        }
+    }
+
+    #[cfg(test)]
+    pub fn contains(&self, pkid: u16) -> bool {
+        self.set.contains(pkid as usize)
+    }
+
+    /// Removes `pkid` from the set returning the value or `Err(OutOfBounds)`.
+    pub fn remove(&mut self, pkid: u16) -> Result<bool, OutOfBounds> {
+        let index = pkid as usize;
+        if index < self.set.len() {
+            let old = self.set.contains(index);
+            self.set.set(index, false);
+            if old {
+                self.len -= 1;
+            }
+            Ok(old)
+        } else {
+            Err(OutOfBounds(pkid))
+        }
+    }
+}

--- a/rumqttc/src/ds.rs
+++ b/rumqttc/src/ds.rs
@@ -43,8 +43,7 @@ impl OutgoingPublishBucketList {
     pub fn insert(&mut self, value: Publish) -> Result<Option<Publish>, OutOfBounds> {
         let index = value.pkid as usize;
         if let Some(elem) = self.vec.get_mut(index) {
-            let old = elem.take();
-            *elem = Some(value);
+            let old = elem.replace(value);
             if old.is_none() {
                 self.len += 1;
             }

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -148,7 +148,7 @@ impl EventLoop {
     async fn select(&mut self) -> Result<Event, ConnectionError> {
         let network = self.network.as_mut().unwrap();
         // let await_acks = self.state.await_acks;
-        let inflight_full = self.state.inflight >= self.options.inflight;
+        let inflight_full = self.state.inflight() >= self.options.inflight as usize;
         let throttle = self.options.pending_throttle;
         let pending = self.pending.len() > 0;
         let collision = self.state.collision.is_some();

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -108,6 +108,7 @@ mod eventloop;
 mod framed;
 mod state;
 mod tls;
+mod ds;
 
 pub use async_channel::{SendError, Sender, TrySendError};
 pub use client::{AsyncClient, Client, ClientError, Connection};

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -290,7 +290,8 @@ impl MqttState {
 
     /// Adds next packet identifier to QoS 1 and 2 publish packets and returns
     /// it buy wrapping publish in packet
-    fn outgoing_publish(&mut self, publish: Publish) -> Result<(), StateError> {
+    fn outgoing_publish(&mut self, mut publish: Publish) -> Result<(), StateError> {
+        self.assign_pkid(&mut publish);
         let publish = match publish.qos {
             QoS::AtMostOnce => publish,
             QoS::AtLeastOnce | QoS::ExactlyOnce => self.save_publish(publish)?,
@@ -421,18 +422,27 @@ impl MqttState {
         Ok(pubrel)
     }
 
+    /// Ensures the `publish` has a valid `pkid` set.
+    ///
+    /// NOTE: The spec requires `pkid` to be `0` in case of `QoS::AtMostOnce` and non-zero in all
+    /// other cases.
+    fn assign_pkid(&mut self, publish: &mut Publish) {
+        match publish.qos {
+            QoS::AtMostOnce => {
+                publish.pkid = 0;
+            }
+            QoS::AtLeastOnce | QoS::ExactlyOnce => {
+                // consider PacketIdentifier(0) as uninitialized packets
+                if publish.pkid == 0 {
+                    publish.pkid = self.next_pkid();
+                }
+            }
+        }
+    }
+
     /// Add publish packet to the state and return the packet. This method clones the
     /// publish packet to save it to the state.
-    fn save_publish(&mut self, mut publish: Publish) -> Result<Publish, StateError> {
-        let publish = match publish.pkid {
-            // consider PacketIdentifier(0) as uninitialized packets
-            0 => {
-                publish.pkid = self.next_pkid();
-                publish
-            }
-            _ => publish,
-        };
-
+    fn save_publish(&mut self, publish: Publish) -> Result<Publish, StateError> {
         // If there is an existing publish at this pkid, this implies that client
         // hasn't acked this packet yet. `next_pkid()` rolls packet id back to 1
         // after a count of 'inflight' messages. This error is possible only when

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -723,4 +723,32 @@ mod test {
         // should ping
         mqtt.outgoing_ping().unwrap();
     }
+
+    #[test]
+    fn incoming_puback_with_pkid_exceeding_max_inflight_should_not_panic() {
+        let max_inflight = 100;
+        let mut mqtt = MqttState::new(max_inflight);
+        let _ = mqtt.handle_incoming_packet(Incoming::PubAck(PubAck::new(max_inflight + 1)));
+    }
+
+    #[test]
+    fn incoming_pubrec_with_pkid_exceeding_max_inflight_should_not_panic() {
+        let max_inflight = 100;
+        let mut mqtt = MqttState::new(max_inflight);
+        let _ = mqtt.handle_incoming_packet(Incoming::PubRec(PubRec::new(max_inflight + 1)));
+    }
+
+    #[test]
+    fn incoming_pubrel_with_pkid_exceeding_max_inflight_should_not_panic() {
+        let max_inflight = 100;
+        let mut mqtt = MqttState::new(max_inflight);
+        let _ = mqtt.handle_incoming_packet(Incoming::PubRel(PubRel::new(max_inflight + 1)));
+    }
+
+    #[test]
+    fn incoming_pubcomp_with_pkid_exceeding_max_inflight_should_not_panic() {
+        let max_inflight = 100;
+        let mut mqtt = MqttState::new(max_inflight);
+        let _ = mqtt.handle_incoming_packet(Incoming::PubComp(PubComp::new(max_inflight + 1)));
+    }
 }

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -562,6 +562,25 @@ mod test {
     }
 
     #[test]
+    fn outgoing_publish_should_zero_pkid_in_case_of_qos0() {
+        let mut mqtt = build_mqttstate();
+
+        // QoS0 Publish with pkid `42`
+        let mut publish = build_outgoing_publish(QoS::AtMostOnce);
+        publish.pkid = 42;
+
+        // QoS 0 publish shouldn't be saved in queue
+        mqtt.outgoing_publish(publish).unwrap();
+        assert_eq!(mqtt.last_pkid, 0);
+
+        if let Some(super::Event::Outgoing(super::Outgoing::Publish(pkid))) = mqtt.events.pop_back() {
+            assert_eq!(pkid, 0);
+        } else {
+            assert!(false);
+        }
+    }
+
+    #[test]
     fn incoming_publish_should_be_added_to_queue_correctly() {
         let mut mqtt = build_mqttstate();
 


### PR DESCRIPTION
* No longer panics when a PubAck, PubComp or PubRec paket is received with
  a `pkid` outside of the inflight range. 

* Avoid cloning `Publish` messages with QoS=1 or QoS=2. Also avoid cloning a `Publish` in case of a collision. Cloning is rather expensive as all the memory has to be duplicated (topic and payload).

* Use a bitset for `incoming_pub`. This drops memory from 256 KiB to just 8 KiB. Also use a bitset for `outgoing_rel`, but as this is limited to just `max_inflight` the saving are usually much less.

* Factor out code that maintains the list of currently inflight Publish messages into `ds.rs`. I have some code that makes the data-structures interchangeable, but as that required some generic traits I have not included it here.