### PR TITLE
fix(mqttbytes): when present wildcard must occupy entire topic level

### DIFF
--- a/rumqttc/src/mqttbytes/topic.rs
+++ b/rumqttc/src/mqttbytes/topic.rs
@@ -26,18 +26,25 @@ pub fn valid_filter(filter: &str) -> bool {
 
     let hirerarchy = filter.split('/').collect::<Vec<&str>>();
     if let Some((last, remaining)) = hirerarchy.split_last() {
-        // # is not allowed in filer except as a last entry
-        // invalid: sport/tennis#/player
-        // invalid: sport/tennis/#/ranking
         for entry in remaining.iter() {
+            // # is not allowed in filter except as a last entry
+            // invalid: sport/tennis#/player
+            // invalid: sport/tennis/#/ranking
             if entry.contains('#') {
+                return false;
+            }
+
+            // + must occupy an entire level of the filter
+            // invalid: sport+
+            if entry.len() > 1 && entry.contains('+') {
                 return false;
             }
         }
 
-        // only single '#" is allowed in last entry
+        // only single '#" or '+' is allowed in last entry
         // invalid: sport/tennis#
-        if last.len() != 1 && last.contains('#') {
+        // invalid: sport/++
+        if last.len() != 1 && (last.contains('#') || last.contains('+')) {
             return false;
         }
     }
@@ -108,6 +115,10 @@ mod test {
         assert!(!super::valid_filter("wrong/wr#ng/filter"));
         assert!(!super::valid_filter("wrong/filter#"));
         assert!(super::valid_filter("correct/filter/#"));
+        assert!(!super::valid_filter("wr/o+/ng"));
+        assert!(!super::valid_filter("wr/+o+/ng"));
+        assert!(!super::valid_filter("wron/+g"));
+        assert!(super::valid_filter("cor/+/rect/+"));
     }
 
     #[test]


### PR DESCRIPTION
Improves validation of filters by checking rule in 4.7.1.3 ('+' must occupy an entire level of the filter).

~~Improves usability by adding a `get_wildcards(topic, filter) -> Option(Vec<&str>)` function that returns `None` if the topic doesn't match the filter, and otherwise returns `Some(v)` where v contains the fragments of the topic corresponding to filter wildcards.~~ removed as requested.