### PR TITLE
Adding server side password check.

### DIFF
--- a/mqttbytes/src/v4/connect.rs
+++ b/mqttbytes/src/v4/connect.rs
@@ -267,6 +267,10 @@ impl Login {
 
         connect_flags
     }
+
+    pub fn validate(&self, username: &String, password: &String ) -> bool {
+        (self.username == *username) && (self.password == *password)
+    }
 }
 
 

--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -83,6 +83,8 @@ pub enum Error {
     InvalidCACert(String),
     #[error("Invalid server cert file {0}")]
     InvalidServerCert(String),
+    #[error("Invalid server pass")]
+    InvalidServerPass(),
     #[error("Invalid server key file {0}")]
     InvalidServerKey(String),
     RustlsNotEnabled,
@@ -137,6 +139,12 @@ pub struct ServerSettings {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ConnectionLoginCredentials {
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ConnectionSettings {
     pub connection_timeout_ms: u16,
     pub max_client_id_len: usize,
@@ -144,8 +152,7 @@ pub struct ConnectionSettings {
     pub max_payload_size: usize,
     pub max_inflight_count: u16,
     pub max_inflight_size: usize,
-    pub username: Option<String>,
-    pub password: Option<String>,
+    pub login_credentials: Option<Vec<ConnectionLoginCredentials>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -276,7 +283,7 @@ impl Server {
 
         // Get the identity
         let identity = native_tls::Identity::from_pkcs12(&buf, &pkcs12_pass)
-            .map_err(|_| Error::InvalidServerCert(pkcs12_path.clone()))?;
+            .map_err(|_| Error::InvalidServerPass())?;
 
         // Builder
         let builder = native_tls::TlsAcceptor::builder(identity).build()?;


### PR DESCRIPTION
Changed:
* Created InvalidServerPass error for pkcs12 password check failure.
* Checking credentials on connection if needed.
* Changed login in ConnectionSettings to be a list rather than a single set of username/password

Added:
* Additional error condition if no valid user/password was found
* Added validate function for Login credentials in codec.
* Checking authentication failure list on initial connection to boot it if it's too soon.
* Propagates device address and AuthenticationAttempts list to Connector & RemoteLink
* Adding or clearing connection from AuthenticationAttempts list depending on password check success
* Setting max lockout duration to 24h (prevent overflow)