### PR TITLE
fix: allow subscription to `test` topics

### DIFF
--- a/rumqttd/src/router/routing.rs
+++ b/rumqttd/src/router/routing.rs
@@ -1178,7 +1178,7 @@ fn validate_subscription(
         return Err(RouterError::UnsupportedQoS(filter.qos));
     }
 
-    if filter.path.starts_with("test") || filter.path.starts_with('$') {
+    if filter.path.starts_with('$') {
         return Err(RouterError::InvalidFilterPrefix(filter.path.to_owned()));
     }
 


### PR DESCRIPTION
We don't allow subscription on `$` topics yet, so might as well use those for test.

fixes: #479 