### PR TITLE
Add stale-issue management bot configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,11 @@
+daysUntilStale: 20
+
+exemptLabels:
+  - "in-pipeline"
+  - "help wanted"
+  - "bug"
+  
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.


### PR DESCRIPTION
Marks as stale if issues are not active for over 20 days

uses [probot/stale](https://github.com/probot/stale)