### PR TITLE
Change set_keep_alive to use Duration instead of u16

### DIFF
--- a/benchmarks/clients/rumqttasync.rs
+++ b/benchmarks/clients/rumqttasync.rs
@@ -21,7 +21,7 @@ async fn main() {
 
 pub async fn start(id: &str, payload_size: usize, count: usize) -> Result<(), Box<dyn Error>> {
     let mut mqttoptions = MqttOptions::new(id, "localhost", 1883);
-    mqttoptions.set_keep_alive(20);
+    mqttoptions.set_keep_alive(Duration::from_secs(20));
     mqttoptions.set_inflight(100);
 
     let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);

--- a/benchmarks/clients/rumqttasyncqos0.rs
+++ b/benchmarks/clients/rumqttasyncqos0.rs
@@ -21,7 +21,7 @@ async fn main() {
 
 pub async fn start(id: &str, payload_size: usize, count: usize) -> Result<(), Box<dyn Error>> {
     let mut mqttoptions = MqttOptions::new(id, "localhost", 1883);
-    mqttoptions.set_keep_alive(20);
+    mqttoptions.set_keep_alive(Duration::from_secs(20));
     mqttoptions.set_inflight(100);
 
     let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);

--- a/benchmarks/clients/rumqttsync.rs
+++ b/benchmarks/clients/rumqttsync.rs
@@ -18,7 +18,7 @@ fn main() {
 
 pub fn start(id: &str, payload_size: usize, count: usize) -> Result<(), Box<dyn Error>> {
     let mut mqttoptions = MqttOptions::new(id, "localhost", 1883);
-    mqttoptions.set_keep_alive(20);
+    mqttoptions.set_keep_alive(Duration::from_secs(20));
     mqttoptions.set_inflight(100);
 
     let (mut client, mut connection) = Client::new(mqttoptions, 10);

--- a/rumqttc/examples/asyncpubsub.rs
+++ b/rumqttc/examples/asyncpubsub.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // color_backtrace::install();
 
     let mut mqttoptions = MqttOptions::new("test-1", "localhost", 1883);
-    mqttoptions.set_keep_alive(5);
+    mqttoptions.set_keep_alive(Duration::from_secs(5));
 
     let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
     task::spawn(async move {

--- a/rumqttc/examples/syncpubsub.rs
+++ b/rumqttc/examples/syncpubsub.rs
@@ -7,7 +7,7 @@ fn main() {
 
     let mut mqttoptions = MqttOptions::new("test-1", "localhost", 1883);
     let will = LastWill::new("hello/world", "good bye", QoS::AtMostOnce, false);
-    mqttoptions.set_keep_alive(5).set_last_will(will);
+    mqttoptions.set_keep_alive(Duration::from_secs(5)).set_last_will(will);
 
     let (client, mut connection) = Client::new(mqttoptions, 10);
     thread::spawn(move || publish(client));

--- a/rumqttc/examples/tls.rs
+++ b/rumqttc/examples/tls.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     color_backtrace::install();
 
     let mut mqtt_options = MqttOptions::new("test-1", "mqtt.example.server", 8883);
-    mqtt_options.set_keep_alive(5);
+    mqtt_options.set_keep_alive(std::time::Duration::from_secs(5));
     mqtt_options.set_credentials("username", "password");
 
     // To customise TLS configuration we create a rustls ClientConfig and set it up how we want.

--- a/rumqttc/examples/tls2.rs
+++ b/rumqttc/examples/tls2.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     color_backtrace::install();
 
     let mut mqtt_options = MqttOptions::new("test-1", "localhost", 8883);
-    mqtt_options.set_keep_alive(5);
+    mqtt_options.set_keep_alive(std::time::Duration::from_secs(5));
 
     let ca = include_bytes!("/home/tekjar/tlsfiles/ca.cert.pem");
     let client_cert = include_bytes!("/home/tekjar/tlsfiles/device-1.cert.pem");

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -383,12 +383,12 @@ impl MqttOptions {
 
     /// Set number of seconds after which client should ping the broker
     /// if there is no other data exchange
-    pub fn set_keep_alive(&mut self, secs: u16) -> &mut Self {
-        if secs < 5 {
+    pub fn set_keep_alive(&mut self, duration: Duration) -> &mut Self {
+        if duration.as_secs() < 5 {
             panic!("Keep alives should be >= 5  secs");
         }
 
-        self.keep_alive = Duration::from_secs(u64::from(secs));
+        self.keep_alive = duration;
         self
     }
 

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -681,7 +681,7 @@ mod test {
     fn outgoing_ping_handle_should_throw_errors_for_no_pingresp() {
         let mut mqtt = build_mqttstate();
         let mut opts = MqttOptions::new("test", "localhost", 1883);
-        opts.set_keep_alive(10);
+        opts.set_keep_alive(std::time::Duration::from_secs(10));
         mqtt.outgoing_ping().unwrap();
 
         // network activity other than pingresp
@@ -704,7 +704,7 @@ mod test {
         let mut mqtt = build_mqttstate();
 
         let mut opts = MqttOptions::new("test", "localhost", 1883);
-        opts.set_keep_alive(10);
+        opts.set_keep_alive(std::time::Duration::from_secs(10));
 
         // should ping
         mqtt.outgoing_ping().unwrap();

--- a/rumqttc/tests/reliability.rs
+++ b/rumqttc/tests/reliability.rs
@@ -83,7 +83,7 @@ async fn idle_connection_triggers_pings_on_time() {
     let keep_alive = 5;
 
     let mut options = MqttOptions::new("dummy", "127.0.0.1", 1885);
-    options.set_keep_alive(keep_alive);
+    options.set_keep_alive(Duration::from_secs(keep_alive));
 
     // Create client eventloop and poll
     task::spawn(async move {
@@ -119,7 +119,7 @@ async fn some_outgoing_and_no_incoming_should_trigger_pings_on_time() {
     let keep_alive = 5;
     let mut options = MqttOptions::new("dummy", "127.0.0.1", 1886);
 
-    options.set_keep_alive(keep_alive);
+    options.set_keep_alive(Duration::from_secs(keep_alive));
 
     // start sending qos0 publishes. this makes sure that there is
     // outgoing activity but no incoming activity
@@ -164,7 +164,7 @@ async fn some_incoming_and_no_outgoing_should_trigger_pings_on_time() {
     let keep_alive = 5;
     let mut options = MqttOptions::new("dummy", "127.0.0.1", 2000);
 
-    options.set_keep_alive(keep_alive);
+    options.set_keep_alive(Duration::from_secs(keep_alive));
 
     task::spawn(async move {
         let mut eventloop = EventLoop::new(options, 5);
@@ -201,7 +201,7 @@ async fn some_incoming_and_no_outgoing_should_trigger_pings_on_time() {
 #[tokio::test]
 async fn detects_halfopen_connections_in_the_second_ping_request() {
     let mut options = MqttOptions::new("dummy", "127.0.0.1", 2001);
-    options.set_keep_alive(5);
+    options.set_keep_alive(Duration::from_secs(5));
 
     // A broker which consumes packets but doesn't reply
     task::spawn(async move {
@@ -441,7 +441,7 @@ async fn next_poll_after_connect_failure_reconnects() {
 #[tokio::test]
 async fn reconnection_resumes_from_the_previous_state() {
     let mut options = MqttOptions::new("dummy", "127.0.0.1", 3001);
-    options.set_keep_alive(5);
+    options.set_keep_alive(Duration::from_secs(5));
 
     // start sending qos0 publishes. Makes sure that there is out activity but no in activity
     let mut eventloop = EventLoop::new(options, 5);
@@ -482,7 +482,7 @@ async fn reconnection_resumes_from_the_previous_state() {
 #[tokio::test]
 async fn reconnection_resends_unacked_packets_from_the_previous_connection_first() {
     let mut options = MqttOptions::new("dummy", "127.0.0.1", 3002);
-    options.set_keep_alive(5);
+    options.set_keep_alive(Duration::from_secs(5));
 
     // start sending qos0 publishes. this makes sure that there is
     // outgoing activity but no incoming activity


### PR DESCRIPTION
Since most libraries use `Duration` to express timeouts, I propose to change the `set_keep_alive` function to consume `Duration`