### PR TITLE
First attempt at getting to compile for both tokio as well as async-std

### DIFF
--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -14,21 +14,32 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-websocket = ["async-tungstenite", "ws_stream_tungstenite"]
+default = ["tokio-runtime"]
+websocket = ["websocket-tokio-runtime"]
+websocket-tokio-runtime = ["async-tungstenite", "async-tungstenite/tokio-rustls", "ws_stream_tungstenite", "ws_stream_tungstenite/tokio_io"]
+websocket-async-std-runtime = ["async-tungstenite", "async-tungstenite/async-tls", "async-tungstenite/async-std-runtime", "ws_stream_tungstenite"]
+tokio-runtime = ["tokio", "tokio-rustls"]
+async-std-runtime = ["async-std", "async-io", "futures", "async-tls", "rustls"]
 
 [dependencies]
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1.0", features = ["full"], optional = true }
+async-std = { version = "1.6", optional = true }
+async-io = { version = "1", optional = true }
+futures = { version = "0.3", optional = true }
 bytes = "1.0"
 webpki = "0.21"
-tokio-rustls = "0.22"
-async-tungstenite = { version = "0.11.0", default-features = false, features = ["tokio-rustls"], optional = true }
-ws_stream_tungstenite = { version = "0.4.0", default-features = false, features = ["tokio_io"], optional = true }
+tokio-rustls = { version = "0.22", optional = true }
+async-tungstenite = { version = "0.11.0", default-features = false, features = [], optional = true }
+ws_stream_tungstenite = { version = "0.4.0", default-features = false, features = [], optional = true }
+async-tls = { version = "0.11", optional = true }
+rustls = {version = "0.19", optional = true }
 mqttbytes = { path = "../mqttbytes", version = "0.2" }
 pollster = "0.2"
 async-channel = "1.5"
 log = "0.4"
 thiserror = "1.0.21"
 http = "^0.2"
+pin-project = "1"
 
 [dev-dependencies]
 pretty_env_logger = "0.4"

--- a/rumqttc/src/framed.rs
+++ b/rumqttc/src/framed.rs
@@ -1,7 +1,10 @@
 use bytes::BytesMut;
 use mqttbytes::v4::*;
 use mqttbytes::*;
+#[cfg(feature = "tokio-runtime")]
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+#[cfg(feature = "async-std-runtime")]
+use futures::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use crate::{Incoming, MqttState, StateError};
 use std::io;
