### PR TITLE
Prevents starving threads of cpu time

### DIFF
--- a/rumqttlog/src/router/mod.rs
+++ b/rumqttlog/src/router/mod.rs
@@ -30,6 +30,8 @@ pub enum Event {
     Disconnect(Disconnection),
     /// Get metrics of a connection or all connections
     Metrics(MetricsRequest),
+    /// Gets fired off when the connect is ready for more processing
+    ConnectionReady,
 }
 
 /// Requests for pull operations


### PR DESCRIPTION
Prevents starving threads/tasks of cpu time.

Since it's a for loop that doesn't yield, it prevents any computation from happening in any other task/thread. This is vitally important for multithread apps where there are multiple tasks running side-by-side.