### PR TITLE
Make rustls optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1685,7 +1685,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "url",
- "webpki",
  "ws_stream_tungstenite",
 ]
 

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -15,7 +15,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["use-rustls"]
-websocket = ["async-tungstenite", "ws_stream_tungstenite", "use-rustls"]
+websocket = ["async-tungstenite", "ws_stream_tungstenite"]
 use-rustls = ["tokio-rustls"]
 
 [dependencies]

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -14,13 +14,15 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-websocket = ["async-tungstenite", "ws_stream_tungstenite"]
+default = ["use-rustls"]
+websocket = ["async-tungstenite", "ws_stream_tungstenite", "use-rustls"]
+use-rustls = ["tokio-rustls"]
 
 [dependencies]
 tokio = { version = "1.0", features = ["rt", "macros", "io-util", "net", "time"] }
 bytes = "1.0"
 webpki = "0.22.0"
-tokio-rustls = "0.23.2"
+tokio-rustls = { version = "0.23.2", optional = true }
 rustls-pemfile = "0.3.0"
 async-tungstenite = { version = "0.16.1", default-features = false, features = ["tokio-rustls-native-certs"], optional = true }
 ws_stream_tungstenite = { version = "0.7.0", default-features = false, features = ["tokio_io"], optional = true }

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -16,14 +16,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = ["use-rustls"]
 websocket = ["async-tungstenite", "ws_stream_tungstenite"]
-use-rustls = ["tokio-rustls"]
+use-rustls = ["tokio-rustls", "rustls-pemfile"]
 
 [dependencies]
 tokio = { version = "1.0", features = ["rt", "macros", "io-util", "net", "time"] }
 bytes = "1.0"
-webpki = "0.22.0"
 tokio-rustls = { version = "0.23.2", optional = true }
-rustls-pemfile = "0.3.0"
+rustls-pemfile = { version = "0.3.0", optional = true }
 async-tungstenite = { version = "0.16.1", default-features = false, features = ["tokio-rustls-native-certs"], optional = true }
 ws_stream_tungstenite = { version = "0.7.0", default-features = false, features = ["tokio_io"], optional = true }
 pollster = "0.2"

--- a/rumqttc/examples/tls.rs
+++ b/rumqttc/examples/tls.rs
@@ -1,11 +1,12 @@
 //! Example of how to configure rumqttd to connect to a server using TLS and authentication.
-
-use rumqttc::{self, AsyncClient, Event, Incoming, MqttOptions, Transport};
-use rustls::ClientConfig;
 use std::error::Error;
 
+#[cfg(feature = "use-rustls")]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
+    use rumqttc::{self, AsyncClient, Event, Incoming, MqttOptions, Transport};
+    use rustls::ClientConfig;
+
     pretty_env_logger::init();
     color_backtrace::install();
 
@@ -42,4 +43,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
             }
         }
     }
+}
+
+#[cfg(not(feature = "use-rustls"))]
+fn main() -> Result<(), Box<dyn Error>> {
+    panic!("Enable feature 'use-rustls'");
 }

--- a/rumqttc/examples/tls2.rs
+++ b/rumqttc/examples/tls2.rs
@@ -1,10 +1,11 @@
 //! Example of how to configure rumqttd to connect to a server using TLS and authentication.
-
-use rumqttc::{self, AsyncClient, Key, MqttOptions, TlsConfiguration, Transport};
 use std::error::Error;
 
+#[cfg(feature = "use-rustls")]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
+    use rumqttc::{self, AsyncClient, Key, MqttOptions, TlsConfiguration, Transport};
+
     pretty_env_logger::init();
     color_backtrace::install();
 
@@ -42,4 +43,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 
     Ok(())
