### PR TITLE
Fix benchmarks build issue: Changed prost::Message to pprof::protos::…

### DIFF
--- a/benchmarks/clients/common.rs
+++ b/benchmarks/clients/common.rs
@@ -1,5 +1,4 @@
-use pprof::ProfilerGuard;
-use prost::Message;
+use pprof::{protos::Message, ProfilerGuard};
 use rumqttlog::router::ConnectionAck;
 use rumqttlog::{Connection, Event, Notification, Receiver, Sender};
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
This small change will fix the build issues of benchmark crates for R8 and master.
It will allow Issue #292 to pass the pipeline as well.