@@ -35,7 +38,10 @@ impl Network {
     async fn read_bytes(&mut self, required: usize) -> io::Result<usize> {
         let mut total_read = 0;
         loop {
+            #[cfg(feature = "tokio-runtime")]
             let read = self.socket.read_buf(&mut self.read).await?;
+            #[cfg(feature = "async-std-runtime")]
+            let read = self.socket.read(&mut self.read).await?;
             if 0 == read {
                 return if self.read.is_empty() {
                     Err(io::Error::new(

--- a/rumqttc/src/helpers.rs
+++ b/rumqttc/src/helpers.rs
@@ -1,0 +1,115 @@
+#[cfg(feature = "async-std-runtime")]
+pub mod time {
+use futures::Future;
+use futures::future::FusedFuture;
+use std::task::{Context, Poll};
+use std::pin::Pin;
+pub use std::time::Instant;
+use async_io::Timer;
+
+pub mod error {
+    pub use async_std::future::TimeoutError as Elapsed;
+}
+
+pub use async_std::future::timeout;
+
+pub struct Sleep {
+    timer: Timer,
+    terminated: bool,
+}
+
+pub fn sleep(duration: std::time::Duration) -> Sleep {
+    Sleep {
+        timer: Timer::after(duration),
+        terminated: false,
+    }
+}
+
+impl Sleep {
+    pub fn reset(&mut self, instant: Instant) {
+        self.timer.set_at(instant);
+        self.terminated = false;
+    }
+}
+
+impl Future for Sleep {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match Pin::new(&mut self.timer).poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(_) => {
+                self.terminated = true;
+                Poll::Ready(())
+            },
+        }
+    }
+}
+
+impl FusedFuture for Sleep {
+    fn is_terminated(&self) -> bool {
+        self.terminated
+    }
+}
+
+
+}
+
+use std::task::{Context, Poll};
+use std::pin::Pin;
+use std::future::Future;
+#[cfg(feature = "async-std-runtime")]
+use futures::future::FusedFuture;
+use pin_project::pin_project;
+
+#[pin_project]
+pub struct CondFuture<F> {
+    #[pin]
+    f: Option<F>
+}
+
+impl<F> CondFuture<F> {
+    pub fn new(f: F, condition: bool) -> CondFuture<F> {
+        if condition {
+            CondFuture { f: Some(f) }
+        } else {
+            CondFuture { f: None }
+        }
+    }
+}
+
+impl<F: Future> Future for CondFuture<F> {
+    type Output = F::Output;
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if let Some(f) = self.project().f.as_pin_mut() {
+            f.poll(cx)
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+#[cfg(feature = "async-std-runtime")]
+impl<F: FusedFuture> FusedFuture for CondFuture<F> {
+    fn is_terminated(&self) -> bool {
+        if let Some(f) = &self.f {
+            f.is_terminated()
+        } else {
+            true
+        }
+    }
+}
+
+pub fn cond_fut<F>(f: F, condition: bool) -> CondFuture<F> {
+    CondFuture::new(f,condition)
+}
+
+#[cfg(feature = "async-std-runtime")]
+pub fn fuse<F: Future>(f: F) -> impl Future<Output = F::Output> + FusedFuture {
+    futures::FutureExt::fuse(f)
+}
+
+#[cfg(feature = "tokio-runtime")]
+pub fn fuse<F>(f: F) -> F {
+    f
+}

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -108,6 +108,7 @@ mod eventloop;
 mod framed;
 mod state;
 mod tls;
+mod helpers;
 
 pub use async_channel::{SendError, Sender, TrySendError};
 pub use client::{AsyncClient, Client, ClientError, Connection};
@@ -115,8 +116,14 @@ pub use eventloop::{ConnectionError, Event, EventLoop};
 pub use mqttbytes::v4::*;
 pub use mqttbytes::*;
 pub use state::{MqttState, StateError};
+#[cfg(feature = "tokio-runtime")]
 pub use tokio_rustls::rustls::internal::pemfile::{certs, pkcs8_private_keys, rsa_private_keys};
+#[cfg(feature = "tokio-runtime")]
 pub use tokio_rustls::rustls::ClientConfig;
+#[cfg(feature = "async-std-runtime")]
+pub use rustls::internal::pemfile::{certs, pkcs8_private_keys, rsa_private_keys};
+#[cfg(feature = "async-std-runtime")]
+pub use rustls::ClientConfig;
 
 pub type Incoming = Packet;
 
@@ -192,11 +199,11 @@ impl From<Unsubscribe> for Request {
 pub enum Transport {
     Tcp,
     Tls(TlsConfiguration),
-    #[cfg(feature = "websocket")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "websocket")))]
+    #[cfg(any(feature = "websocket-tokio-runtime", feature = "websocket-async-std-runtime"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "websocket-tokio-runtime", feature = "websocket-async-std-runtime"))))]
     Ws,
-    #[cfg(feature = "websocket")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "websocket")))]
+    #[cfg(any(feature = "websocket-tokio-runtime", feature = "websocket-async-std-runtime"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "websocket-tokio-runtime", feature = "websocket-async-std-runtime"))))]
     Wss(TlsConfiguration),
 }
 
@@ -232,15 +239,15 @@ impl Transport {
     }
 
     /// Use websockets as transport
-    #[cfg(feature = "websocket")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "websocket")))]
+    #[cfg(any(feature = "websocket-tokio-runtime", feature = "websocket-async-std-runtime"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "websocket-tokio-runtime", feature = "websocket-async-std-runtime"))))]
     pub fn ws() -> Self {
         Self::Ws
     }
 
     /// Use secure websockets with tls as transport
-    #[cfg(feature = "websocket")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "websocket")))]
+    #[cfg(any(feature = "websocket-tokio-runtime", feature = "websocket-async-std-runtime"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "websocket-tokio-runtime", feature = "websocket-async-std-runtime"))))]
     pub fn wss(
         ca: Vec<u8>,
         client_auth: Option<(Vec<u8>, Key)>,
@@ -255,8 +262,8 @@ impl Transport {
         Self::wss_with_config(config)
     }
 
-    #[cfg(feature = "websocket")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "websocket")))]
+    #[cfg(any(feature = "websocket-tokio-runtime", feature = "websocket-async-std-runtime"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "websocket-tokio-runtime", feature = "websocket-async-std-runtime"))))]
     pub fn wss_with_config(tls_config: TlsConfiguration) -> Self {
         Self::Wss(tls_config)
     }
@@ -527,7 +534,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "websocket")]
+    #[cfg(any(feature = "websocket-tokio-runtime", feature = "websocket-async-std-runtime"))]
     fn no_scheme() {
         let mut _mqtt_opts = MqttOptions::new("client_a", "a3f8czas.iot.eu-west-1.amazonaws.com/mqtt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=MyCreds%2F20201001%2Feu-west-1%2Fiotdevicegateway%2Faws4_request&X-Amz-Date=20201001T130812Z&X-Amz-Expires=7200&X-Amz-Signature=9ae09b49896f44270f2707551581953e6cac71a4ccf34c7c3415555be751b2d1&X-Amz-SignedHeaders=host", 443);
 

--- a/rumqttc/src/tls.rs
+++ b/rumqttc/src/tls.rs
@@ -1,8 +1,23 @@
+#[cfg(feature = "tokio-runtime")]
 use tokio::net::TcpStream;
+#[cfg(feature = "tokio-runtime")]
 use tokio_rustls::rustls::internal::pemfile::{certs, pkcs8_private_keys, rsa_private_keys};
+#[cfg(feature = "tokio-runtime")]
 use tokio_rustls::rustls::{ClientConfig, TLSError};
+#[cfg(feature = "tokio-runtime")]
 use tokio_rustls::webpki::{self, DNSNameRef, InvalidDNSNameError};
+#[cfg(feature = "tokio-runtime")]
 use tokio_rustls::{client::TlsStream, TlsConnector};
+#[cfg(feature = "async-std-runtime")]
+use async_std::net::TcpStream;
+#[cfg(feature = "async-std-runtime")]
+use rustls::internal::pemfile::{certs, pkcs8_private_keys, rsa_private_keys};
+#[cfg(feature = "async-std-runtime")]
+use rustls::{ClientConfig, TLSError};
+#[cfg(feature = "async-std-runtime")]
+use webpki::{self, InvalidDNSNameError};
+#[cfg(feature = "async-std-runtime")]
+use async_tls::{client::TlsStream, TlsConnector};
 
 use crate::{Key, MqttOptions, TlsConfiguration};
 
@@ -100,7 +115,10 @@ pub async fn tls_connect(
     let addr = options.broker_addr.as_str();
     let port = options.port;
     let connector = tls_connector(tls_config).await?;
+    #[cfg(feature = "tokio-runtime")]
     let domain = DNSNameRef::try_from_ascii_str(&options.broker_addr)?;
+    #[cfg(feature = "async-std-runtime")]
+    let domain = &options.broker_addr;
     let tcp = TcpStream::connect((addr, port)).await?;
     let tls = connector.connect(domain, tcp).await?;
     Ok(tls)


### PR DESCRIPTION
Hi,

I'm more of a fan of async-std than tokio, and needed an MQTT client library. I've put most of the changes behind features such that you can choose to compile with support for either async-std or tokio.

Currently helpers.rs is a bit of a mess that I'd like to clean up a little, any guidance on this would be appreciated.