### PR TITLE
Cleanup

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -3,23 +3,22 @@ name = "benchmarks"
 version = "0.4.0"
 authors = ["tekjar <raviteja@bytebeam.io>"]
 edition = "2018"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 argh = "0.1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+async-channel = "1"
+bytes = "1"
+futures = { version = "0.3", features = ["compat"] }
+itoa = "0.4"
+pprof = { version = "0.3", features = ["flamegraph", "protobuf"] }
+pretty_env_logger = "0.4"
+prost = "0.6"
 rumqttc = { path = "../rumqttc" }
 rumqttd = { path = "../rumqttd" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tokio = { version = "1", features = ["full"] }
-futures = { version = "0.3", features = ["compat"] }	
-bytes = "1.0"
-async-channel = "1.4"
-pretty_env_logger = "0.4"
-itoa = "0.4"
-prost = "0.6"
-pprof = { version = "0.3", features = ["flamegraph", "protobuf"] }
 # paho-mqtt = { git = "https://github.com/eclipse/paho.mqtt.rust" }
 # paho-mqtt = "0.7"
 
@@ -29,7 +28,6 @@ jemallocator = "0.3"
 [[bin]]
 name = "rumqttasync"
 path = "clients/rumqttasync.rs"
-
 
 [[bin]]
 name = "rumqttasyncqos0"

--- a/benchmarks/simplerouter/Cargo.toml
+++ b/benchmarks/simplerouter/Cargo.toml
@@ -2,12 +2,11 @@
 name = "simplerouter"
 version = "0.1.0"
 edition = "2021"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytes = "1.1.0"
-log = "0.4.14"
-pretty_env_logger = "0.4.0"
-thiserror = "1.0.30"
-tokio = { version = "1.17.0", features = ["net", "sync", "rt-multi-thread", "io-util", "macros"] }
+bytes = "1"
+log = "0.4"
+pretty_env_logger = "0.4"
+thiserror = "1"
+tokio = { version = "1", features = ["net", "sync", "rt-multi-thread", "io-util", "macros"] }

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -19,28 +19,28 @@ websocket = ["async-tungstenite", "ws_stream_tungstenite"]
 use-rustls = ["tokio-rustls", "rustls-pemfile"]
 
 [dependencies]
-tokio = { version = "1.0", features = ["rt", "macros", "io-util", "net", "time"] }
-bytes = "1.0"
-tokio-rustls = { version = "0.23.2", optional = true }
-rustls-pemfile = { version = "0.3.0", optional = true }
-async-tungstenite = { version = "0.16.1", default-features = false, features = ["tokio-rustls-native-certs"], optional = true }
-ws_stream_tungstenite = { version = "0.7.0", default-features = false, features = ["tokio_io"], optional = true }
-pollster = "0.2"
+async-tungstenite = { version = "0.16", default-features = false, features = ["tokio-rustls-native-certs"], optional = true }
+bytes = "1"
+flume = "0.10"
+http = "0.2"
 log = "0.4"
-thiserror = "1.0.21"
-http = "^0.2"
-url = { version = "2.2", default-features = false, optional = true }
-flume = "0.10.10"
+pollster = "0.2"
+rustls-pemfile = { version = "0.3", optional = true }
+thiserror = "1"
+tokio = { version = "1", features = ["rt", "macros", "io-util", "net", "time"] }
+tokio-rustls = { version = "0.23", optional = true }
+url = { version = "2", default-features = false, optional = true }
+ws_stream_tungstenite = { version = "0.7", default-features = false, features = ["tokio_io"], optional = true }
 
 [dev-dependencies]
-pretty_env_logger = "0.4"
 color-backtrace = "0.4"
 crossbeam-channel = "0.5"
-serde = {version = "1", features = ["derive"]}
 envy = "0.4"
 jsonwebtoken = "7"
-tokio = { version = "1.0", features = ["full", "macros"] }
-matches = "0.1.8"
-rustls = "0.20.2"
-rustls-native-certs = "0.6.1"
-pretty_assertions = "1.1.0"
+matches = "0.1"
+pretty_assertions = "1"
+pretty_env_logger = "0.4"
+rustls = "0.20"
+rustls-native-certs = "0.6"
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["full", "macros"] }

