### PR TITLE
feat: Implement `recv` `try_recv` `recv_timeout` for `Connection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,23 @@
 ### Unreleased
 ---
 rumqttc
+-------
+- Implement `recv`, `try_recv`, `recv_timeout` for `Connection` (#458)
+
+rumqttd
+-------
+- Make dependency on `rustls-pemfile` optional (#439)
+-----------
+
+### R16
+---
+
+rumqttc v0.16.0
 ---
 - Remove `Eventloop::handle`, and stop re-exporting `flume` constructs (#441)
 - Unchain features `url` and `url-rustls` (#440)
 - Make dependency on `rustls-native-certs` optional (#438)
 -----------
-
-rumqttd
----
-- Make dependency on `rustls-pemfile` optional (#439)
 
 ### R15
 ---

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2389,6 +2389,7 @@ dependencies = [
  "crossbeam-channel",
  "envy",
  "flume",
+ "futures 0.3.24",
  "http",
  "jsonwebtoken",
  "log",

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -22,6 +22,7 @@ use-rustls = ["tokio-rustls", "rustls-pemfile", "rustls-native-certs"]
 async-tungstenite = { version = "0.16", default-features = false, features = ["tokio-rustls-native-certs"], optional = true }
 bytes = "1"
 flume = "0.10"
+futures = "0.3"
 http = "0.2"
 log = "0.4"
 pollster = "0.2"

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -1,13 +1,15 @@
 //! This module offers a high level synchronous and asynchronous abstraction to
 //! async eventloop.
+use std::time::Duration;
+
 use crate::mqttbytes::{v4::*, QoS};
 use crate::{valid_topic, ConnectionError, Event, EventLoop, MqttOptions, Request};
 
 use bytes::Bytes;
 use flume::{SendError, Sender, TrySendError};
-
-use tokio::runtime;
-use tokio::runtime::Runtime;
+use futures::FutureExt;
+use tokio::runtime::{self, Runtime};
+use tokio::time::timeout;
 
 /// Client Error
 #[derive(Debug, thiserror::Error)]
@@ -352,6 +354,28 @@ impl Client {
     }
 }
 
+/// Error type returned by [`Connection::recv`]
+#[derive(Debug, Eq, PartialEq)]
+pub struct RecvError;
+
+/// Error type returned by [`Connection::try_recv`]
+#[derive(Debug, Eq, PartialEq)]
+pub enum TryRecvError {
+    /// User has closed requests channel
+    Disconnected,
+    /// Did not resolve
+    Empty,
+}
+
+/// Error type returned by [`Connection::recv_timeout`]
+#[derive(Debug, Eq, PartialEq)]
+pub enum RecvTimeoutError {
+    /// User has closed requests channel
+    Disconnected,
+    /// Recv request timedout
+    Timeout,
+}
+
 ///  MQTT connection. Maintains all the necessary state
 pub struct Connection {
     pub eventloop: EventLoop,
@@ -372,6 +396,51 @@ impl Connection {
     pub fn iter(&mut self) -> Iter<'_> {
         Iter { connection: self }
     }
+
+    /// Attempt to fetch an incoming [`Event`] on the [`EvenLoop`], returning an error
+    /// if all clients/users have closed requests channel.
+    pub fn recv(&mut self) -> Result<Result<Event, ConnectionError>, RecvError> {
+        let f = self.eventloop.poll();
+        let event = self.runtime.block_on(f);
+
+        resolve_event(event).ok_or(RecvError)
+    }
+
+    /// Attempt to fetch an incoming [`Event`] on the [`EvenLoop`], returning an error
+    /// if none immediately present or all clients/users have closed requests channel.
+    pub fn try_recv(&mut self) -> Result<Result<Event, ConnectionError>, TryRecvError> {
+        let f = self.eventloop.poll();
+        let event = f.now_or_never().ok_or(TryRecvError::Empty)?;
+
+        resolve_event(event).ok_or(TryRecvError::Disconnected)
+    }
+
+    /// Attempt to fetch an incoming [`Event`] on the [`EvenLoop`], returning an error
+    /// if all clients/users have closed requests channel or the timeout has expired.
+    pub fn recv_timeout(
+        &mut self,
+        duration: Duration,
+    ) -> Result<Result<Event, ConnectionError>, RecvTimeoutError> {
+        let f = timeout(duration, self.eventloop.poll());
+        let event = self
+            .runtime
+            .block_on(f)
+            .map_err(|_| RecvTimeoutError::Timeout)?;
+
+        resolve_event(event).ok_or(RecvTimeoutError::Disconnected)
+    }
+}
+
+fn resolve_event(event: Result<Event, ConnectionError>) -> Option<Result<Event, ConnectionError>> {
+    match event {
+        Ok(v) => Some(Ok(v)),
+        // closing of request channel should stop the iterator
+        Err(ConnectionError::RequestsDone) => {
+            trace!("Done with requests");
+            None
+        }
+        Err(e) => Some(Err(e)),
+    }
 }
 
 /// Iterator which polls the `EventLoop` for connection progress
@@ -383,17 +452,7 @@ impl Iterator for Iter<'_> {
     type Item = Result<Event, ConnectionError>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let f = self.connection.eventloop.poll();
-        let r = &self.connection.runtime;
-        match r.block_on(f) {
-            Ok(v) => Some(Ok(v)),
-            // closing of request channel should stop the iterator
-            Err(ConnectionError::RequestsDone) => {
-                trace!("Done with requests");
-                None
-            }
-            Err(e) => Some(Err(e)),
-        }
+        self.connection.recv().ok()
     }
 }
 

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -399,6 +399,8 @@ impl Connection {
 
     /// Attempt to fetch an incoming [`Event`] on the [`EvenLoop`], returning an error
     /// if all clients/users have closed requests channel.
+    /// 
+    /// [`EvenLoop`]: super::EventLoop
     pub fn recv(&mut self) -> Result<Result<Event, ConnectionError>, RecvError> {
         let f = self.eventloop.poll();
         let event = self.runtime.block_on(f);
@@ -408,6 +410,8 @@ impl Connection {
 
     /// Attempt to fetch an incoming [`Event`] on the [`EvenLoop`], returning an error
     /// if none immediately present or all clients/users have closed requests channel.
+    /// 
+    /// [`EvenLoop`]: super::EventLoop
     pub fn try_recv(&mut self) -> Result<Result<Event, ConnectionError>, TryRecvError> {
         let f = self.eventloop.poll();
         let event = f.now_or_never().ok_or(TryRecvError::Empty)?;
@@ -417,6 +421,8 @@ impl Connection {
 
     /// Attempt to fetch an incoming [`Event`] on the [`EvenLoop`], returning an error
     /// if all clients/users have closed requests channel or the timeout has expired.
+    /// 
+    /// [`EvenLoop`]: super::EventLoop
     pub fn recv_timeout(
         &mut self,
         duration: Duration,


### PR DESCRIPTION
Continued from discussion on #430

Implement `recv` `try_recv` `recv_timeout` for `Connection` similar to `v5::Notifier::try_recv`

CC @sirver