### PR TITLE
Add `Request::PublishWithNotify` to notify about selected pkid

### DIFF
--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -116,6 +116,7 @@ pub use mqttbytes::*;
 pub use state::{MqttState, StateError};
 pub use tokio_rustls::rustls::internal::pemfile::{certs, pkcs8_private_keys, rsa_private_keys};
 pub use tokio_rustls::rustls::ClientConfig;
+pub use tokio::sync::oneshot::Sender as OneshotSender;
 
 pub type Incoming = Packet;
 
@@ -146,9 +147,14 @@ pub enum Outgoing {
 
 /// Requests by the client to mqtt event loop. Request are
 /// handled one by one.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 pub enum Request {
     Publish(Publish),
+    PublishWithNotify {
+        publish: Publish,
+        /// notifies the caller about the selected `pkid`
+        notify: OneshotSender<u16>,
+    },
     PubAck(PubAck),
     PubRec(PubRec),
     PubComp(PubComp),


### PR DESCRIPTION
* This allows to get notified about the selected `pkid` for a given
  `Publish` message.

* The purpose of this is be able to wait for PubAck (QoS=1) or PubComp
  (QoS=2) messages on a per message basis. For that we need to know the
  `pkid` that is choosen by `rumqttc` as we can't realiably provide our
  own `pkid`.