### PR TITLE
fix: ignore doc-test for ci sanity

### DIFF
--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -436,7 +436,7 @@ impl MqttOptions {
     /// system's root certificates. To configure with custom certificates, one may use the
     /// [`set_transport`](MqttOptions::set_transport) method.
     ///
-    /// ```
+    /// ```ignore
     /// # use rumqttc::{MqttOptions, Transport};
     /// # use tokio_rustls::rustls::ClientConfig;
     /// # let root_cert_store = rustls::RootCertStore::empty();


### PR DESCRIPTION
ignore documentation tests that relies on `use-rustls` dependencies