--- a/rumqttc/examples/async_manual_acks.rs
+++ b/rumqttc/examples/async_manual_acks.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     task::spawn(async move {
         // send some messages to example topic and disconnect
         requests(client.clone()).await;
-        client.disconnect().await.unwrap()
+        client.disconnect().await.unwrap();
     });
 
     loop {

--- a/rumqttc/examples/syncpubsub.rs
+++ b/rumqttc/examples/syncpubsub.rs
@@ -23,8 +23,8 @@ fn main() {
 
 fn publish(mut client: Client) {
     client.subscribe("hello/+/world", QoS::AtMostOnce).unwrap();
-    for i in 0..10 {
-        let payload = vec![1; i as usize];
+    for i in 0..10_usize {
+        let payload = vec![1; i];
         let topic = format!("hello/{}/world", i);
         let qos = QoS::AtLeastOnce;
 

--- a/rumqttc/examples/syncpubsub_v5.rs
+++ b/rumqttc/examples/syncpubsub_v5.rs
@@ -23,8 +23,8 @@ fn main() {
 
 fn publish(client: Client) {
     client.subscribe("hello/+/world", QoS::AtMostOnce).unwrap();
-    for i in 0..10 {
-        let payload = vec![1; i as usize];
+    for i in 0..10_usize {
+        let payload = vec![1; i];
         let topic = format!("hello/{}/world", i);
         let qos = QoS::AtLeastOnce;
 

--- a/rumqttc/examples/tls.rs
+++ b/rumqttc/examples/tls.rs
@@ -10,9 +10,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
     color_backtrace::install();
 
-    let mut mqtt_options = MqttOptions::new("test-1", "mqtt.example.server", 8883);
-    mqtt_options.set_keep_alive(std::time::Duration::from_secs(5));
-    mqtt_options.set_credentials("username", "password");
+    let mut mqttoptions = MqttOptions::new("test-1", "mqtt.example.server", 8883);
+    mqttoptions.set_keep_alive(std::time::Duration::from_secs(5));
+    mqttoptions.set_credentials("username", "password");
 
     // Use rustls-native-certs to load root certificates from the operating system.
     let mut root_cert_store = rustls::RootCertStore::empty();
@@ -25,14 +25,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .with_root_certificates(root_cert_store)
         .with_no_client_auth();
 
-    mqtt_options.set_transport(Transport::tls_with_config(client_config.into()));
+    mqttoptions.set_transport(Transport::tls_with_config(client_config.into()));
 
-    let (_client, mut eventloop) = AsyncClient::new(mqtt_options, 10);
+    let (_client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
 
     loop {
         match eventloop.poll().await {
             Ok(Event::Incoming(Incoming::Publish(p))) => {
-                println!("Topic: {}, Payload: {:?}", p.topic, p.payload)
+                println!("Topic: {}, Payload: {:?}", p.topic, p.payload);
             }
             Ok(Event::Incoming(i)) => {
                 println!("Incoming = {:?}", i);

--- a/rumqttc/examples/tls2.rs
+++ b/rumqttc/examples/tls2.rs
@@ -9,8 +9,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
     color_backtrace::install();
 
-    let mut mqtt_options = MqttOptions::new("test-1", "localhost", 8883);
-    mqtt_options.set_keep_alive(std::time::Duration::from_secs(5));
+    let mut mqttoptions = MqttOptions::new("test-1", "localhost", 8883);
+    mqttoptions.set_keep_alive(std::time::Duration::from_secs(5));
 
     // Dummies to prevent compilation error in CI
     let ca = vec![1, 2, 3];
@@ -21,14 +21,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
     //     let client_key = include_bytes!("/home/tekjar/tlsfiles/device-1.key.pem");
 
     let transport = Transport::Tls(TlsConfiguration::Simple {
-        ca: ca.to_vec(),
+        ca,
         alpn: None,
-        client_auth: Some((client_cert.to_vec(), Key::RSA(client_key.to_vec()))),
+        client_auth: Some((client_cert, Key::RSA(client_key))),
     });
 
-    mqtt_options.set_transport(transport);
+    mqttoptions.set_transport(transport);
 
-    let (_client, mut eventloop) = AsyncClient::new(mqtt_options, 10);
+    let (_client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
 
     loop {
         match eventloop.poll().await {

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -3,8 +3,8 @@
 use crate::mqttbytes::{self, v4::*, QoS};
 use crate::{ConnectionError, Event, EventLoop, MqttOptions, Request};
 
-use flume::{SendError, Sender, TrySendError};
 use bytes::Bytes;
+use flume::{SendError, Sender, TrySendError};
 use std::mem;
 use tokio::runtime;
 use tokio::runtime::Runtime;

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -4,11 +4,11 @@ use crate::tls;
 use crate::{Incoming, MqttOptions, MqttState, Outgoing, Packet, Request, StateError, Transport};
 
 use crate::mqttbytes::v4::*;
-use flume::{bounded, Receiver, Sender};
 #[cfg(feature = "websocket")]
 use async_tungstenite::tokio::connect_async;
 #[cfg(all(feature = "use-rustls", feature = "websocket"))]
 use async_tungstenite::tokio::connect_async_with_tls_connector;
+use flume::{bounded, Receiver, Sender};
 use tokio::net::TcpStream;
 #[cfg(unix)]
 use tokio::net::UnixStream;

--- a/rumqttc/src/mqttbytes/v4/publish.rs
+++ b/rumqttc/src/mqttbytes/v4/publish.rs
@@ -37,9 +37,10 @@ impl Publish {
 
     fn len(&self) -> usize {
         let len = 2 + self.topic.len() + self.payload.len();
-        match self.qos != QoS::AtMostOnce && self.pkid != 0 {
-            true => len + 2,
-            _ => len,
+        if self.qos != QoS::AtMostOnce && self.pkid != 0 {
+            len + 2
+        } else {
+            len
         }
     }
 

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -197,7 +197,7 @@ impl MqttState {
             QoS::AtLeastOnce => {
                 if !self.manual_acks {
                     let puback = PubAck::new(publish.pkid);
-                    self.outgoing_puback(puback)?
+                    self.outgoing_puback(puback)?;
                 }
                 Ok(())
             }
@@ -505,7 +505,7 @@ mod test {
     use super::{MqttState, StateError};
     use crate::mqttbytes::v4::*;
     use crate::mqttbytes::*;
-    use crate::{Event, Incoming, MqttOptions, Outgoing, Request};
+    use crate::{Event, Incoming, Outgoing, Request};
 
     fn build_outgoing_publish(qos: QoS) -> Publish {
         let topic = "hello/world".to_owned();
@@ -621,13 +621,13 @@ mod test {
         if let Event::Outgoing(Outgoing::PubAck(pkid)) = mqtt.events[0] {
             assert_eq!(pkid, 2);
         } else {
-            panic!("missing puback")
+            panic!("missing puback");
         }
 
         if let Event::Outgoing(Outgoing::PubRec(pkid)) = mqtt.events[1] {
             assert_eq!(pkid, 3);
         } else {
-            panic!("missing PubRec")
+            panic!("missing PubRec");
         }
     }
 
@@ -773,8 +773,6 @@ mod test {
     #[test]
     fn outgoing_ping_handle_should_throw_errors_for_no_pingresp() {
         let mut mqtt = build_mqttstate();
-        let mut opts = MqttOptions::new("test", "localhost", 1883);
-        opts.set_keep_alive(std::time::Duration::from_secs(10));
         mqtt.outgoing_ping().unwrap();
 
         // network activity other than pingresp
@@ -795,9 +793,6 @@ mod test {
     #[test]
     fn outgoing_ping_handle_should_succeed_if_pingresp_is_received() {
         let mut mqtt = build_mqttstate();
-
-        let mut opts = MqttOptions::new("test", "localhost", 1883);
-        opts.set_keep_alive(std::time::Duration::from_secs(10));
 
         // should ping
         mqtt.outgoing_ping().unwrap();

--- a/rumqttc/src/v5/mod.rs
+++ b/rumqttc/src/v5/mod.rs
@@ -229,7 +229,7 @@ impl MqttOptions {
     pub fn new<S: Into<String>, T: Into<String>>(id: S, host: T, port: u16) -> MqttOptions {
         let id = id.into();
         if id.starts_with(' ') || id.is_empty() {
-            panic!("Invalid client id")
+            panic!("Invalid client id");
         }
 
         MqttOptions {
@@ -362,7 +362,7 @@ impl MqttOptions {
     /// Set number of concurrent in flight messages
     pub fn set_inflight(&mut self, inflight: u16) -> &mut Self {
         if inflight == 0 {
-            panic!("zero in flight is not allowed")
+            panic!("zero in flight is not allowed");
         }
 
         self.inflight = inflight;

--- a/rumqttc/src/v5/packet/connect.rs
+++ b/rumqttc/src/v5/packet/connect.rs
@@ -284,15 +284,15 @@ impl WillProperties {
         }
 
         if let Some(typ) = &self.content_type {
-            len += 1 + 2 + typ.len()
+            len += 1 + 2 + typ.len();
         }
 
         if let Some(topic) = &self.response_topic {
-            len += 1 + 2 + topic.len()
+            len += 1 + 2 + topic.len();
         }
 
         if let Some(data) = &self.correlation_data {
-            len += 1 + 2 + data.len()
+            len += 1 + 2 + data.len();
         }
 
         for (key, value) in self.user_properties.iter() {

--- a/rumqttc/src/v5/packet/publish.rs
+++ b/rumqttc/src/v5/packet/publish.rs
@@ -156,11 +156,11 @@ impl PublishProperties {
         }
 
         if let Some(topic) = &self.response_topic {
-            len += 1 + 2 + topic.len()
+            len += 1 + 2 + topic.len();
         }
 
         if let Some(data) = &self.correlation_data {
-            len += 1 + 2 + data.len()
+            len += 1 + 2 + data.len();
         }
 
         for (key, value) in self.user_properties.iter() {
@@ -172,7 +172,7 @@ impl PublishProperties {
         }
 
         if let Some(typ) = &self.content_type {
-            len += 1 + 2 + typ.len()
+            len += 1 + 2 + typ.len();
         }
 
         len

--- a/rumqttc/src/v5/packet/subscribe.rs
+++ b/rumqttc/src/v5/packet/subscribe.rs
@@ -190,7 +190,7 @@ impl SubscribeProperties {
                     // TODO: Validate 1 +. Tests are working either way
                     cursor += 1 + id_len;
                     bytes.advance(id_len);
-                    id = Some(sub_id)
+                    id = Some(sub_id);
                 }
                 PropertyType::UserProperty => {
                     let key = read_mqtt_string(&mut bytes)?;

--- a/rumqttc/tests/broker.rs
+++ b/rumqttc/tests/broker.rs
@@ -7,8 +7,8 @@ use tokio::net::TcpListener;
 use tokio::select;
 use tokio::{task, time};
 
-use flume::{bounded, Receiver, Sender};
 use bytes::BytesMut;
+use flume::{bounded, Receiver, Sender};
 use rumqttc::{Event, Incoming, Outgoing, Packet};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
@@ -95,7 +95,7 @@ impl Broker {
         time::timeout(Duration::from_secs(30), async {
             let p = self.framed.readb(&mut self.incoming).await;
             // println!("Broker read = {:?}", p);
-            p.unwrap()
+            p.unwrap();
         })
         .await
         .unwrap();
@@ -106,7 +106,7 @@ impl Broker {
     /// Reads next packet from the stream
     pub async fn blackhole(&mut self) -> Packet {
         loop {
-            let _packet = self.framed.readb(&mut self.incoming).await.unwrap();
+            self.framed.readb(&mut self.incoming).await.unwrap();
         }
     }
 

--- a/rumqttc/tests/reliability.rs
+++ b/rumqttc/tests/reliability.rs
@@ -14,7 +14,7 @@ async fn start_requests(count: u8, qos: QoS, delay: u64, requests_tx: Sender<Req
 
         let publish = Publish::new(topic, qos, payload);
         let request = Request::Publish(publish);
-        let _ = requests_tx.send_async(request).await;
+        drop(requests_tx.send_async(request).await);
         time::sleep(Duration::from_secs(delay)).await;
     }
 }
@@ -143,7 +143,7 @@ async fn some_outgoing_and_no_incoming_should_trigger_pings_on_time() {
     loop {
         let event = broker.tick().await;
 
-        if let Event::Incoming(Incoming::PingReq) = event {
+        if event == Event::Incoming(Incoming::PingReq) {
             // wait for 3 pings
             count += 1;
             if count == 3 {
@@ -182,7 +182,7 @@ async fn some_incoming_and_no_outgoing_should_trigger_pings_on_time() {
     loop {
         let event = broker.tick().await;
 
-        if let Event::Incoming(Incoming::PingReq) = event {
+        if event == Event::Incoming(Incoming::PingReq) {
             // wait for 3 pings
             count += 1;
             if count == 3 {

--- a/rumqttd/Cargo.toml
+++ b/rumqttd/Cargo.toml
@@ -20,26 +20,26 @@ use-rustls = ["tokio-rustls"]
 use-native-tls = ["tokio-native-tls"]
 
 [dependencies]
-tokio = { version = "1.0", features = ["full"] }
-serde = { version = "1", features = ["derive"] }
-log = "0.4"
-thiserror = "1"
-argh = "0.1.3"
-confy = "0.4.0"
-pretty_env_logger = "0.4"
-bytes = "1.0"
-warp = "0.3"
-futures-util = "0.3.8"
-rustls-pemfile = "0.3.0"
+argh = "0.1"
+bytes = "1"
+confy = "0.4"
+futures-util = "0.3"
 jackiechan = "0.0.4"
+log = "0.4"
+pretty_env_logger = "0.4"
+rustls-pemfile = "0.3"
 segments = "0.1"
+serde = { version = "1", features = ["derive"] }
+thiserror = "1"
+tokio = { version = "1", features = ["full"] }
+warp = "0.3"
 
 # Optional
-tokio-rustls = { version = "0.23.2", optional = true }
 tokio-native-tls = { version = "0.3", optional = true }
+tokio-rustls = { version = "0.23", optional = true }
 
 [dev-dependencies]
-pretty_assertions = "0.6.1"
+pretty_assertions = "0.6"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = "0.3"

--- a/rumqttd/src/async_locallink.rs
+++ b/rumqttd/src/async_locallink.rs
@@ -175,7 +175,7 @@ pub fn construct_broker(
         async {
             // `ConsoleLink::new` won't terminate until router is running
             let console = ConsoleLink::new(config, router_tx).into();
-            consolelink::start(console).await
+            consolelink::start(console).await;
         }
     };
 

--- a/rumqttd/src/rumqttlog/logs/acks.rs
+++ b/rumqttd/src/rumqttlog/logs/acks.rs
@@ -27,7 +27,7 @@ impl Acks {
     }
 
     pub fn register_pending_acks_request(&mut self) {
-        self.pending_acks_request = Some(())
+        self.pending_acks_request = Some(());
     }
 
     pub fn take_pending_acks_request(&mut self) -> Option<()> {
@@ -45,13 +45,13 @@ impl Acks {
     pub fn push_subscribe_ack(&mut self, pkid: u16, return_codes: Vec<SubscribeReasonCode>) {
         let suback = SubAck::new(pkid, return_codes);
         let suback = Packet::SubAck(suback);
-        self.acks.push(suback)
+        self.acks.push(suback);
     }
 
     pub fn push_unsubscribe_ack(&mut self, pkid: u16) {
         let unsuback = UnsubAck::new(pkid);
         let unsuback = Packet::UnsubAck(unsuback);
-        self.acks.push(unsuback)
+        self.acks.push(unsuback);
     }
 
     /// Returns committed acks by take

--- a/rumqttd/src/rumqttlog/router/readyqueue.rs
+++ b/rumqttd/src/rumqttlog/router/readyqueue.rs
@@ -23,7 +23,7 @@ impl ReadyQueue {
     }
 
     pub fn push_back(&mut self, id: ConnectionId) {
-        self.queue.push_back(id)
+        self.queue.push_back(id);
     }
 
     /// Remove a connection from waiters

--- a/rumqttd/src/state.rs
+++ b/rumqttd/src/state.rs
@@ -158,7 +158,7 @@ impl State {
         while let Some(payload) = self.pending.next() {
             let mut publish = Publish::from_bytes(&self.pending.topic, self.pending.qos, payload);
 
-            if let QoS::AtMostOnce = publish.qos {
+            if publish.qos == QoS::AtMostOnce {
                 debug!("Publish. Qos 0. Payload size = {:?}", publish.payload.len());
                 publish.write(&mut self.write)?;
                 continue;


### PR DESCRIPTION
Listed changes from the commits:

- Cargo.toml dependencies:
  - sorted alphabetically
  - use shorter version identifier with same meaning
- remove unused test variables
- add ; at last statement
- cargo fmt
- same mqttoptions variable name in all examples
- minor things found in #391

This should also simplify the diff of #391 (after merging, this will create merge conflicts)
