### PR TITLE
Make mqttc::AsyncClient fully asynchronous

### DIFF
--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -128,7 +128,7 @@ impl AsyncClient {
     }
 
     /// Sends a MQTT Subscribe for multiple topics to the eventloop
-    pub async fn subscribe_many<T>(&mut self, topics: T) -> Result<(), ClientError>
+    pub async fn subscribe_many<T>(&self, topics: T) -> Result<(), ClientError>
     where
         T: IntoIterator<Item = SubscribeFilter>,
     {
@@ -139,7 +139,7 @@ impl AsyncClient {
     }
 
     /// Sends a MQTT Subscribe for multiple topics to the eventloop
-    pub fn try_subscribe_many<T>(&mut self, topics: T) -> Result<(), ClientError>
+    pub fn try_subscribe_many<T>(&self, topics: T) -> Result<(), ClientError>
     where
         T: IntoIterator<Item = SubscribeFilter>,
     {


### PR DESCRIPTION
Thank you for welcoming my small contributions in the project.

I love the `mqttc::AsyncClient` implementation as it allows to have access to a single instance from multiple threads if shared as `Arc<AsyncClient>` between them. 

The small change I made removes the requirement to have a Mutex to access the AsyncClient from other threads in case you need to use the `subscribe_many` methods, thus making AsyncClient trully asynchronous. 

The `&mut self` in the `subcribe_many` method signatures was "breaking" the true asynchronous implementation as it was causing it to fail the `Deref` trait on my `Arc<AsyncClient>` when I wanted to use the `subscribe_many()` method. I believe the mutability requirement does not offer any apparent benefits and does not break anything if removed.

So, I just removed the mutability requirement and now I can call any method of `AsyncClient` from many threads without the need to use a Mutex. The change is tested internally in my projects and `mqttc::AsyncClient` works as expected.
