### PR TITLE
fix Tracker: fix unregister_data_requests in Tracker to properly filter

### DIFF
--- a/rumqttd/src/router/scheduler.rs
+++ b/rumqttd/src/router/scheduler.rs
@@ -196,15 +196,8 @@ impl Tracker {
     }
 
     pub fn unregister_data_request(&mut self, filter: Filter) {
-        let mut idxs = Vec::<usize>::new();
-        for (i, data_req) in self.data_requests.iter().enumerate() {
-            if data_req.filter == filter {
-                idxs.push(i);
-            }
-        }
-        for idx in idxs {
-            self.data_requests.remove(idx);
-        }
+        self.data_requests
+            .retain(|data_req| data_req.filter != filter);
     }
 }
 


### PR DESCRIPTION
Initially, we were finding out indexes of elements which we want to remove, and then we will remove it by 
```rust
// ....
for idx in idxs {
    self.data_requests.remove(idx);
}
```

The problem with this approach is, when we call `remove(idx)`, it shifts other elements too. Thus indexes of other elements which we want to remove get changed. And due to this, we end up filtering wrong elemets.

To fix this, we can use [retain](https://doc.rust-lang.org/std/collections/struct.VecDeque.html#method.retain) method to retain only those elements which does not match our filter, which is what we intend to do.

```rust
self.data_requests.retain(|data_req| data_req.filter != filter);
```