### PR TITLE
add support for MQTT 3.1

### DIFF
--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -333,7 +333,7 @@ async fn mqtt_connect(
     let clean_session = options.clean_session();
     let last_will = options.last_will();
 
-    let mut connect = Connect::new(options.client_id());
+    let mut connect = Connect::new(options.protocol, options.client_id());
     connect.keep_alive = keep_alive;
     connect.clean_session = clean_session;
     connect.last_will = last_will;

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -345,6 +345,8 @@ pub struct MqttOptions {
     /// If set to `true` MQTT acknowledgements are not sent automatically.
     /// Every incoming publish packet must be manually acknowledged with `client.ack(...)` method.
     manual_acks: bool,
+    /// the protocol. Should be `Protocol::V3` or `Protocol::V4`.
+    protocol: Protocol,
 }
 
 impl MqttOptions {
@@ -386,6 +388,7 @@ impl MqttOptions {
             last_will: None,
             conn_timeout: 5,
             manual_acks: false,
+            protocol: Protocol::V4,
         }
     }
 
@@ -549,6 +552,21 @@ impl MqttOptions {
     /// get manual acknowledgements
     pub fn manual_acks(&self) -> bool {
         self.manual_acks
+    }
+
+    /// set the protocol.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `protocol` is not `Protocol::V3` or `Protocol::V4`.
+    pub fn set_protocol(&mut self, protocol: Protocol) {
+        assert!(matches!(protocol, Protocol::V3 | Protocol::V4));
+        self.protocol = protocol;
+    }
+
+    /// get the protocol
+    pub fn protocol(&self) -> Protocol {
+        self.protocol
     }
 }
 

--- a/rumqttc/src/mqttbytes/mod.rs
+++ b/rumqttc/src/mqttbytes/mod.rs
@@ -85,6 +85,7 @@ pub enum PacketType {
 /// Protocol type
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Protocol {
+    V3,
     V4,
     V5,
 }


### PR DESCRIPTION
This pr adds support for MQTT 3.1 to `rumqttc`.

This pr is based on https://www.oasis-open.org/committees/download.php/55095/mqtt-diffs-v1.0-wd01.doc.

This pr introduces a breaking change: https://github.com/bytebeamio/rumqtt/blob/23b23d6997d0e5b0d7ec3d9f4fc79ade6bd9015b/rumqttc/src/mqttbytes/v4/connect.rs#L22