### PR TITLE
Improve MqttOptions creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1717,6 +1717,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-rustls",
+ "typed-builder",
  "url",
  "ws_stream_tungstenite",
 ]
@@ -2341,6 +2342,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "typed-builder"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89851716b67b937e393b3daa8423e67ddfc4bbbf1654bcf05488e95e0828db0c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/benchmarks/clients/rumqttasync.rs
+++ b/benchmarks/clients/rumqttasync.rs
@@ -21,9 +21,13 @@ async fn main() {
 }
 
 pub async fn start(id: &str, payload_size: usize, count: usize) -> Result<(), Box<dyn Error>> {
-    let mut mqttoptions = MqttOptions::new(id, "localhost", 1883);
-    mqttoptions.set_keep_alive(Duration::from_secs(20));
-    mqttoptions.set_inflight(100);
+    let mqttoptions = MqttOptions::builder()
+        .broker_addr("localhost")
+        .port(1883)
+        .client_id(id.parse().unwrap())
+        .keep_alive(Duration::from_secs(20))
+        .inflight(100)
+        .build();
 
     let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
     task::spawn(async move {

--- a/benchmarks/clients/rumqttasyncqos0.rs
+++ b/benchmarks/clients/rumqttasyncqos0.rs
@@ -21,9 +21,13 @@ async fn main() {
 }
 
 pub async fn start(id: &str, payload_size: usize, count: usize) -> Result<(), Box<dyn Error>> {
-    let mut mqttoptions = MqttOptions::new(id, "localhost", 1883);
-    mqttoptions.set_keep_alive(Duration::from_secs(20));
-    mqttoptions.set_inflight(100);
+    let mqttoptions = MqttOptions::builder()
+        .broker_addr("localhost")
+        .port(1883)
+        .client_id(id.parse().unwrap())
+        .keep_alive(Duration::from_secs(20))
+        .inflight(100)
+        .build();
 
     let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
     task::spawn(async move {

--- a/benchmarks/clients/rumqttsync.rs
+++ b/benchmarks/clients/rumqttsync.rs
@@ -17,9 +17,13 @@ fn main() {
 }
 
 pub fn start(id: &str, payload_size: usize, count: usize) -> Result<(), Box<dyn Error>> {
-    let mut mqttoptions = MqttOptions::new(id, "localhost", 1883);
-    mqttoptions.set_keep_alive(Duration::from_secs(20));
-    mqttoptions.set_inflight(100);
+    let mqttoptions = MqttOptions::builder()
+        .broker_addr("localhost")
+        .port(1883)
+        .client_id(id.parse().unwrap())
+        .keep_alive(Duration::from_secs(20))
+        .inflight(100)
+        .build();
 
     let (mut client, mut connection) = Client::new(mqttoptions, 10);
     thread::spawn(move || {

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -31,6 +31,7 @@ thiserror = "1.0.21"
 http = "^0.2"
 url = { version = "2.2", default-features = false, optional = true }
 flume = "0.10.10"
+typed-builder = "0.10"
 
 [dev-dependencies]
 pretty_env_logger = "0.4"

--- a/rumqttc/examples/async_manual_acks.rs
+++ b/rumqttc/examples/async_manual_acks.rs
@@ -5,11 +5,14 @@ use std::error::Error;
 use std::time::Duration;
 
 fn create_conn() -> (AsyncClient, EventLoop) {
-    let mut mqttoptions = MqttOptions::new("test-1", "localhost", 1883);
-    mqttoptions
-        .set_keep_alive(Duration::from_secs(5))
-        .set_manual_acks(true)
-        .set_clean_session(false);
+    let mqttoptions = MqttOptions::builder()
+        .broker_addr("localhost")
+        .port(1883)
+        .client_id("test-1".parse().expect("invalid client id"))
+        .keep_alive(Duration::from_secs(5))
+        .manual_acks(true)
+        .clean_session(false)
+        .build();
 
     AsyncClient::new(mqttoptions, 10)
 }
@@ -30,7 +33,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     task::spawn(async move {
         // send some messages to example topic and disconnect
         requests(client.clone()).await;
-        client.disconnect().await.unwrap()
+        client.disconnect().await.unwrap();
     });
 
     loop {

--- a/rumqttc/examples/asyncpubsub.rs
+++ b/rumqttc/examples/asyncpubsub.rs
@@ -9,8 +9,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
     // color_backtrace::install();
 
-    let mut mqttoptions = MqttOptions::new("test-1", "localhost", 1883);
-    mqttoptions.set_keep_alive(Duration::from_secs(5));
+    let mqttoptions = MqttOptions::builder()
+        .broker_addr("localhost")
+        .port(1883)
+        .client_id("test-1".parse().expect("invalid client id"))
+        .keep_alive(Duration::from_secs(5))
+        .build();
 
     let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
     task::spawn(async move {

--- a/rumqttc/examples/syncpubsub.rs
+++ b/rumqttc/examples/syncpubsub.rs
@@ -5,11 +5,14 @@ use std::time::Duration;
 fn main() {
     pretty_env_logger::init();
 
-    let mut mqttoptions = MqttOptions::new("test-1", "localhost", 1883);
     let will = LastWill::new("hello/world", "good bye", QoS::AtMostOnce, false);
-    mqttoptions
-        .set_keep_alive(Duration::from_secs(5))
-        .set_last_will(will);
+    let mqttoptions = MqttOptions::builder()
+        .broker_addr("localhost")
+        .port(1883)
+        .client_id("test-1".parse().expect("invalid client id"))
+        .last_will(will)
+        .keep_alive(Duration::from_secs(5))
+        .build();
 
     let (client, mut connection) = Client::new(mqttoptions, 10);
     thread::spawn(move || publish(client));
@@ -23,8 +26,8 @@ fn main() {
 
 fn publish(mut client: Client) {
     client.subscribe("hello/+/world", QoS::AtMostOnce).unwrap();
-    for i in 0..10 {
-        let payload = vec![1; i as usize];
+    for i in 0..10_usize {
+        let payload = vec![1; i];
         let topic = format!("hello/{}/world", i);
         let qos = QoS::AtLeastOnce;
 

--- a/rumqttc/examples/tls.rs
+++ b/rumqttc/examples/tls.rs
@@ -10,10 +10,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
     color_backtrace::install();
 
-    let mut mqtt_options = MqttOptions::new("test-1", "mqtt.example.server", 8883);
-    mqtt_options.set_keep_alive(std::time::Duration::from_secs(5));
-    mqtt_options.set_credentials("username", "password");
-
     // Use rustls-native-certs to load root certificates from the operating system.
     let mut root_cert_store = rustls::RootCertStore::empty();
     for cert in rustls_native_certs::load_native_certs().expect("could not load platform certs") {
@@ -25,14 +21,21 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .with_root_certificates(root_cert_store)
         .with_no_client_auth();
 
-    mqtt_options.set_transport(Transport::tls_with_config(client_config.into()));
+    let mqttoptions = MqttOptions::builder()
+        .broker_addr("mqtt.example.server")
+        .port(8883)
+        .client_id("test-1".parse().expect("invalid client id"))
+        .keep_alive(std::time::Duration::from_secs(5))
+        .credentials(("username".into(), "password".into()))
+        .transport(Transport::tls_with_config(client_config.into()))
+        .build();
 
-    let (_client, mut eventloop) = AsyncClient::new(mqtt_options, 10);
+    let (_client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
 
     loop {
         match eventloop.poll().await {
             Ok(Event::Incoming(Incoming::Publish(p))) => {
-                println!("Topic: {}, Payload: {:?}", p.topic, p.payload)
+                println!("Topic: {}, Payload: {:?}", p.topic, p.payload);
             }
             Ok(Event::Incoming(i)) => {
                 println!("Incoming = {:?}", i);

--- a/rumqttc/examples/websocket.rs
+++ b/rumqttc/examples/websocket.rs
@@ -10,14 +10,13 @@ use tokio::{task, time};
 async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
 
-    // port parameter is ignored when scheme is websocket
-    let mut mqttoptions = MqttOptions::new(
-        "clientId-aSziq39Bp3",
-        "ws://broker.mqttdashboard.com:8000/mqtt",
-        8000,
-    );
-    mqttoptions.set_transport(Transport::Ws);
-    mqttoptions.set_keep_alive(Duration::from_secs(60));
+    let mqttoptions = MqttOptions::builder()
+        .broker_addr("ws://broker.mqttdashboard.com:8000/mqtt")
+        // port parameter is ignored when scheme is websocket
+        .port(8000)
+        .client_id("clientId-aSziq39Bp3".parse().expect("invalid client id"))
+        .transport(Transport::Ws)
+        .build();
 
     let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
     task::spawn(async move {

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -314,7 +314,7 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
                 .header("Sec-WebSocket-Protocol", "mqttv3.1")
                 .body(())?;
 
-            let connector = tls::tls_connector(&tls_config).await?;
+            let connector = tls::tls_connector(tls_config).await?;
 
             let (socket, _) = connect_async_with_tls_connector(request, Some(connector)).await?;
 

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -285,7 +285,7 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
         }
         #[cfg(feature = "use-rustls")]
         Transport::Tls(tls_config) => {
-            let socket = tls::tls_connect(options, &tls_config).await?;
+            let socket = tls::tls_connect(options, tls_config).await?;
             Network::new(socket, options.max_incoming_packet_size)
         }
         #[cfg(unix)]

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -111,7 +111,6 @@
 extern crate log;
 
 use std::fmt::{self, Debug, Formatter};
-use std::str::FromStr;
 #[cfg(feature = "use-rustls")]
 use std::sync::Arc;
 use std::time::Duration;
@@ -327,7 +326,7 @@ pub enum ClientIdError {
 #[repr(transparent)]
 pub struct ClientId(String);
 
-impl FromStr for ClientId {
+impl std::str::FromStr for ClientId {
     type Err = ClientIdError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.is_empty() {

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -698,7 +698,7 @@ mod test {
     #[cfg(feature = "url")]
     fn from_url() {
         fn opt(s: &str) -> Result<MqttOptions, OptionError> {
-            s.parse()
+            MqttOptions::parse_url(s)
         }
         fn ok(s: &str) -> MqttOptions {
             opt(s).expect("valid options")

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -367,24 +367,32 @@ impl From<ClientId> for String {
 /// When the [`url`] feature is enabled the [`MqttOptions`] can be parsed from an [`Url`](url::Url) or `str`.
 ///
 /// ```
+/// // Requires feature: url
 /// # use rumqttc::MqttOptions;
+/// # #[cfg(feature = "url")]
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let options = "mqtt://example.com:1883?client_id=123".parse::<MqttOptions>()?;
 /// # Ok(())
 /// # }
+/// # #[cfg(not(feature = "url"))]
+/// # fn main() {}
 /// ```
 ///
 /// You can also go from an [`Url`](url::Url) directly:
 ///
 /// ```
+/// // Requires feature: url
 /// # use rumqttc::MqttOptions;
 /// use std::convert::TryFrom;
-/// # use url::Url;
+/// # #[cfg(feature = "url")]
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # use url::Url;
 /// let url = Url::parse("mqtt://example.com:1883?client_id=123")?;
 /// let options = MqttOptions::try_from(url)?;
 /// # Ok(())
 /// # }
+/// # #[cfg(not(feature = "url"))]
+/// # fn main() {}
 /// ```
 ///
 /// NOTE: An URL must be prefixed with one of either `tcp://`, `mqtt://`, `ssl://`,`mqtts://`,

--- a/rumqttc/tests/reliability.rs
+++ b/rumqttc/tests/reliability.rs
@@ -63,7 +63,10 @@ async fn connection_should_timeout_on_time() {
     });
 
     time::sleep(Duration::from_secs(1)).await;
-    let options = MqttOptions::new("dummy", "127.0.0.1", 1880);
+    let options = MqttOptions::builder()
+        .port(1880)
+        .client_id("dummy".parse().unwrap())
+        .build();
     let mut eventloop = EventLoop::new(options, 5);
 
     let start = Instant::now();
@@ -81,9 +84,11 @@ async fn connection_should_timeout_on_time() {
 #[tokio::test]
 async fn idle_connection_triggers_pings_on_time() {
     let keep_alive = 5;
-
-    let mut options = MqttOptions::new("dummy", "127.0.0.1", 1885);
-    options.set_keep_alive(Duration::from_secs(keep_alive));
+    let options = MqttOptions::builder()
+        .port(1885)
+        .client_id("dummy".parse().unwrap())
+        .keep_alive(Duration::from_secs(keep_alive))
+        .build();
 
     // Create client eventloop and poll
     task::spawn(async move {
@@ -117,9 +122,11 @@ async fn idle_connection_triggers_pings_on_time() {
 #[tokio::test]
 async fn some_outgoing_and_no_incoming_should_trigger_pings_on_time() {
     let keep_alive = 5;
-    let mut options = MqttOptions::new("dummy", "127.0.0.1", 1886);
-
-    options.set_keep_alive(Duration::from_secs(keep_alive));
+    let options = MqttOptions::builder()
+        .port(1886)
+        .client_id("dummy".parse().unwrap())
+        .keep_alive(Duration::from_secs(keep_alive))
+        .build();
 
     // start sending qos0 publishes. this makes sure that there is
     // outgoing activity but no incoming activity
@@ -162,9 +169,11 @@ async fn some_outgoing_and_no_incoming_should_trigger_pings_on_time() {
 #[tokio::test]
 async fn some_incoming_and_no_outgoing_should_trigger_pings_on_time() {
     let keep_alive = 5;
-    let mut options = MqttOptions::new("dummy", "127.0.0.1", 2000);
-
-    options.set_keep_alive(Duration::from_secs(keep_alive));
+    let options = MqttOptions::builder()
+        .port(2000)
+        .client_id("dummy".parse().unwrap())
+        .keep_alive(Duration::from_secs(keep_alive))
+        .build();
 
     task::spawn(async move {
         let mut eventloop = EventLoop::new(options, 5);
@@ -200,8 +209,11 @@ async fn some_incoming_and_no_outgoing_should_trigger_pings_on_time() {
 
 #[tokio::test]
 async fn detects_halfopen_connections_in_the_second_ping_request() {
-    let mut options = MqttOptions::new("dummy", "127.0.0.1", 2001);
-    options.set_keep_alive(Duration::from_secs(5));
+    let options = MqttOptions::builder()
+        .port(2001)
+        .client_id("dummy".parse().unwrap())
+        .keep_alive(Duration::from_secs(5))
+        .build();
 
     // A broker which consumes packets but doesn't reply
     task::spawn(async move {
@@ -230,9 +242,12 @@ async fn detects_halfopen_connections_in_the_second_ping_request() {
 
 #[tokio::test]
 async fn requests_are_blocked_after_max_inflight_queue_size() {
-    let mut options = MqttOptions::new("dummy", "127.0.0.1", 1887);
-    options.set_inflight(5);
-    let inflight = options.inflight();
+    let inflight = 5;
+    let options = MqttOptions::builder()
+        .port(1887)
+        .client_id("dummy".parse().unwrap())
+        .inflight(inflight)
+        .build();
 
     // start sending qos0 publishes. this makes sure that there is
     // outgoing activity but no incoming activity
@@ -259,8 +274,11 @@ async fn requests_are_blocked_after_max_inflight_queue_size() {
 
 #[tokio::test]
 async fn requests_are_recovered_after_inflight_queue_size_falls_below_max() {
-    let mut options = MqttOptions::new("dummy", "127.0.0.1", 1888);
-    options.set_inflight(3);
+    let options = MqttOptions::builder()
+        .port(1888)
+        .client_id("dummy".parse().unwrap())
+        .inflight(3)
+        .build();
 
     let mut eventloop = EventLoop::new(options, 5);
     let requests_tx = eventloop.handle();
@@ -298,8 +316,11 @@ async fn requests_are_recovered_after_inflight_queue_size_falls_below_max() {
 
 #[tokio::test]
 async fn packet_id_collisions_are_detected_and_flow_control_is_applied() {
-    let mut options = MqttOptions::new("dummy", "127.0.0.1", 1891);
-    options.set_inflight(10);
+    let options = MqttOptions::builder()
+        .port(1891)
+        .client_id("dummy".parse().unwrap())
+        .inflight(10)
+        .build();
 
     let mut eventloop = EventLoop::new(options, 5);
     let requests_tx = eventloop.handle();
@@ -415,7 +436,10 @@ async fn packet_id_collisions_are_detected_and_flow_control_is_applied() {
 //
 #[tokio::test]
 async fn next_poll_after_connect_failure_reconnects() {
-    let options = MqttOptions::new("dummy", "127.0.0.1", 3000);
+    let options = MqttOptions::builder()
+        .port(3000)
+        .client_id("dummy".parse().unwrap())
+        .build();
 
     task::spawn(async move {
         let _broker = Broker::new(3000, 1).await;
@@ -442,8 +466,11 @@ async fn next_poll_after_connect_failure_reconnects() {
 
 #[tokio::test]
 async fn reconnection_resumes_from_the_previous_state() {
-    let mut options = MqttOptions::new("dummy", "127.0.0.1", 3001);
-    options.set_keep_alive(Duration::from_secs(5));
+    let options = MqttOptions::builder()
+        .port(3001)
+        .client_id("dummy".parse().unwrap())
+        .keep_alive(Duration::from_secs(5))
+        .build();
 
     // start sending qos0 publishes. Makes sure that there is out activity but no in activity
     let mut eventloop = EventLoop::new(options, 5);
@@ -483,8 +510,11 @@ async fn reconnection_resumes_from_the_previous_state() {
 
 #[tokio::test]
 async fn reconnection_resends_unacked_packets_from_the_previous_connection_first() {
-    let mut options = MqttOptions::new("dummy", "127.0.0.1", 3002);
-    options.set_keep_alive(Duration::from_secs(5));
+    let options = MqttOptions::builder()
+        .port(3002)
+        .client_id("dummy".parse().unwrap())
+        .keep_alive(Duration::from_secs(5))
+        .build();
 
     // start sending qos0 publishes. this makes sure that there is
     // outgoing activity but no incoming activity


### PR DESCRIPTION
Improvements:
- typed-builder
- ClientId struct
- deprecated old `MqttOptions::new` for easier migration

I dont think its that bad to expose the MqttOptions to the public. The types itself prevent a lot of wrong content (maybe types like NonZeroU16 could improve that even further). I refactored the client id check into `ClientId` so it is checked by itself.

There are still a few open questions.
- I set the `broker_addr` and `port` to `localhost` and `1883`. Especially the port sounds sane to me. Should this be kept?
- It would be nice to have some generator for ClientId. Like `rumqttc-<systemtime>` or so to connect easier to some broker when the client id does not need to be something fix. But this should be a separate PR.
- The content of the options is now completely public. Should be rename some of them now to something better or should we keep them like that?
- `MqttState::new` got the panic which was previously in `MqttOptions::set_inflight`. Personally I think there shouldnt be any panic in a library (only impossible ones like `unreachable!()`). Should we change that behaviour there towards `Result<MqttState, SomeError>` or keep the panic for now?


I am open for feedback here. When only part of the improvements is liked I can create another PR with only that part.