### PR TITLE
Forward TLS implementation selection to reqwest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,6 +1029,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1979,6 +1992,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1988,16 +2002,20 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pemfile 1.0.1",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -3133,6 +3151,15 @@ checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/rumqttd/Cargo.toml
+++ b/rumqttd/Cargo.toml
@@ -29,15 +29,15 @@ rouille = "3.1.1"
 # x509-parser = {version= "0.9.2", optional = true}
 futures-util = "0.3.16"
 parking_lot = "0.11.2"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", features = ["json"], default-features = false }
 config = "0.13"
 simplelog = "0.12.0"
 structopt = "0.3.26"
 
 [features]
 default = ["use-rustls"]
-use-rustls = ["tokio-rustls", "rustls-pemfile"] #, "x509-parser"]
-use-native-tls = ["tokio-native-tls"] #, "x509-parser"]
+use-rustls = ["tokio-rustls", "rustls-pemfile", "reqwest/rustls-tls"] #, "x509-parser"]
+use-native-tls = ["tokio-native-tls", "reqwest/native-tls"] #, "x509-parser"]
 websockets = ["tokio-tungstenite", "ws_stream_tungstenite", "websocket-codec"]
 
 [dev-dependencies]


### PR DESCRIPTION
The TLS implementation is selected by either feature `use-rustls` or `use-native-tls`. The selection of the TLS implementation is forwarded to the `request` dependency which otherwise defaults to `native-tls`.