### PR TITLE
fix: set `rustls-native-certs` dependency as optional

### DIFF
--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -16,7 +16,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = ["use-rustls"]
 websocket = ["async-tungstenite", "ws_stream_tungstenite"]
-use-rustls = ["tokio-rustls", "rustls-pemfile"]
+use-rustls = ["tokio-rustls", "rustls-pemfile", "rustls-native-certs"]
 
 [dependencies]
 async-tungstenite = { version = "0.16", default-features = false, features = ["tokio-rustls-native-certs"], optional = true }
@@ -29,7 +29,7 @@ rustls-pemfile = { version = "0.3", optional = true }
 thiserror = "1"
 tokio = { version = "1", features = ["rt", "macros", "io-util", "net", "time"] }
 tokio-rustls = { version = "=0.23.3", optional = true }
-rustls-native-certs = "0.6"
+rustls-native-certs = { version = "0.6", optional = true }
 url = { version = "2", default-features = false, optional = true }
 ws_stream_tungstenite = { version = "0.7", default-features = false, features = ["tokio_io"], optional = true }
 


### PR DESCRIPTION
`rustls-native-certs` dependency is needed only when `use-rustls` feature is enabled.