### PR TITLE
let username and password fields in connect message in public

### DIFF
--- a/mqttbytes/src/v4/connect.rs
+++ b/mqttbytes/src/v4/connect.rs
@@ -209,8 +209,8 @@ impl LastWill {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Login {
-    username: String,
-    password: String,
+    pub username: String,
+    pub password: String,
 }
 
 impl Login {

--- a/mqttbytes/src/v5/connect.rs
+++ b/mqttbytes/src/v5/connect.rs
@@ -420,8 +420,8 @@ impl WillProperties {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Login {
-    username: String,
-    password: String,
+    pub username: String,
+    pub password: String,
 }
 
 impl Login {


### PR DESCRIPTION
I'm trying to use mqttbytes as a library in my C project though Rust FFI, but username and password in Connect::Login as private fields prevent they be visited through FFI. 

Set the username and password fields as pub is straight forward and we have all other packet struct fields as pub too. 