### PR TITLE
Replace hard coded 0.0.0.0 bind of broker and console with configuration option `listen`

### DIFF
--- a/rumqttd/config/rumqttd.conf
+++ b/rumqttd/config/rumqttd.conf
@@ -13,7 +13,7 @@ max_connections = 10001
 
 # Configuration of server and connections that it accepts
 [servers.1]
-port = 1883
+listen = "0.0.0.0:1883"
 next_connection_delay_ms = 1
     [servers.1.connections]
     connection_timeout_ms = 100
@@ -25,7 +25,7 @@ next_connection_delay_ms = 1
 
 # Configuration of server and connections that it accepts
 [servers.2]
-port = 8883
+listen = "0.0.0.0:8883"
 cert_path = "tlsfiles/server.cert.pem"
 key_path = "tlsfiles/server.key.pem"
 ca_path = "tlsfiles/ca-chain.cert.pem"
@@ -40,4 +40,4 @@ next_connection_delay_ms = 10
     max_inflight_size = 1024
 
 [console]
-port = 3030
+listen = "0.0.0.0:3030"

--- a/rumqttd/config/rumqttd0.conf
+++ b/rumqttd/config/rumqttd0.conf
@@ -13,7 +13,7 @@ max_connections = 10001
 
 # Configuration of server and connections that it accepts
 [servers.1]
-port = 1883
+listen = "0.0.0.0:1883"
 next_connection_delay_ms = 1
     [servers.1.connections]
     connection_timeout_ms = 100
@@ -25,7 +25,7 @@ next_connection_delay_ms = 1
 
 # Configuration of server and connections that it accepts
 [servers.2]
-port = 8883
+listen = "0.0.0.0:1883"
 next_connection_delay_ms = 10
     # Tls connections. ca_path enables client authentication
     [servers.2.connections]
@@ -46,14 +46,11 @@ next_connection_delay_ms = 10
 # 2 waits for 0 and 1 as a server
 [cluster]
     [cluster.0]
-    host = "localhost"
-    port = 1800
+    address = "localhost:1800"
     [cluster.1]
-    host = "localhost"
-    port = 1801
+    address = "localhost:1801"
     # [cluster.2]
-    # host = "localhost"
-    # port = 1802
+    # address = "localhost:1802"
 
 # Io configuration for replication
 [replicator]
@@ -65,5 +62,5 @@ max_inflight_count = 500
 max_inflight_size = 1024
 
 [console]
-port = 3030
+listen = "0.0.0.0:3030"
 

--- a/rumqttd/config/rumqttd1.conf
+++ b/rumqttd/config/rumqttd1.conf
@@ -13,7 +13,7 @@ max_connections = 10001
 
 # Configuration of server and connections that it accepts
 [servers.1]
-port = 1884
+listen = "0.0.0.0:1884"
 next_connection_delay_ms = 1
     [servers.1.connections]
     connection_timeout_ms = 100
@@ -25,7 +25,7 @@ next_connection_delay_ms = 1
 
 # Configuration of server and connections that it accepts
 [servers.2]
-port = 8884
+listen = "0.0.0.0:1884"
 next_connection_delay_ms = 10
     # Tls connections. ca_path enables client authentication
     [servers.2.connections]
@@ -39,21 +39,18 @@ next_connection_delay_ms = 10
     key_path = "tlsfiles/server.key.pem"
     ca_path = "tlsfiles/ca-chain.cert.pem"
 
-# Cluster configuration. Remote host and port to connect to.
+# Cluster configuration. Remote address to connect to.
 # Mesh is created based on ids.
 # 0 connects to 1 & 2 as client
 # 1 connects to 2 as client and waits for 0 as a server
 # 2 waits for 0 and 1 as a server
 [cluster]
     [cluster.0]
-    host = "localhost"
-    port = 1800
+    address = "localhost:1800"
     [cluster.1]
-    host = "localhost"
-    port = 1801
+    address = "localhost:1801"
     # [cluster.2]
-    # host = "localhost"
-    # port = 1802
+    # address = "localhost:1802"
 
 # Io configuration for replication
 [replicator]
@@ -65,4 +62,4 @@ max_inflight_count = 500
 max_inflight_size = 1024
 
 [console]
-port = 3031
+listen = "0.0.0.0:3031"

--- a/rumqttd/config/rumqttd2.conf
+++ b/rumqttd/config/rumqttd2.conf
@@ -13,7 +13,7 @@ max_connections = 10001
 
 # Configuration of server and connections that it accepts
 [servers.1]
-port = 1885
+listen = "0.0.0.0:1885"
 next_connection_delay_ms = 1
     [servers.1.connections]
     connection_timeout_ms = 100
@@ -25,7 +25,7 @@ next_connection_delay_ms = 1
 
 # Configuration of server and connections that it accepts
 [servers.2]
-port = 8885
+listen = "0.0.0.0:1885"
 next_connection_delay_ms = 10
     # Tls connections. ca_path enables client authentication
     [servers.2.connections]
@@ -39,21 +39,18 @@ next_connection_delay_ms = 10
     key_path = "tlsfiles/server.key.pem"
     ca_path = "tlsfiles/ca-chain.cert.pem"
 
-# Cluster configuration. Remote host and port to connect to.
+# Cluster configuration. Remote address to connect to.
 # Mesh is created based on ids.
 # 0 connects to 1 & 2 as client
 # 1 connects to 2 as client and waits for 0 as a server
 # 2 waits for 0 and 1 as a server
 [cluster]
     [cluster.0]
-    host = "localhost"
-    port = 1800
+    address = "localhost:1800"
     [cluster.1]
-    host = "localhost"
-    port = 1801
+    address = "localhost:1801"
     # [cluster.2]
-    # host = "localhost"
-    # port = 1802
+    # address = "localhost:1802"
 
 # Io configuration for replication
 [replicator]
@@ -65,4 +62,4 @@ max_inflight_count = 500
 max_inflight_size = 1024
 
 [console]
-port = 3032
+listen = "0.0.0.0:3032"

--- a/rumqttd/src/consolelink.rs
+++ b/rumqttd/src/consolelink.rs
@@ -39,7 +39,10 @@ impl ConsoleLink {
 
 pub async fn start(console: Arc<ConsoleLink>) {
     let config_console = console.clone();
-    let port = config_console.config.console.port;
+    let address = config_console
+        .config
+        .console
+        .listen;
 
     let config = warp::path!("node" / "config").map(move || {
         let config = config_console.config.clone();
@@ -75,5 +78,5 @@ pub async fn start(console: Arc<ConsoleLink>) {
     });
 
     let routes = warp::get().and(config.or(router).or(connection));
-    warp::serve(routes).run(([127, 0, 0, 1], port)).await;
+    warp::serve(routes).run(address).await;
 }


### PR DESCRIPTION
The address that the broker and console binds is hardcoded to the v4 any address 0.0.0.0. In order to operate the broker on
a dedicated address or a v6 ip this needs to be added to the configuration. Replace the lonely `port` setting in the configuration with a `std::net::SocketAddr`.

There are host and port configs in `rumqttlog/timestmp.toml` and `rumqttlog/mesh.toml` which I couldn't identify. Looks like outdated stuff.