+}
+
+#[cfg(not(feature = "use-rustls"))]
+fn main() -> Result<(), Box<dyn Error>> {
+    panic!("Enable feature 'use-rustls'");
 }

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -35,10 +35,13 @@ pub enum ConnectionError {
     #[error("Packet parsing error: {0}")]
     Mqtt4Bytes(mqttbytes::Error),
     #[cfg(feature = "use-rustls")]
-    #[error("Network: {0}")]
-    Network(#[from] tls::Error),
+    #[error("Tls Error: {0}")]
+    Tls(#[from] tls::Error),
     #[error("I/O: {0}")]
     Io(#[from] io::Error),
+    #[cfg(feature = "websocket")]
+    #[error("Websocket Connect: {0}")]
+    WsConnect(#[from] http::Error),
     #[error("Stream done")]
     StreamDone,
     #[error("Requests done")]
@@ -295,8 +298,7 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
                 .method(http::Method::GET)
                 .uri(options.broker_addr.as_str())
                 .header("Sec-WebSocket-Protocol", "mqttv3.1")
-                .body(())
-                .unwrap();
+                .body(())?;
 
             let (socket, _) = connect_async(request)
                 .await
@@ -310,8 +312,7 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
                 .method(http::Method::GET)
                 .uri(options.broker_addr.as_str())
                 .header("Sec-WebSocket-Protocol", "mqttv3.1")
-                .body(())
-                .unwrap();
+                .body(())?;
 
             let connector = tls::tls_connector(&tls_config).await?;
 

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -7,7 +7,9 @@ use crate::mqttbytes;
 use crate::mqttbytes::v4::*;
 use async_channel::{bounded, Receiver, Sender};
 #[cfg(feature = "websocket")]
-use async_tungstenite::tokio::{connect_async, connect_async_with_tls_connector};
+use async_tungstenite::tokio::connect_async;
+#[cfg(all(feature = "use-rustls", feature = "websocket"))]
+use async_tungstenite::tokio::connect_async_with_tls_connector;
 use tokio::net::TcpStream;
 #[cfg(unix)]
 use tokio::net::UnixStream;
@@ -302,7 +304,7 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
 
             Network::new(WsStream::new(socket), options.max_incoming_packet_size)
         }
-        #[cfg(feature = "websocket")]
+        #[cfg(all(feature = "use-rustls", feature = "websocket"))]
         Transport::Wss(tls_config) => {
             let request = http::Request::builder()
                 .method(http::Method::GET)

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -205,8 +205,8 @@ pub enum Transport {
     #[cfg(feature = "websocket")]
     #[cfg_attr(docsrs, doc(cfg(feature = "websocket")))]
     Ws,
-    #[cfg(feature = "websocket")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "websocket")))]
+    #[cfg(all(feature = "use-rustls", feature = "websocket"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "use-rustls", feature = "websocket"))))]
     Wss(TlsConfiguration),
 }
 
@@ -256,8 +256,8 @@ impl Transport {
     }
 
     /// Use secure websockets with tls as transport
-    #[cfg(feature = "websocket")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "websocket")))]
+    #[cfg(all(feature = "use-rustls", feature = "websocket"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "use-rustls", feature = "websocket"))))]
     pub fn wss(
         ca: Vec<u8>,
         client_auth: Option<(Vec<u8>, Key)>,
@@ -272,8 +272,8 @@ impl Transport {
         Self::wss_with_config(config)
     }
 
-    #[cfg(feature = "websocket")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "websocket")))]
+    #[cfg(all(feature = "use-rustls", feature = "websocket"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "use-rustls", feature = "websocket"))))]
     pub fn wss_with_config(tls_config: TlsConfiguration) -> Self {
         Self::Wss(tls_config)
     }
@@ -724,7 +724,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "websocket")]
+    #[cfg(all(feature = "use-rustls", feature = "websocket"))]
     fn no_scheme() {
         let mut _mqtt_opts = MqttOptions::new("client_a", "a3f8czas.iot.eu-west-1.amazonaws.com/mqtt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=MyCreds%2F20201001%2Feu-west-1%2Fiotdevicegateway%2Faws4_request&X-Amz-Date=20201001T130812Z&X-Amz-Expires=7200&X-Amz-Signature=9ae09b49896f44270f2707551581953e6cac71a4ccf34c7c3415555be751b2d1&X-Amz-SignedHeaders=host", 443);
 

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -100,6 +100,7 @@
 extern crate log;
 
 use std::fmt::{self, Debug, Formatter};
+#[cfg(feature = "use-rustls")]
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -108,6 +109,7 @@ mod eventloop;
 mod framed;
 pub mod mqttbytes;
 mod state;
+#[cfg(feature = "use-rustls")]
 mod tls;
 
 pub use async_channel::{SendError, Sender, TrySendError};
@@ -116,7 +118,9 @@ pub use eventloop::{ConnectionError, Event, EventLoop};
 pub use mqttbytes::v4::*;
 pub use mqttbytes::*;
 pub use state::{MqttState, StateError};
+#[cfg(feature = "use-rustls")]
 pub use tls::Error;
+#[cfg(feature = "use-rustls")]
 pub use tokio_rustls::rustls::ClientConfig;
 
 pub type Incoming = Packet;
@@ -194,6 +198,7 @@ impl From<Unsubscribe> for Request {
 #[derive(Clone)]
 pub enum Transport {
     Tcp,
+    #[cfg(feature = "use-rustls")]
     Tls(TlsConfiguration),
     #[cfg(unix)]
     Unix,
@@ -218,6 +223,7 @@ impl Transport {
     }
 
     /// Use secure tcp with tls as transport
+    #[cfg(feature = "use-rustls")]
     pub fn tls(
         ca: Vec<u8>,
         client_auth: Option<(Vec<u8>, Key)>,
@@ -232,6 +238,7 @@ impl Transport {
         Self::tls_with_config(config)
     }
 
+    #[cfg(feature = "use-rustls")]
     pub fn tls_with_config(tls_config: TlsConfiguration) -> Self {
         Self::Tls(tls_config)
     }
@@ -273,6 +280,7 @@ impl Transport {
 }
 
 #[derive(Clone)]
+#[cfg(feature = "use-rustls")]
 pub enum TlsConfiguration {
     Simple {
         /// connection method
@@ -286,6 +294,7 @@ pub enum TlsConfiguration {
     Rustls(Arc<ClientConfig>),
 }
 
+#[cfg(feature = "use-rustls")]
 impl From<ClientConfig> for TlsConfiguration {
     fn from(config: ClientConfig) -> Self {
         TlsConfiguration::Rustls(Arc::new(config))

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -119,7 +119,7 @@ pub use mqttbytes::v4::*;
 pub use mqttbytes::*;
 pub use state::{MqttState, StateError};
 #[cfg(feature = "use-rustls")]
-pub use tls::Error;
+pub use tls::Error as TlsError;
 #[cfg(feature = "use-rustls")]
 pub use tokio_rustls::rustls::ClientConfig;
 


### PR DESCRIPTION
Closes #305

Enables the compilation of `rumqttc` without rustls/TLS support by using `--no-default-features` flag during compilation. `rustls` support is enabled by default, otherwise can be enabled with `use_rustls` feature flag.