### PR TITLE
TryFrom<Url> impl for MqttOptions

### DIFF
--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -29,6 +29,7 @@ async-channel = "1.5"
 log = "0.4"
 thiserror = "1.0.21"
 http = "^0.2"
+url = { version = "2.2", default-features = false, optional = true }
 
 [dev-dependencies]
 pretty_env_logger = "0.4"


### PR DESCRIPTION
I noticed #255 and had a need for this feature as well, to integrate mqtt into [Vector](https://github.com/vectordotdev/vector).

The implementation is based on https://github.com/mqtt/mqtt.org/wiki/URI-Scheme, but extended with query support to enable full configuration of the client through the URI.

closes #255