### PR TITLE
refactor!: unexpose eventloop handle, unexport flume

### DIFF
--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -48,7 +48,7 @@ impl AsyncClient {
     /// `cap` specifies the capacity of the bounded async channel.
     pub fn new(options: MqttOptions, cap: usize) -> (AsyncClient, EventLoop) {
         let eventloop = EventLoop::new(options, cap);
-        let request_tx = eventloop.handle();
+        let request_tx = eventloop.requests_tx.clone();
 
         let client = AsyncClient { request_tx };
 

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -57,15 +57,15 @@ pub struct EventLoop {
     /// Current state of the connection
     pub state: MqttState,
     /// Request stream
-    pub requests_rx: Receiver<Request>,
+    requests_rx: Receiver<Request>,
     /// Requests handle to send requests
-    pub requests_tx: Sender<Request>,
+    pub(crate) requests_tx: Sender<Request>,
     /// Pending packets from last session
     pub pending: IntoIter<Request>,
     /// Network connection to the broker
-    pub(crate) network: Option<Network>,
+    network: Option<Network>,
     /// Keep alive time
-    pub(crate) keepalive_timeout: Option<Pin<Box<Sleep>>>,
+    keepalive_timeout: Option<Pin<Box<Sleep>>>,
 }
 
 /// Events which can be yielded by the event loop
@@ -96,11 +96,6 @@ impl EventLoop {
             network: None,
             keepalive_timeout: None,
         }
-    }
-
-    /// Returns a handle to communicate with this eventloop
-    pub fn handle(&self) -> Sender<Request> {
-        self.requests_tx.clone()
     }
 
     fn clean(&mut self) {

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -114,15 +114,13 @@ pub mod v5;
 
 pub use client::{AsyncClient, Client, ClientError, Connection, Iter};
 pub use eventloop::{ConnectionError, Event, EventLoop};
-pub use flume::{SendError, Sender, TrySendError};
 pub use mqttbytes::v4::*;
 pub use mqttbytes::*;
 #[cfg(feature = "use-rustls")]
-pub use rustls_native_certs::load_native_certs;
+use rustls_native_certs::load_native_certs;
 pub use state::{MqttState, StateError};
 #[cfg(feature = "use-rustls")]
 pub use tls::Error as TlsError;
-
 #[cfg(feature = "use-rustls")]
 pub use tokio_rustls;
 #[cfg(feature = "use-rustls")]


### PR DESCRIPTION
redo #437 

BREAKING CHANGE: don't expose flume types and handles to send `EventLoop` requests

**Why**: `EventLoop::handle` is determined to be best unexposed as a public interface along with other flume types

Rewrite tests with `AsyncClient`

attributes: @henil 