### PR TITLE
mqttbytes v5 disconnect make disconnect packet fields public

### DIFF
--- a/mqttbytes/src/v5/disconnect.rs
+++ b/mqttbytes/src/v5/disconnect.rs
@@ -128,10 +128,10 @@ pub struct DisconnectProperties {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Disconnect {
     /// Disconnect Reason Code
-    reason_code: DisconnectReasonCode,
+    pub reason_code: DisconnectReasonCode,
 
     /// Disconnect Properties
-    properties: Option<DisconnectProperties>,
+    pub properties: Option<DisconnectProperties>,
 }
 
 impl DisconnectProperties {


### PR DESCRIPTION
I forgot about this in my last PR :p 

However  @qm3ster commented my last PR:
> Very nice.
> However, I think you should have introduced a `Error::InvalidDisconnectReturnCode` instead of using `Error::InvalidConnectReturnCode`.

It seems to me it would be a good idea to rename `Error::InvalidConnectReturnCode` to `Error::InvalidReturnCode` because this error is used in other packets, not only in Connect. What do you think? 