### PR TITLE
fix(exports): remove leaky `pub use`

### DIFF
--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -120,8 +120,11 @@ pub use mqttbytes::*;
 pub use state::{MqttState, StateError};
 #[cfg(feature = "use-rustls")]
 pub use tls::Error as TlsError;
+
 #[cfg(feature = "use-rustls")]
-pub use tokio_rustls::rustls::ClientConfig;
+pub use tokio_rustls;
+#[cfg(feature = "use-rustls")]
+use tokio_rustls::rustls::ClientConfig;
 
 pub type Incoming = Packet;
 

--- a/rumqttc/src/v5/mod.rs
+++ b/rumqttc/src/v5/mod.rs
@@ -25,7 +25,9 @@ pub use state::{MqttState, StateError};
 #[cfg(feature = "use-rustls")]
 pub use tls::Error;
 #[cfg(feature = "use-rustls")]
-pub use tokio_rustls::rustls::ClientConfig;
+pub use tokio_rustls;
+#[cfg(feature = "use-rustls")]
+use tokio_rustls::rustls::ClientConfig;
 
 pub type Incoming = Packet;
 


### PR DESCRIPTION
Closes: #426 

This exports are causing `ClientConfig` to be shown as a type coming from `rumqttc` in [docs.rs](https://docs.rs/rumqttc/latest/rumqttc/struct.ClientConfig.html). Uses of this [type](https://docs.rs/rumqttc/latest/src/rumqttc/lib.rs.html#299-304) still expect the correct `tokio_rustls::rustls::ClientConfig` type.

 So this could just be a bug in generating docs still not sure if this is the right way to do it, suggestions welcome. 

re: https://github.com/thin-edge/thin-edge.io/pull/1291