### PR TITLE
Support for manual acks 

### DIFF
--- a/rumqttc/examples/async_manual_acks.rs
+++ b/rumqttc/examples/async_manual_acks.rs
@@ -1,0 +1,77 @@
+use tokio::{task, time};
+
+use rumqttc::{self, AsyncClient, Event, EventLoop, Incoming, MqttOptions, QoS};
+use std::error::Error;
+use std::time::Duration;
+
+fn create_conn() -> (AsyncClient, EventLoop) {
+    let mut mqttoptions = MqttOptions::new("test-1", "localhost", 1883);
+    mqttoptions
+        .set_keep_alive(Duration::from_secs(5))
+        .set_manual_acks(true)
+        .set_clean_session(false);
+
+    AsyncClient::new(mqttoptions, 10)
+}
+
+
+#[tokio::main(worker_threads = 1)]
+async fn main() -> Result<(), Box<dyn Error>> {
+    pretty_env_logger::init();
+
+    // create mqtt connection with clean_session = false and manual_acks = true
+    let (client, mut eventloop) = create_conn();
+
+    // subscribe example topic
+    client
+        .subscribe("hello/world", QoS::AtLeastOnce)
+        .await
+        .unwrap();
+
+    task::spawn(async move {
+        // send some messages to example topic and disconnect
+        requests(client.clone()).await;
+        client.disconnect().await.unwrap()
+    });
+
+    loop {
+        // get subscribed messages without acking
+        let event = eventloop.poll().await;
+        println!("{:?}", event);
+        if let Err(_err) = event {
+            // break loop on disconnection
+            break;
+        }
+    }
+
+    // create new broker connection
+    let (client, mut eventloop) = create_conn();
+
+    loop {
+        // previously published messages should be republished after reconnection.
+        let event = eventloop.poll().await;
+        println!("{:?}", event);
+        match event {
+            Ok(Event::Incoming(Incoming::Publish(publish))) => {
+                // this time we will ack incoming publishes.
+                // Its important not to block eventloop as this can cause deadlock.
+                let c = client.clone();
+                tokio::spawn(async move {
+                    c.ack(&publish).await.unwrap();
+                });
+            }
+            _ => {}
+        }
+    }
+}
+
+async fn requests(client: AsyncClient) {
+    for i in 1..=10 {
+        client
+            .publish("hello/world", QoS::AtLeastOnce, false, vec![1; i])
+            .await
+            .unwrap();
+
+        time::sleep(Duration::from_secs(1)).await;
+    }
+}

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -277,7 +277,7 @@ impl Client {
     }
 
     /// Sends a MQTT PubAck to the eventloop. Only needed in if `manual_acks` flag is set.
-    pub async fn ack(
+    pub fn ack(
         &self,
         publish: &Publish
     ) -> Result<(), ClientError>

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -82,10 +82,11 @@ impl EventLoop {
         let pending = Vec::new();
         let pending = pending.into_iter();
         let max_inflight = options.inflight;
+        let manual_acks = options.manual_acks;
 
         EventLoop {
             options,
-            state: MqttState::new(max_inflight),
+            state: MqttState::new(max_inflight, manual_acks),
             requests_tx,
             requests_rx,
             pending,

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -332,7 +332,8 @@ pub struct MqttOptions {
     last_will: Option<LastWill>,
     /// Connection timeout
     conn_timeout: u64,
-    /// If set to `true`, then MQTT acknowledgements are not sent automatically.
+    /// If set to `true` MQTT acknowledgements are not sent automatically.
+    /// Every incoming publish packet must be manually acknowledged with `client.ack(...)` method.
     manual_acks: bool,
 }
 

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -332,6 +332,8 @@ pub struct MqttOptions {
     last_will: Option<LastWill>,
     /// Connection timeout
     conn_timeout: u64,
+    /// If set to `true`, then MQTT acknowledgements are not sent automatically.
+    manual_acks: bool,
 }
 
 impl MqttOptions {
@@ -358,6 +360,7 @@ impl MqttOptions {
             inflight: 100,
             last_will: None,
             conn_timeout: 5,
+            manual_acks: false,
         }
     }
 
@@ -490,6 +493,17 @@ impl MqttOptions {
     /// get timeout in secs
     pub fn connection_timeout(&self) -> u64 {
         self.conn_timeout
+    }
+
+    /// set manual acknowledgements
+    pub fn set_manual_acks(&mut self, manual_acks: bool) -> &mut Self {
+        self.manual_acks = manual_acks;
+        self
+    }
+
+    /// get manual acknowledgements
+    pub fn manual_acks(&self) -> bool {
+        self.manual_acks
     }
 }
 
@@ -657,6 +671,7 @@ impl std::convert::TryFrom<url::Url> for MqttOptions {
             inflight,
             last_will: None,
             conn_timeout,
+            manual_acks: false
         })
     }
 }
@@ -679,6 +694,7 @@ impl Debug for MqttOptions {
             .field("inflight", &self.inflight)
             .field("last_will", &self.last_will)
             .field("conn_timeout", &self.conn_timeout)
+            .field("manual_acks", &self.manual_acks)
             .finish()
     }
 }


### PR DESCRIPTION
This PR introduces support for manual acknowledgements.
With `MqttOptions.manual_acks = true` every message must be manually with `client.ack()` method.
By using manual acknowledgements users are able to guarantee that they will not loose any messages.