### PR TITLE
fix: remove unused and feature gate websocket dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,19 +163,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-tungstenite"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b71b31561643aa8e7df3effe284fa83ab1a840e52294c5f4bd7bfd8b2becbb"
-dependencies = [
- "futures-io",
- "futures-util",
- "log",
- "pin-project-lite",
- "tungstenite 0.17.3",
-]
-
-[[package]]
 name = "async_io_stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,15 +575,6 @@ name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
-dependencies = [
- "cfg-if 1.0.0",
-]
 
 [[package]]
 name = "enum-iterator"
@@ -1029,32 +1007,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
-dependencies = [
- "http",
- "hyper",
- "rustls",
- "tokio",
- "tokio-rustls",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,12 +1065,6 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
 ]
-
-[[package]]
-name = "ipnet"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "itertools"
@@ -1978,48 +1924,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.11.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
-dependencies = [
- "base64",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-rustls",
- "hyper-tls",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls",
- "rustls-pemfile 1.0.1",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "tokio-native-tls",
- "tokio-rustls",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
- "winreg",
-]
-
-[[package]]
 name = "rgb"
 version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2083,7 +1987,7 @@ dependencies = [
 name = "rumqttc"
 version = "0.17.0"
 dependencies = [
- "async-tungstenite 0.16.1",
+ "async-tungstenite",
  "bytes",
  "color-backtrace",
  "flume",
@@ -2102,7 +2006,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "url",
- "ws_stream_tungstenite 0.7.0",
+ "ws_stream_tungstenite",
 ]
 
 [[package]]
@@ -2118,7 +2022,6 @@ dependencies = [
  "parking_lot 0.11.2",
  "pretty_assertions 1.3.0",
  "pretty_env_logger",
- "reqwest",
  "rouille",
  "rustls-pemfile 0.3.0",
  "serde",
@@ -2134,7 +2037,6 @@ dependencies = [
  "tokio-util",
  "vergen",
  "websocket-codec",
- "ws_stream_tungstenite 0.8.0",
 ]
 
 [[package]]
@@ -3093,18 +2995,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
-dependencies = [
- "cfg-if 1.0.0",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3151,15 +3041,6 @@ checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.22.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
-dependencies = [
- "webpki",
 ]
 
 [[package]]
@@ -3263,21 +3144,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
-name = "winreg"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "ws_stream_tungstenite"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a672ec78525bf189cefa7f1b72c55f928b3edbdb967e680ca49748ab20821045"
 dependencies = [
- "async-tungstenite 0.16.1",
+ "async-tungstenite",
  "async_io_stream",
  "bitflags",
  "futures-core",
@@ -3289,25 +3161,6 @@ dependencies = [
  "rustc_version",
  "tokio",
  "tungstenite 0.16.0",
-]
-
-[[package]]
-name = "ws_stream_tungstenite"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ece1fc9cd67a4e6edc845d350391fe5d115ff716aeec145be927fa2dab44b3"
-dependencies = [
- "async-tungstenite 0.17.2",
- "async_io_stream",
- "bitflags",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-util",
- "log",
- "pharos",
- "rustc_version",
- "tungstenite 0.17.3",
 ]
 
 [[package]]

--- a/rumqttd/Cargo.toml
+++ b/rumqttd/Cargo.toml
@@ -23,7 +23,6 @@ tokio-rustls =  { version = "0.23.0", optional = true }
 tokio-native-tls = { version = "0.3", optional = true }
 rustls-pemfile = { version = "0.3.0", optional = true }
 tokio-tungstenite = { version = "0.15.0", optional = true }
-ws_stream_tungstenite = { version = "0.8", optional = true }
 websocket-codec = { version = "0.5.1", optional = true }
 rouille = "3.1.1"
 # x509-parser = {version= "0.9.2", optional = true}
@@ -37,7 +36,7 @@ structopt = "0.3.26"
 default = ["use-rustls"]
 use-rustls = ["tokio-rustls", "rustls-pemfile"] #, "x509-parser"]
 use-native-tls = ["tokio-native-tls"] #, "x509-parser"]
-websockets = ["tokio-tungstenite", "ws_stream_tungstenite", "websocket-codec"]
+websockets = ["tokio-tungstenite", "websocket-codec"]
 
 [dev-dependencies]
 pretty_env_logger = "0.4.0"

--- a/rumqttd/Cargo.toml
+++ b/rumqttd/Cargo.toml
@@ -18,7 +18,7 @@ flume = "0.10.9"
 slab = "0.4.3"
 log = "0.4.14"
 thiserror = "1.0.24"
-tokio-util = { version = "0.7", features = ["codec"] }
+tokio-util = { version = "0.7", features = ["codec"], optional = true }
 tokio-rustls =  { version = "0.23.0", optional = true }
 tokio-native-tls = { version = "0.3", optional = true }
 rustls-pemfile = { version = "0.3.0", optional = true }
@@ -26,7 +26,7 @@ tokio-tungstenite = { version = "0.15.0", optional = true }
 websocket-codec = { version = "0.5.1", optional = true }
 rouille = "3.1.1"
 # x509-parser = {version= "0.9.2", optional = true}
-futures-util = "0.3.16"
+futures-util = { version = "0.3.16", optional = true}
 parking_lot = "0.11.2"
 config = "0.13"
 simplelog = "0.12.0"
@@ -36,7 +36,7 @@ structopt = "0.3.26"
 default = ["use-rustls"]
 use-rustls = ["tokio-rustls", "rustls-pemfile"] #, "x509-parser"]
 use-native-tls = ["tokio-native-tls"] #, "x509-parser"]
-websockets = ["tokio-tungstenite", "websocket-codec"]
+websockets = ["tokio-tungstenite", "websocket-codec", "tokio-util", "futures-util"]
 
 [dev-dependencies]
 pretty_env_logger = "0.4.0"

--- a/rumqttd/Cargo.toml
+++ b/rumqttd/Cargo.toml
@@ -29,15 +29,14 @@ rouille = "3.1.1"
 # x509-parser = {version= "0.9.2", optional = true}
 futures-util = "0.3.16"
 parking_lot = "0.11.2"
-reqwest = { version = "0.11", features = ["json"], default-features = false }
 config = "0.13"
 simplelog = "0.12.0"
 structopt = "0.3.26"
 
 [features]
 default = ["use-rustls"]
-use-rustls = ["tokio-rustls", "rustls-pemfile", "reqwest/rustls-tls"] #, "x509-parser"]
-use-native-tls = ["tokio-native-tls", "reqwest/native-tls"] #, "x509-parser"]
+use-rustls = ["tokio-rustls", "rustls-pemfile"] #, "x509-parser"]
+use-native-tls = ["tokio-native-tls"] #, "x509-parser"]
 websockets = ["tokio-tungstenite", "ws_stream_tungstenite", "websocket-codec"]
 
 [dev-dependencies]

--- a/rumqttd/src/link/shadow.rs
+++ b/rumqttd/src/link/shadow.rs
@@ -40,8 +40,6 @@ pub enum Error {
     Ws(#[from] tungstenite::Error),
     #[error("Json error = {0}")]
     Json(#[from] serde_json::Error),
-    #[error("Reqwest Error = {0}")]
-    Reqwest(#[from] reqwest::Error),
     #[error("Shadow filter not set properly")]
     InvalidFilter,
 }


### PR DESCRIPTION
Continues #488 

rumqttd doesn't depend on `reqwest`/`ws_stream_tungstenite` anymore.

Feature gate dependency on `tokio-util` and `futures-util` to `websockets` builds only