### PR TITLE
GitHub Action improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 on:
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - '**.rs'
       - 'Cargo.*'
@@ -42,12 +42,12 @@ jobs:
         uses: actions-rs/cargo@v1
         env:
           RUSTFLAGS: "-D warnings"
-        # NOTE: benchmarks are limited to compiling only on non windows systems, without any features enabled. 
+        # NOTE: benchmarks are limited to compiling only on non windows systems, without any features enabled.
         if: ${{ matrix.os != 'windows-latest' && matrix.features == '--no-default-features' }}
         with:
           command: clippy
           args: --verbose --all-targets -p benchmarks
-      
+
       - name: Check rumqttc and rumqttd
         uses: actions-rs/cargo@v1
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,12 @@ jobs:
           profile: minimal
           toolchain: stable
 
+      - name: Fetch dependencies
+        uses: actions-rs/cargo@v1
+        with:
+          command: fetch
+          args: --verbose
+
       - name: Check benchmarks
         uses: actions-rs/cargo@v1
         env:
@@ -55,6 +61,13 @@ jobs:
         with:
           command: clippy
           args: --verbose --all-targets ${{ matrix.features }} -p rumqttc -p rumqttd
+
+      - name: Check docs
+        if: ${{ matrix.os != 'windows-latest' }}
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --verbose --no-deps ${{ matrix.features }}
 
         # NOTE: Tests for rumqttc and rumqttd
       - name: Run tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,12 @@ jobs:
           - windows-latest
         features:
           - --no-default-features
+          - --features url
           - --features use-rustls
-          - --no-default-features --features use-native-tls
+          - --features websocket
+          - --no-default-features --features url
+          - --no-default-features --features use-rustls
+          - --no-default-features --features websocket
           - --all-features
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
 on:
   push:
     branches:
-      - master
+      - main
 
-name: master
+name: main
 
 env:
   PROJECT_ID: ${{ secrets.GCE_PROJECT }}
@@ -14,7 +14,7 @@ jobs:
   test:
     name: Source test
     # runs-on: [self-hosted, linux, X64, rumqtt]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -58,7 +58,7 @@ jobs:
     #   run: |-
     #     gcloud --quiet auth configure-docker
 
-    # # Copy rumqttd and config files 
+    # # Copy rumqttd and config files
     # - name: Prepare config and binary
     #   run: |-
     #     cp -r target/release/rumqttd docker/stage/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ name: Publish to crates.io
 jobs:
   publish:
     name: Publish crates
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -17,10 +17,10 @@ jobs:
       - uses: katyo/publish-crates@v1
         name: Publish rumqttc
         with:
-          path: './rumqttc' 
+          path: './rumqttc'
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - uses: katyo/publish-crates@v1
         name: Publish rumqttd
         with:
-          path: './rumqttd' 
+          path: './rumqttd'
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Started with testing the available features on their own. Might find mistakes with wrong `#[cfg(feature = …)]` thingies like #440.

Then I noticed they still run on the old `master` branch name which is now `main`. Also fetch dependencies in its own step to have less mixed up output per step.
Also ensure docs are working. It does not seem to work on windows so I disabled it there.

Additionally I switched from the ubuntu-18.04 image to the latest image as 18.04 is deprecated.