### PR TITLE
Improve Error texts

### DIFF
--- a/benchmarks/simplerouter/src/protocol/mod.rs
+++ b/benchmarks/simplerouter/src/protocol/mod.rs
@@ -68,7 +68,7 @@ pub enum Error {
     InvalidReason(u8),
     #[error("Invalid protocol used")]
     InvalidProtocol,
-    #[error("Invalid protocol level")]
+    #[error("Invalid protocol level = {0}")]
     InvalidProtocolLevel(u8),
     #[error("Invalid packet format")]
     IncorrectPacketFormat,

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -18,8 +18,8 @@ pub enum ClientError {
     Request(#[from] SendError<Request>),
     #[error("Failed to send mqtt requests to eventloop")]
     TryRequest(#[from] TrySendError<Request>),
-    #[error("Serialization error")]
-    Mqtt4(mqttbytes::Error),
+    #[error("Serialization error: {0}")]
+    Mqtt4(#[from] mqttbytes::Error),
 }
 
 /// `AsyncClient` to communicate with MQTT `Eventloop`

--- a/rumqttc/src/mqttbytes/mod.rs
+++ b/rumqttc/src/mqttbytes/mod.rs
@@ -4,7 +4,7 @@
 //! The [`bytes`](https://docs.rs/bytes) crate is used internally.
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-use core::fmt::{self, Display, Formatter};
+use core::fmt;
 use std::slice::Iter;
 
 mod topic;
@@ -15,31 +15,54 @@ pub use topic::*;
 /// Error during serialization and deserialization
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum Error {
+    #[error("expected connect but got packet: {0:?}")]
     NotConnect(PacketType),
+    #[error("unexpected connect")]
     UnexpectedConnect,
+    #[error("invalid connect return type: {0}")]
     InvalidConnectReturnCode(u8),
+    #[error("invalid reason: {0}")]
     InvalidReason(u8),
+    #[error("invalid protocol")]
     InvalidProtocol,
+    #[error("invalid protocol level: {0}")]
     InvalidProtocolLevel(u8),
+    #[error("incorrect packet format")]
     IncorrectPacketFormat,
+    #[error("invalid packet type: {0}")]
     InvalidPacketType(u8),
+    #[error("invalid property type: {0}")]
     InvalidPropertyType(u8),
+    #[error("invalid retain forward rule: {0}")]
     InvalidRetainForwardRule(u8),
+    #[error("invalid QoS: {0}")]
     InvalidQoS(u8),
+    #[error("invalid subscribe reason code: {0}")]
     InvalidSubscribeReasonCode(u8),
+    #[error("packet id is zero")]
     PacketIdZero,
+    #[error("subscription id is zero")]
     SubscriptionIdZero,
+    #[error("payload size is incorrect")]
     PayloadSizeIncorrect,
+    #[error("payload is too long")]
     PayloadTooLong,
+    #[error("payload size limit exceeded: {0}")]
     PayloadSizeLimitExceeded(usize),
+    #[error("payload required")]
     PayloadRequired,
+    #[error("topic is not UTF-8")]
     TopicNotUtf8,
+    #[error("boundary crossed: {0}")]
     BoundaryCrossed(usize),
+    #[error("malformed packet")]
     MalformedPacket,
+    #[error("malformed remaining length")]
     MalformedRemainingLength,
     /// More bytes required to frame packet. Argument
     /// implies minimum additional bytes required to
     /// proceed further
+    #[error("More bytes required to frame packet. Requires at least {0} more bytes.")]
     InsufficientBytes(usize),
 }
 
@@ -314,10 +337,4 @@ fn read_u8(stream: &mut Bytes) -> Result<u8, Error> {
     }
 
     Ok(stream.get_u8())
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "Error = {:?}", self)
-    }
 }

--- a/rumqttc/src/mqttbytes/mod.rs
+++ b/rumqttc/src/mqttbytes/mod.rs
@@ -13,7 +13,7 @@ pub mod v4;
 pub use topic::*;
 
 /// Error during serialization and deserialization
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum Error {
     NotConnect(PacketType),
     UnexpectedConnect,

--- a/rumqttc/src/mqttbytes/mod.rs
+++ b/rumqttc/src/mqttbytes/mod.rs
@@ -15,54 +15,48 @@ pub use topic::*;
 /// Error during serialization and deserialization
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum Error {
-    #[error("expected connect but got packet: {0:?}")]
+    #[error("Expected Connect, received: {0:?}")]
     NotConnect(PacketType),
-    #[error("unexpected connect")]
+    #[error("Unexpected Connect")]
     UnexpectedConnect,
-    #[error("invalid connect return type: {0}")]
+    #[error("Invalid Connect return code: {0}")]
     InvalidConnectReturnCode(u8),
-    #[error("invalid reason: {0}")]
-    InvalidReason(u8),
-    #[error("invalid protocol")]
+    #[error("Invalid protocol")]
     InvalidProtocol,
-    #[error("invalid protocol level: {0}")]
+    #[error("Invalid protocol level: {0}")]
     InvalidProtocolLevel(u8),
-    #[error("incorrect packet format")]
+    #[error("Incorrect packet format")]
     IncorrectPacketFormat,
-    #[error("invalid packet type: {0}")]
+    #[error("Invalid packet type: {0}")]
     InvalidPacketType(u8),
-    #[error("invalid property type: {0}")]
+    #[error("Invalid property type: {0}")]
     InvalidPropertyType(u8),
-    #[error("invalid retain forward rule: {0}")]
-    InvalidRetainForwardRule(u8),
-    #[error("invalid QoS: {0}")]
+    #[error("Invalid QoS level: {0}")]
     InvalidQoS(u8),
-    #[error("invalid subscribe reason code: {0}")]
+    #[error("Invalid subscribe reason code: {0}")]
     InvalidSubscribeReasonCode(u8),
-    #[error("packet id is zero")]
+    #[error("Packet id Zero")]
     PacketIdZero,
-    #[error("subscription id is zero")]
-    SubscriptionIdZero,
-    #[error("payload size is incorrect")]
+    #[error("Payload size is incorrect")]
     PayloadSizeIncorrect,
     #[error("payload is too long")]
     PayloadTooLong,
     #[error("payload size limit exceeded: {0}")]
     PayloadSizeLimitExceeded(usize),
-    #[error("payload required")]
+    #[error("Payload required")]
     PayloadRequired,
-    #[error("topic is not UTF-8")]
+    #[error("Topic is not UTF-8")]
     TopicNotUtf8,
-    #[error("boundary crossed: {0}")]
+    #[error("Promised boundary crossed: {0}")]
     BoundaryCrossed(usize),
-    #[error("malformed packet")]
+    #[error("Malformed packet")]
     MalformedPacket,
-    #[error("malformed remaining length")]
+    #[error("Malformed remaining length")]
     MalformedRemainingLength,
     /// More bytes required to frame packet. Argument
     /// implies minimum additional bytes required to
     /// proceed further
-    #[error("More bytes required to frame packet. Requires at least {0} more bytes.")]
+    #[error("At least {0} more bytes required to frame packet")]
     InsufficientBytes(usize),
 }
 

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -29,14 +29,8 @@ pub enum StateError {
     WrongPacket,
     #[error("Timeout while waiting to resolve collision")]
     CollisionTimeout,
-    #[error("Mqtt serialization/deserialization error")]
-    Deserialization(mqttbytes::Error),
-}
-
-impl From<mqttbytes::Error> for StateError {
-    fn from(e: mqttbytes::Error) -> StateError {
-        StateError::Deserialization(e)
-    }
+    #[error("Mqtt serialization/deserialization error: {0}")]
+    Deserialization(#[from] mqttbytes::Error),
 }
 
 /// State of the mqtt connection.

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -10,16 +10,16 @@ use std::{io, mem, time::Instant};
 #[derive(Debug, thiserror::Error)]
 pub enum StateError {
     /// Io Error while state is passed to network
-    #[error("Io error {0:?}")]
+    #[error("Io error: {0:?}")]
     Io(#[from] io::Error),
     /// Broker's error reply to client's connect packet
-    #[error("Connect return code `{0:?}`")]
+    #[error("Connect return code: `{0:?}`")]
     Connect(ConnectReturnCode),
     /// Invalid state for a given operation
     #[error("Invalid state for a given operation")]
     InvalidState,
     /// Received a packet (ack) which isn't asked for
-    #[error("Received unsolicited ack pkid {0}")]
+    #[error("Received unsolicited ack pkid: {0}")]
     Unsolicited(u16),
     /// Last pingreq isn't acked
     #[error("Last pingreq isn't acked")]

--- a/rumqttc/src/tls.rs
+++ b/rumqttc/src/tls.rs
@@ -19,13 +19,13 @@ use std::sync::Arc;
 pub enum Error {
     #[error("Addr")]
     Addr(#[from] AddrParseError),
-    #[error("I/O")]
+    #[error("I/O: {0}")]
     Io(#[from] io::Error),
-    #[error("Web Pki")]
+    #[error("Web Pki: {0}")]
     WebPki(#[from] webpki::Error),
     #[error("DNS name")]
     DNSName(#[from] InvalidDnsNameError),
-    #[error("TLS error")]
+    #[error("TLS error: {0}")]
     TLS(#[from] rustls::Error),
     #[error("No valid cert in chain")]
     NoValidCertInChain,

--- a/rumqttd/src/async_locallink.rs
+++ b/rumqttd/src/async_locallink.rs
@@ -17,7 +17,7 @@ use log::{error, trace, warn};
 pub enum LinkError {
     #[error("Unexpected router message: {0:?}")]
     NotConnectionAck(Notification),
-    #[error("Connack error {0}")]
+    #[error("Connack error: {0}")]
     ConnectionAck(String),
     #[error("Channel send error")]
     Send(#[from] SendError<(Id, Event)>),

--- a/rumqttd/src/async_locallink.rs
+++ b/rumqttd/src/async_locallink.rs
@@ -15,7 +15,7 @@ use log::{error, trace, warn};
 
 #[derive(Debug, thiserror::Error)]
 pub enum LinkError {
-    #[error("Unexpected router message")]
+    #[error("Unexpected router message: {0:?}")]
     NotConnectionAck(Notification),
     #[error("Connack error {0}")]
     ConnectionAck(String),

--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -55,9 +55,9 @@ use std::io::BufReader;
 #[derive(Debug, thiserror::Error)]
 #[error("Acceptor error")]
 pub enum Error {
-    #[error("I/O {0}")]
+    #[error("I/O: {0}")]
     Io(#[from] io::Error),
-    #[error("Connection error {0}")]
+    #[error("Connection error: {0}")]
     Connection(#[from] remotelink::Error),
     #[error("Timeout")]
     Timeout(#[from] Elapsed),
@@ -66,10 +66,10 @@ pub enum Error {
     #[error("Channel send error")]
     Send(#[from] SendError<(Id, Event)>),
     #[cfg(feature = "use-native-tls")]
-    #[error("Native TLS error {0}")]
+    #[error("Native TLS error: {0}")]
     NativeTls(#[from] NativeTlsError),
     #[cfg(feature = "use-rustls")]
-    #[error("Rustls error {0}")]
+    #[error("Rustls error: {0}")]
     Rustls(#[from] RustlsError),
     #[error("Server cert not provided")]
     ServerCertRequired,
@@ -81,19 +81,19 @@ pub enum Error {
     ServerCertNotFound(String),
     #[error("Server private key file {0} not found")]
     ServerKeyNotFound(String),
-    #[error("Invalid CA cert file {0}")]
+    #[error("Invalid CA cert file: {0}")]
     InvalidCACert(String),
-    #[error("Invalid server cert file {0}")]
+    #[error("Invalid server cert file: {0}")]
     InvalidServerCert(String),
     #[error("Invalid server pass")]
     InvalidServerPass,
-    #[error("Invalid server key file {0}")]
+    #[error("Invalid server key file: {0}")]
     InvalidServerKey(String),
     RustlsNotEnabled,
     NativeTlsNotEnabled,
     Disconnected,
     NetworkClosed,
-    #[error("Wrong packet {0:?}")]
+    #[error("Wrong packet: {0:?}")]
     WrongPacket(Packet),
 }
 

--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -86,13 +86,14 @@ pub enum Error {
     #[error("Invalid server cert file {0}")]
     InvalidServerCert(String),
     #[error("Invalid server pass")]
-    InvalidServerPass(),
+    InvalidServerPass,
     #[error("Invalid server key file {0}")]
     InvalidServerKey(String),
     RustlsNotEnabled,
     NativeTlsNotEnabled,
     Disconnected,
     NetworkClosed,
+    #[error("Wrong packet {0:?}")]
     WrongPacket(Packet),
 }
 
@@ -285,7 +286,7 @@ impl Server {
 
         // Get the identity
         let identity = native_tls::Identity::from_pkcs12(&buf, pkcs12_pass)
-            .map_err(|_| Error::InvalidServerPass())?;
+            .map_err(|_| Error::InvalidServerPass)?;
 
         // Builder
         let builder = native_tls::TlsAcceptor::builder(identity).build()?;

--- a/rumqttd/src/locallink.rs
+++ b/rumqttd/src/locallink.rs
@@ -11,9 +11,9 @@ use std::time::Instant;
 
 #[derive(Debug, thiserror::Error)]
 pub enum LinkError {
-    #[error("Unexpected router message {0:?}")]
+    #[error("Unexpected router message: {0:?}")]
     NotConnectionAck(Notification),
-    #[error("Connack error {0}")]
+    #[error("Connack error: {0}")]
     ConnectionAck(String),
     #[error("Channel send error")]
     Send(#[from] SendError<(Id, Event)>),

--- a/rumqttd/src/locallink.rs
+++ b/rumqttd/src/locallink.rs
@@ -11,7 +11,7 @@ use std::time::Instant;
 
 #[derive(Debug, thiserror::Error)]
 pub enum LinkError {
-    #[error("Unexpected router message")]
+    #[error("Unexpected router message {0:?}")]
     NotConnectionAck(Notification),
     #[error("Connack error {0}")]
     ConnectionAck(String),

--- a/rumqttd/src/mqttbytes/mod.rs
+++ b/rumqttd/src/mqttbytes/mod.rs
@@ -13,7 +13,7 @@ pub mod v4;
 pub use topic::*;
 
 /// Error during serialization and deserialization
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum Error {
     NotConnect(PacketType),
     UnexpectedConnect,

--- a/rumqttd/src/mqttbytes/mod.rs
+++ b/rumqttd/src/mqttbytes/mod.rs
@@ -4,7 +4,7 @@
 //! The [`bytes`](https://docs.rs/bytes) crate is used internally.
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-use core::fmt::{self, Display, Formatter};
+use core::fmt;
 use std::slice::Iter;
 
 mod topic;
@@ -15,31 +15,54 @@ pub use topic::*;
 /// Error during serialization and deserialization
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum Error {
+    #[error("expected connect but got packet: {0:?}")]
     NotConnect(PacketType),
+    #[error("unexpected connect")]
     UnexpectedConnect,
+    #[error("invalid connect return type: {0}")]
     InvalidConnectReturnCode(u8),
+    #[error("invalid reason: {0}")]
     InvalidReason(u8),
+    #[error("invalid protocol")]
     InvalidProtocol,
+    #[error("invalid protocol level: {0}")]
     InvalidProtocolLevel(u8),
+    #[error("incorrect packet format")]
     IncorrectPacketFormat,
+    #[error("invalid packet type: {0}")]
     InvalidPacketType(u8),
+    #[error("invalid property type: {0}")]
     InvalidPropertyType(u8),
+    #[error("invalid retain forward rule: {0}")]
     InvalidRetainForwardRule(u8),
+    #[error("invalid QoS: {0}")]
     InvalidQoS(u8),
+    #[error("invalid subscribe reason code: {0}")]
     InvalidSubscribeReasonCode(u8),
+    #[error("packet id is zero")]
     PacketIdZero,
+    #[error("subscription id is zero")]
     SubscriptionIdZero,
+    #[error("payload size is incorrect")]
     PayloadSizeIncorrect,
+    #[error("payload is too long")]
     PayloadTooLong,
+    #[error("payload size limit exceeded: {0}")]
     PayloadSizeLimitExceeded(usize),
+    #[error("payload required")]
     PayloadRequired,
+    #[error("topic is not UTF-8")]
     TopicNotUtf8,
+    #[error("boundary crossed: {0}")]
     BoundaryCrossed(usize),
+    #[error("malformed packet")]
     MalformedPacket,
+    #[error("malformed remaining length")]
     MalformedRemainingLength,
     /// More bytes required to frame packet. Argument
     /// implies minimum additional bytes required to
     /// proceed further
+    #[error("More bytes required to frame packet. Requires at least {0} more bytes.")]
     InsufficientBytes(usize),
 }
 
@@ -315,10 +338,4 @@ fn read_u8(stream: &mut Bytes) -> Result<u8, Error> {
     }
 
     Ok(stream.get_u8())
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "Error = {:?}", self)
-    }
 }

--- a/rumqttd/src/mqttbytes/mod.rs
+++ b/rumqttd/src/mqttbytes/mod.rs
@@ -15,54 +15,48 @@ pub use topic::*;
 /// Error during serialization and deserialization
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum Error {
-    #[error("expected connect but got packet: {0:?}")]
+    #[error("Expected Connect, received: {0:?}")]
     NotConnect(PacketType),
-    #[error("unexpected connect")]
+    #[error("Unexpected Connect")]
     UnexpectedConnect,
-    #[error("invalid connect return type: {0}")]
+    #[error("Invalid Connect return code: {0}")]
     InvalidConnectReturnCode(u8),
-    #[error("invalid reason: {0}")]
-    InvalidReason(u8),
-    #[error("invalid protocol")]
+    #[error("Invalid protocol")]
     InvalidProtocol,
-    #[error("invalid protocol level: {0}")]
+    #[error("Invalid protocol level: {0}")]
     InvalidProtocolLevel(u8),
-    #[error("incorrect packet format")]
+    #[error("Incorrect packet format")]
     IncorrectPacketFormat,
-    #[error("invalid packet type: {0}")]
+    #[error("Invalid packet type: {0}")]
     InvalidPacketType(u8),
-    #[error("invalid property type: {0}")]
+    #[error("Invalid property type: {0}")]
     InvalidPropertyType(u8),
-    #[error("invalid retain forward rule: {0}")]
-    InvalidRetainForwardRule(u8),
-    #[error("invalid QoS: {0}")]
+    #[error("Invalid QoS level: {0}")]
     InvalidQoS(u8),
-    #[error("invalid subscribe reason code: {0}")]
+    #[error("Invalid subscribe reason code: {0}")]
     InvalidSubscribeReasonCode(u8),
-    #[error("packet id is zero")]
+    #[error("Packet id Zero")]
     PacketIdZero,
-    #[error("subscription id is zero")]
-    SubscriptionIdZero,
-    #[error("payload size is incorrect")]
+    #[error("Payload size is incorrect")]
     PayloadSizeIncorrect,
     #[error("payload is too long")]
     PayloadTooLong,
     #[error("payload size limit exceeded: {0}")]
     PayloadSizeLimitExceeded(usize),
-    #[error("payload required")]
+    #[error("Payload required")]
     PayloadRequired,
-    #[error("topic is not UTF-8")]
+    #[error("Topic is not UTF-8")]
     TopicNotUtf8,
-    #[error("boundary crossed: {0}")]
+    #[error("Promised boundary crossed: {0}")]
     BoundaryCrossed(usize),
-    #[error("malformed packet")]
+    #[error("Malformed packet")]
     MalformedPacket,
-    #[error("malformed remaining length")]
+    #[error("Malformed remaining length")]
     MalformedRemainingLength,
     /// More bytes required to frame packet. Argument
     /// implies minimum additional bytes required to
     /// proceed further
-    #[error("More bytes required to frame packet. Requires at least {0} more bytes.")]
+    #[error("At least {0} more bytes required to frame packet")]
     InsufficientBytes(usize),
 }
 

--- a/rumqttd/src/network.rs
+++ b/rumqttd/src/network.rs
@@ -14,8 +14,8 @@ pub enum Error {
     #[error("State = {0}")]
     State(#[from] state::Error),
     #[error("Invalid data = {0}")]
-    Mqtt(mqttbytes::Error),
-    #[error["Keep alive timeout"]]
+    Mqtt(#[from] mqttbytes::Error),
+    #[error("Keep alive timeout")]
     KeepAlive(#[from] Elapsed),
 }
 

--- a/rumqttd/src/network.rs
+++ b/rumqttd/src/network.rs
@@ -9,11 +9,11 @@ use tokio::time::{self, error::Elapsed, Duration};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("I/O = {0}")]
+    #[error("I/O: {0}")]
     Io(#[from] io::Error),
-    #[error("State = {0}")]
+    #[error("State: {0}")]
     State(#[from] state::Error),
-    #[error("Invalid data = {0}")]
+    #[error("Invalid data: {0}")]
     Mqtt(#[from] mqttbytes::Error),
     #[error("Keep alive timeout")]
     KeepAlive(#[from] Elapsed),

--- a/rumqttd/src/remotelink.rs
+++ b/rumqttd/src/remotelink.rs
@@ -27,17 +27,17 @@ pub struct RemoteLink {
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("I/O {0}")]
+    #[error("I/O: {0}")]
     Io(#[from] io::Error),
-    #[error("Network {0}")]
+    #[error("Network: {0}")]
     Network(#[from] network::Error),
     #[error("Timeout")]
     Timeout(#[from] Elapsed),
-    #[error("State error {0}")]
+    #[error("State error: {0}")]
     State(#[from] state::Error),
-    #[error("Unexpected router message {0:?}")]
+    #[error("Unexpected router message: {0:?}")]
     RouterMessage(Notification),
-    #[error("Connack error {0}")]
+    #[error("Connack error: {0}")]
     ConnAck(String),
     #[error("Keep alive time exceeded")]
     KeepAlive,

--- a/rumqttd/src/remotelink.rs
+++ b/rumqttd/src/remotelink.rs
@@ -27,15 +27,15 @@ pub struct RemoteLink {
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("I/O")]
+    #[error("I/O {0}")]
     Io(#[from] io::Error),
     #[error("Network {0}")]
     Network(#[from] network::Error),
     #[error("Timeout")]
     Timeout(#[from] Elapsed),
-    #[error("State error")]
+    #[error("State error {0}")]
     State(#[from] state::Error),
-    #[error("Unexpected router message")]
+    #[error("Unexpected router message {0:?}")]
     RouterMessage(Notification),
     #[error("Connack error {0}")]
     ConnAck(String),
@@ -45,7 +45,7 @@ pub enum Error {
     Send(#[from] SendError<(Id, Event)>),
     #[error("Channel recv error")]
     Recv(#[from] RecvError),
-    #[error("Payload count greater than max inflight")]
+    #[error("Payload count ({0}) greater than max inflight")]
     TooManyPayloads(usize),
     #[error("Persistent session requires valid client id")]
     InvalidClientId,

--- a/rumqttd/src/state.rs
+++ b/rumqttd/src/state.rs
@@ -11,8 +11,8 @@ use std::vec::IntoIter;
 pub enum Error {
     #[error("Received unsolicited ack from the device. {0}")]
     Unsolicited(u16),
-    #[error("Collision with an unacked packet")]
-    Serialization(mqttbytes::Error),
+    #[error("Collision with an unacked packet: {0}")]
+    Serialization(#[from] mqttbytes::Error),
     #[error("Collision with an unacked packet")]
     Collision,
     #[error("Duplicate connect")]
@@ -21,12 +21,6 @@ pub enum Error {
     ClientConnAck,
     #[error("Client disconnect")]
     Disconnect,
-}
-
-impl From<mqttbytes::Error> for Error {
-    fn from(e: mqttbytes::Error) -> Error {
-        Error::Serialization(e)
-    }
 }
 
 #[derive(Debug)]

--- a/rumqttd/src/state.rs
+++ b/rumqttd/src/state.rs
@@ -9,7 +9,7 @@ use std::vec::IntoIter;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Received unsolicited ack from the device. {0}")]
+    #[error("Received unsolicited ack from the device: {0}")]
     Unsolicited(u16),
     #[error("Collision with an unacked packet: {0}")]
     Serialization(#[from] mqttbytes::Error),


### PR DESCRIPTION
Initially I wanted to just add details for the `mqttbytes::Error` in the `StateError`. I continued with other `thiserror::Error` implementations to improve error details.

Something that is not the same everywhere is the formatting style: `text: {0}`, `text {0}` or `text = {0}` are used currently. I could also improve that with this PR but I am not sure with format is preferred. Maybe `text: {0}`?