### PR TITLE
rumqttd: adding optional native-tls support.

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -21,6 +21,18 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --release --no-default-features
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release --features use-rustls
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release --no-default-features --features use-native-tls
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
           args: --release --all-features
 
 

--- a/rumqttd/Cargo.toml
+++ b/rumqttd/Cargo.toml
@@ -18,13 +18,15 @@ name = "rumqttd"
 path = "src/bin.rs"
 
 [features]
+default = ["use-rustls"]
 prof = ["pprof"]
+use-rustls = ["tokio-rustls"]
+use-native-tls = ["tokio-native-tls"]
 
 [dependencies]
 rumqttlog = { path = "../rumqttlog", version = "0.6"}
 mqttbytes = { path = "../mqttbytes", version = "0.3" }
 tokio = { version = "1.0", features = ["full"] }
-tokio-rustls = "0.22"
 serde = { version = "1", features = ["derive"] }
 log = "0.4"
 thiserror = "1"
@@ -35,6 +37,10 @@ bytes = "1.0"
 warp = "0.3"
 futures-util = "0.3.8"
 pprof = { version = "0.4", features = ["flamegraph", "protobuf"], optional = true }
+
+# Optional
+tokio-rustls = { version = "0.22", optional = true }
+tokio-native-tls = { version = "0.3", optional = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = "0.3"

--- a/rumqttd/README.md
+++ b/rumqttd/README.md
@@ -2,3 +2,44 @@
 
 [![crates.io page](https://img.shields.io/crates/v/rumqttd.svg)](https://crates.io/crates/rumqttd)
 [![docs.rs page](https://docs.rs/rumqttd/badge.svg)](https://docs.rs/rumqttd)
+
+## `native-tls` support
+
+This crate, by default uses the `tokio-rustls` crate. There's also support for the `tokio-native-tls` crate.
+Add it to your Cargo.toml like so:
+
+```
+rumqttd = { version = "0.5", default-features = false, features = ["use-native-tls"] }
+```
+
+Then in your config file make sure that you use the `pkcs12` entries under `certs` for your cert instead of `cert_path`, `key_path`, etc.
+
+```toml
+[rumqtt.servers.1]
+port = 8883
+
+[servers.1.cert]
+pkcs12_path = "/root/identity.pfx"
+pkcs12_pass = "<your password>"
+```
+
+Here's what a Rustls config looks like:
+
+```toml
+[servers.1]
+port = 8883
+
+[servers.1.cert]
+cert_path = "tlsfiles/server.cert.pem"
+key_path = "tlsfiles/server.key.pem"
+ca_path = "tlsfiles/ca.cert.pem"
+```
+
+
+You can generate the `.p12`/`.pfx` file using `openssl`:
+
+```
+openssl pkcs12 -export -out identity.pfx -inkey ~/pki/private/test.key -in ~/pki/issued/test.crt -certfile ~/pki/ca.crt
+```
+
+Make sure if you use a password it matches the entry in `pkcs12_pass`. If no password, use an empty string `""`.

--- a/rumqttd/config/rumqttd.conf
+++ b/rumqttd/config/rumqttd.conf
@@ -26,11 +26,13 @@ next_connection_delay_ms = 1
 # Configuration of server and connections that it accepts
 [servers.2]
 listen = "0.0.0.0:8883"
-cert_path = "tlsfiles/server.cert.pem"
-key_path = "tlsfiles/server.key.pem"
-ca_path = "tlsfiles/ca.cert.pem"
 next_connection_delay_ms = 10
-    # Tls connections. ca_path enables client authentication
+    # Cert config
+    [servers.2.cert]
+    cert_path = "tlsfiles/server.cert.pem"
+    key_path = "tlsfiles/server.key.pem"
+    ca_path = "tlsfiles/ca.cert.pem"
+    # Connection parameters
     [servers.2.connections]
     connection_timeout_ms = 5000
     max_client_id_len = 256

--- a/rumqttd/config/rumqttd0.conf
+++ b/rumqttd/config/rumqttd0.conf
@@ -27,7 +27,12 @@ next_connection_delay_ms = 1
 [servers.2]
 listen = "0.0.0.0:1883"
 next_connection_delay_ms = 10
-    # Tls connections. ca_path enables client authentication
+    # Handling of Certs
+    [servers.2.cert]
+    cert_path = "tlsfiles/server.cert.pem"
+    key_path = "tlsfiles/server.key.pem"
+    ca_path = "tlsfiles/ca-chain.cert.pem"
+    # Connection parameters
     [servers.2.connections]
     connection_timeout_ms = 100
     max_client_id_len = 256
@@ -35,9 +40,7 @@ next_connection_delay_ms = 10
     max_payload_size = 2048
     max_inflight_count = 100
     max_inflight_size = 1024
-    cert_path = "tlsfiles/server.cert.pem"
-    key_path = "tlsfiles/server.key.pem"
-    ca_path = "tlsfiles/ca-chain.cert.pem"
+
 
 # Cluster configuration. Remote host and port to connect to.
 # Mesh is created based on ids.

--- a/rumqttd/config/rumqttd1.conf
+++ b/rumqttd/config/rumqttd1.conf
@@ -27,7 +27,7 @@ next_connection_delay_ms = 1
 [servers.2]
 listen = "0.0.0.0:1884"
 next_connection_delay_ms = 10
-    # Tls connections. ca_path enables client authentication
+    # Connection parameters
     [servers.2.connections]
     connection_timeout_ms = 100
     max_client_id_len = 256
@@ -35,6 +35,8 @@ next_connection_delay_ms = 10
     max_payload_size = 2048
     max_inflight_count = 100
     max_inflight_size = 1024
+    # Certs for connection
+    [servers.2.certs]
     cert_path = "tlsfiles/server.cert.pem"
     key_path = "tlsfiles/server.key.pem"
     ca_path = "tlsfiles/ca-chain.cert.pem"

--- a/rumqttd/config/rumqttd2.conf
+++ b/rumqttd/config/rumqttd2.conf
@@ -27,7 +27,7 @@ next_connection_delay_ms = 1
 [servers.2]
 listen = "0.0.0.0:1885"
 next_connection_delay_ms = 10
-    # Tls connections. ca_path enables client authentication
+    # Connection parameters
     [servers.2.connections]
     connection_timeout_ms = 100
     max_client_id_len = 256
@@ -35,6 +35,8 @@ next_connection_delay_ms = 10
     max_payload_size = 2048
     max_inflight_count = 100
     max_inflight_size = 1024
+    # Certs for connection
+    [servers.2.certs]
     cert_path = "tlsfiles/server.cert.pem"
     key_path = "tlsfiles/server.key.pem"
     ca_path = "tlsfiles/ca-chain.cert.pem"


### PR DESCRIPTION
By using the `use-native-tls` feature, this crate can now use tokio-native-tls vs tokio-rustls. Discussed this in #257. Turns out it was trivial to add since `tokio` uses the same API for both packages. The only thing that seems like a bummer right now is that it requires use of a `pkcs12` cert rather than 3 separate ones. 