### PR TITLE
fix: allow use of `url` feature without `use-rustls`

### DIFF
--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -657,11 +657,12 @@ impl std::convert::TryFrom<url::Url> for MqttOptions {
             // Encrypted connections are supported, but require explicit TLS configuration. We fall
             // back to the unencrypted transport layer, so that `set_transport` can be used to
             // configure the encrypted transport layer with the provided TLS configuration.
+            #[cfg(feature = "use-rustls")]
             "mqtts" | "ssl" => (Transport::tls_with_default_config(), 8883),
             "mqtt" | "tcp" => (Transport::Tcp, 1883),
             #[cfg(feature = "websocket")]
             "ws" => (Transport::Ws, 8000),
-            #[cfg(feature = "websocket")]
+            #[cfg(all(feature = "use-rustls", feature = "websocket"))]
             "wss" => (Transport::wss_with_default_config(), 8000),
             _ => return Err(OptionError::Scheme),
         };

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -6,7 +6,9 @@ use crate::v5::{
 };
 
 #[cfg(feature = "websocket")]
-use async_tungstenite::tokio::{connect_async, connect_async_with_tls_connector};
+use async_tungstenite::tokio::connect_async;
+#[cfg(all(feature = "use-rustls", feature = "websocket"))]
+use async_tungstenite::tokio::connect_async_with_tls_connector;
 use flume::{bounded, Receiver, Sender};
 use tokio::net::TcpStream;
 #[cfg(unix)]
@@ -284,7 +286,7 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
 
             Network::new(WsStream::new(socket), options.max_incoming_packet_size)
         }
-        #[cfg(feature = "websocket")]
+        #[cfg(all(feature = "use-rustls", feature = "websocket"))]
         Transport::Wss(tls_config) => {
             let request = http::Request::builder()
                 .method(http::Method::GET)


### PR DESCRIPTION
Compiling the crate failed when default features were disabled and `url` feature was enabled. That happened due to missing conditinal compilation attributes in URL parsing. This was tested by building `rumqttc` with the following commands:
```sh
cargo build --no-default-features --features=url
cargo build --no-default-features --features=url --features=websocket
```