### PR TITLE
Make tls::Error public in rumqttc

### DIFF
--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -117,6 +117,7 @@ pub use mqttbytes::*;
 pub use state::{MqttState, StateError};
 pub use tokio_rustls::rustls::internal::pemfile::{certs, pkcs8_private_keys, rsa_private_keys};
 pub use tokio_rustls::rustls::ClientConfig;
+pub use tls::Error;
 
 pub type Incoming = Packet;
 


### PR DESCRIPTION
Right now it's impossible to use / match against `rumqttc::tls::Error`, therefore I propose this change
Realted to #323 