### PR TITLE
Remove `must_use` attribute over `poll()`

### DIFF
--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -64,6 +64,9 @@ pub struct EventLoop {
     pub(crate) cancel_tx: Sender<()>,
 }
 
+#[must_use = "Eventloop should be iterated over a loop to make progress"]
+pub type PollResult = Result<Event, ConnectionError>;
+
 /// Events which can be yielded by the event loop
 #[derive(Debug, PartialEq, Clone)]
 pub enum Event {
@@ -120,8 +123,7 @@ impl EventLoop {
     /// the broker. Continuing to poll will reconnect to the broker if there is
     /// a disconnection.
     /// **NOTE** Don't block this while iterating
-    #[must_use = "Eventloop should be iterated over a loop to make progress"]
-    pub async fn poll(&mut self) -> Result<Event, ConnectionError> {
+    pub async fn poll(&mut self) -> PollResult {
         if self.network.is_none() {
             let (network, connack) = connect_or_cancel(&self.options, &self.cancel_rx).await?;
             self.network = Some(network);

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -64,9 +64,6 @@ pub struct EventLoop {
     pub(crate) cancel_tx: Sender<()>,
 }
 
-#[must_use = "Eventloop should be iterated over a loop to make progress"]
-pub type PollResult = Result<Event, ConnectionError>;
-
 /// Events which can be yielded by the event loop
 #[derive(Debug, PartialEq, Clone)]
 pub enum Event {
@@ -123,7 +120,7 @@ impl EventLoop {
     /// the broker. Continuing to poll will reconnect to the broker if there is
     /// a disconnection.
     /// **NOTE** Don't block this while iterating
-    pub async fn poll(&mut self) -> PollResult {
+    pub async fn poll(&mut self) -> Result<Event, ConnectionError> {
         if self.network.is_none() {
             let (network, connack) = connect_or_cancel(&self.options, &self.cancel_rx).await?;
             self.network = Some(network);


### PR DESCRIPTION
Currently the `must_use` attribute is being applied to the `Future` instead of `Eventloop::poll()` itself.