### PR TITLE
fix: export enum `TryRecvError`

### DIFF
--- a/rumqttc/src/v5/mod.rs
+++ b/rumqttc/src/v5/mod.rs
@@ -19,7 +19,7 @@ mod tls;
 pub use client::{AsyncClient, Client, ClientError, Connection, Iter};
 pub use eventloop::{ConnectionError, EventLoop};
 pub use flume::{SendError, Sender, TrySendError};
-pub use notifier::Notifier;
+pub use notifier::{Notifier, TryRecvError};
 pub use packet::*;
 pub use state::{MqttState, StateError};
 #[cfg(feature = "use-rustls")]

--- a/rumqttc/src/v5/notifier.rs
+++ b/rumqttc/src/v5/notifier.rs
@@ -8,11 +8,19 @@ use crate::v5::Incoming;
 #[derive(Debug, Eq, PartialEq)]
 pub enum TryRecvError {
     /// [`EventLoop`] is disconnected from broker
+    ///
+    /// [`EventLoop`]: super::EventLoop
     Disconnected,
     /// [`EventLoop`] is connected to broker
+    ///
+    /// [`EventLoop`]: super::EventLoop
     Waiting,
 }
 
+/// Interface to receive incoming [`Packet`]s from the [`EventLoop`]
+///
+/// [`Packet`]: super::Packet
+/// [`EventLoop`]: super::EventLoop
 #[derive(Debug)]
 pub struct Notifier {
     incoming_buf: Arc<Mutex<VecDeque<Incoming>>>,


### PR DESCRIPTION
Fixes #456

Enable use of `TryRecvError` variants