### PR TITLE
fix: enter runtime context for `now_or_never()` within `try_recv`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 ### Unreleased
-
+---
+rumqttc
+-------
+- Fixed panicking in `recv_timeout` and `try_recv` by entering tokio runtime context (#492, #497)
 - Removed unused dependencies and updated version of some of used libraries to fix dependabots warning (#475)
-- (rumqttd) Added properties field to `Unsubscribe`, `UnsubAck`, and `Disconnect` packets so its consistent with other packets. (#480)
-- (rumqttd) Changed default segment size in demo config to 100MB (#484)
-- (rumqttc) Fixed panicking of `timeout` in `recv_timeout` by entering tokio runtime context (#492)
-- (rumqttd) Allow subscription on topic's starting with `test` (#494)
+
+rumqttd
+-------
+- Added properties field to `Unsubscribe`, `UnsubAck`, and `Disconnect` packets so its consistent with other packets. (#480)
+- Changed default segment size in demo config to 100MB (#484)
+- Allow subscription on topic's starting with `test` (#494)
+-----------
 
 ### R17
 ---

--- a/rumqttc/examples/syncrecv.rs
+++ b/rumqttc/examples/syncrecv.rs
@@ -1,0 +1,41 @@
+use rumqttc::{self, Client, LastWill, MqttOptions, QoS};
+use std::thread;
+use std::time::Duration;
+
+fn main() {
+    pretty_env_logger::init();
+
+    let mut mqttoptions = MqttOptions::new("test-1", "localhost", 1883);
+    let will = LastWill::new("hello/world", "good bye", QoS::AtMostOnce, false);
+    mqttoptions
+        .set_keep_alive(Duration::from_secs(5))
+        .set_last_will(will);
+
+    let (client, mut connection) = Client::new(mqttoptions, 10);
+    thread::spawn(move || publish(client));
+
+    if let Ok(notification) = connection.recv() {
+        println!("Notification = {:?}", notification);
+    }
+
+    if let Ok(notification) = connection.try_recv() {
+        println!("Notification = {:?}", notification);
+    }
+
+    if let Ok(notification) = connection.recv_timeout(Duration::from_secs(10)) {
+        println!("Notification = {:?}", notification);
+    }
+}
+
+fn publish(mut client: Client) {
+    client.subscribe("hello/+/world", QoS::AtMostOnce).unwrap();
+    for i in 0..3 {
+        let payload = vec![1; i];
+        let topic = format!("hello/{}/world", i);
+        let qos = QoS::AtLeastOnce;
+
+        client.publish(topic, qos, true, payload).unwrap();
+    }
+
+    thread::sleep(Duration::from_secs(1));
+}

--- a/rumqttc/examples/syncrecv_v5.rs
+++ b/rumqttc/examples/syncrecv_v5.rs
@@ -1,0 +1,42 @@
+use rumqttc::v5::mqttbytes::{LastWill, QoS};
+use rumqttc::v5::{Client, MqttOptions};
+use std::thread;
+use std::time::Duration;
+
+fn main() {
+    pretty_env_logger::init();
+
+    let mut mqttoptions = MqttOptions::new("test-1", "localhost", 1883);
+    let will = LastWill::new("hello/world", "good bye", QoS::AtMostOnce, false);
+    mqttoptions
+        .set_keep_alive(Duration::from_secs(5))
+        .set_last_will(will);
+
+    let (client, mut connection) = Client::new(mqttoptions, 10);
+    thread::spawn(move || publish(client));
+
+    if let Ok(notification) = connection.recv() {
+        println!("Notification = {:?}", notification);
+    }
+
+    if let Ok(notification) = connection.try_recv() {
+        println!("Notification = {:?}", notification);
+    }
+
+    if let Ok(notification) = connection.recv_timeout(Duration::from_secs(10)) {
+        println!("Notification = {:?}", notification);
+    }
+}
+
+fn publish(client: Client) {
+    client.subscribe("hello/+/world", QoS::AtMostOnce).unwrap();
+    for i in 0..3 {
+        let payload = vec![1; i];
+        let topic = format!("hello/{}/world", i);
+        let qos = QoS::AtLeastOnce;
+
+        client.publish(topic, qos, true, payload).unwrap();
+    }
+
+    thread::sleep(Duration::from_secs(1));
+}

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -414,6 +414,9 @@ impl Connection {
     /// [`EvenLoop`]: super::EventLoop
     pub fn try_recv(&mut self) -> Result<Result<Event, ConnectionError>, TryRecvError> {
         let f = self.eventloop.poll();
+        // Enters the runtime context so we can poll the future, as required by `now_or_never()`.
+        // ref: https://docs.rs/tokio/latest/tokio/runtime/struct.Runtime.html#method.enter
+        let _guard = self.runtime.enter();
         let event = f.now_or_never().ok_or(TryRecvError::Empty)?;
 
         resolve_event(event).ok_or(TryRecvError::Disconnected)

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -430,13 +430,10 @@ impl Connection {
         &mut self,
         duration: Duration,
     ) -> Result<Result<Event, ConnectionError>, RecvTimeoutError> {
-        // Enter the runtime so we can use Sleep, which is required by timeout.
-        // ref: https://docs.rs/tokio/latest/tokio/runtime/struct.Runtime.html#method.enter
-        let _guard = self.runtime.enter();
-        let f = timeout(duration, self.eventloop.poll());
+        let f = self.eventloop.poll();
         let event = self
             .runtime
-            .block_on(f)
+            .block_on(async { timeout(duration, f).await })
             .map_err(|_| RecvTimeoutError::Timeout)?;
 
         resolve_event(event).ok_or(RecvTimeoutError::Disconnected)

--- a/rumqttc/src/v5/client.rs
+++ b/rumqttc/src/v5/client.rs
@@ -417,6 +417,9 @@ impl Connection {
     /// [`EvenLoop`]: super::EventLoop
     pub fn try_recv(&mut self) -> Result<Result<Event, ConnectionError>, TryRecvError> {
         let f = self.eventloop.poll();
+        // Enters the runtime context so we can poll the future, as required by `now_or_never()`.
+        // ref: https://docs.rs/tokio/latest/tokio/runtime/struct.Runtime.html#method.enter
+        let _guard = self.runtime.enter();
         let event = f.now_or_never().ok_or(TryRecvError::Empty)?;
 
         resolve_event(event).ok_or(TryRecvError::Disconnected)


### PR DESCRIPTION
Closes #496 

Enter the runtime context within `Connection::try_recv()` in order to allow the creation and passing of a noop waker for the instantaneous polling of associated future.