### PR TITLE
feat: `MqttOptions::parse_url` uses `rustls-native-certs::load_native_certs()` for encrypted connections

### DIFF
--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -29,6 +29,7 @@ rustls-pemfile = { version = "0.3", optional = true }
 thiserror = "1"
 tokio = { version = "1", features = ["rt", "macros", "io-util", "net", "time"] }
 tokio-rustls = { version = "=0.23.3", optional = true }
+rustls-native-certs = "0.6"
 url = { version = "2", default-features = false, optional = true }
 ws_stream_tungstenite = { version = "0.7", default-features = false, features = ["tokio_io"], optional = true }
 

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -33,7 +33,7 @@ impl From<TrySendError<Request>> for ClientError {
 /// An asynchronous client, communicates with MQTT `EventLoop`.
 /// 
 /// This is cloneable and can be used to asynchronously [`publish`](`AsyncClient::publish`),
-/// [`subscribe`](`AsynClient::subscribe`) through the `EventLoop`, which is to be polled parallelly.
+/// [`subscribe`](`AsyncClient::subscribe`) through the `EventLoop`, which is to be polled parallelly.
 ///
 /// **NOTE**: The `EventLoop` must be regularly polled in order to send, receive and process packets 
 /// from the broker, i.e. move ahead.
@@ -217,7 +217,7 @@ fn get_ack_req(publish: &Publish) -> Option<Request> {
 /// A synchronous client, communicates with MQTT `EventLoop`.
 ///
 /// This is cloneable and can be used to synchronously [`publish`](`AsyncClient::publish`),
-/// [`subscribe`](`AsynClient::subscribe`) through the `EventLoop`/`Connection`, which is to be polled in parallel
+/// [`subscribe`](`AsyncClient::subscribe`) through the `EventLoop`/`Connection`, which is to be polled in parallel
 /// by iterating over the object returned by [`Connection.iter()`](Connection::iter) in a separate thread.
 ///
 /// **NOTE**: The `EventLoop`/`Connection` must be regularly polled(`.next()` in case of `Connection`) in order 

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -433,10 +433,9 @@ impl MqttOptions {
     /// **NOTE:** A url must be prefixed with one of either `tcp://`, `mqtt://`, `ssl://`,`mqtts://`,
     /// `ws://` or `wss://` to denote the protocol for establishing a connection with the broker.
     ///
-    /// **NOTE:** Though encrypted connections(i.e. `mqtts://`, `ssl://`, `wss://`) are supported, they
-    /// require explicit TLS configuration. This is why we fall back to the unencrypted transport layer,
-    /// so that [`set_transport`](MqttOptions::set_transport) can be used to configure the encrypted
-    /// transport layer with the provided TLS configuration.
+    /// **NOTE:** Encrypted connections(i.e. `mqtts://`, `ssl://`, `wss://`) by default use the
+    /// system's root certificates. To configure with custom certificates, one may use the
+    /// [`set_transport`](MqttOptions::set_transport) method.
     ///
     /// ```
     /// # use rumqttc::{MqttOptions, Transport};

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -399,8 +399,25 @@ impl MqttOptions {
     /// let options = MqttOptions::parse_url("mqtt://example.com:1883?client_id=123").unwrap();
     /// ```
     ///
-    /// NOTE: A url must be prefixed with one of either `tcp://`, `mqtt://`, `ssl://`,`mqtts://`,
+    /// **NOTE:** A url must be prefixed with one of either `tcp://`, `mqtt://`, `ssl://`,`mqtts://`,
     /// `ws://` or `wss://` to denote the protocol for establishing a connection with the broker.
+    ///
+    /// **NOTE:** Though encrypted connections(i.e. `mqtts://`, `ssl://`, `wss://`) are supported, they
+    /// require explicit TLS configuration. This is why we fall back to the unencrypted transport layer,
+    /// so that [`set_transport`](MqttOptions::set_transport) can be used to configure the encrypted
+    /// transport layer with the provided TLS configuration.
+    ///
+    /// ```
+    /// # use rumqttc::{MqttOptions, Transport};
+    /// # use tokio_rustls::rustls::ClientConfig;
+    /// # let root_cert_store = rustls::RootCertStore::empty();
+    /// # let client_config = ClientConfig::builder()
+    /// #    .with_safe_defaults()
+    /// #    .with_root_certificates(root_cert_store)
+    /// #    .with_no_client_auth();
+    /// let mut options = MqttOptions::parse_url("mqtts://example.com?client_id=123").unwrap();
+    /// options.set_transport(Transport::tls_with_config(client_config.into()));
+    /// ```
     pub fn parse_url<S: Into<String>>(url: S) -> Result<MqttOptions, OptionError> {
         use std::convert::TryFrom;
 

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -123,7 +123,7 @@ pub use state::{MqttState, StateError};
 #[cfg(feature = "use-rustls")]
 pub use tls::Error as TlsError;
 #[cfg(feature = "use-rustls")]
-pub use tokio_rustls::rustls::ClientConfig;
+pub use tokio_rustls::rustls::{Certificate, ClientConfig, RootCertStore};
 
 pub type Incoming = Packet;
 
@@ -312,11 +312,9 @@ pub enum TlsConfiguration {
 #[cfg(feature = "use-rustls")]
 impl Default for TlsConfiguration {
     fn default() -> Self {
-        let mut root_cert_store = tokio_rustls::rustls::RootCertStore::empty();
+        let mut root_cert_store = RootCertStore::empty();
         for cert in load_native_certs().expect("could not load platform certs") {
-            root_cert_store
-                .add(&tokio_rustls::rustls::Certificate(cert.0))
-                .unwrap();
+            root_cert_store.add(&Certificate(cert.0)).unwrap();
         }
         let tls_config = ClientConfig::builder()
             .with_safe_defaults()


### PR DESCRIPTION
fixes #435 

## Changelog
- `MqttOptions::parse_url` when passed the url for an encrypted protocol, e.g. `mqtts://`, `ssl://` or `wss://` will from now on use `rustls-native-certs::load_native_certs()` to load the certificates from the native cert store.
- Updated documentation