### PR TITLE
chore(rumqttd): Make tracing events human-readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ rumqttc
 
 rumqttd
 -------
-- Add `tracing` for structured, context-aware logging (#499)
+- Add `tracing` for structured, context-aware logging (#499, #503)
 - Added properties field to `Unsubscribe`, `UnsubAck`, and `Disconnect` packets so its consistent with other packets. (#480)
 - Changed default segment size in demo config to 100MB (#484)
 - Allow subscription on topic's starting with `test` (#494)

--- a/rumqttd/src/link/console.rs
+++ b/rumqttd/src/link/console.rs
@@ -4,7 +4,9 @@ use crate::{ConnectionId, ConsoleSettings};
 use flume::Sender;
 use rouille::{router, try_or_400};
 use std::sync::Arc;
+use tracing::info;
 
+#[derive(Debug)]
 pub struct ConsoleLink {
     config: ConsoleSettings,
     connection_id: ConnectionId,
@@ -28,6 +30,7 @@ impl ConsoleLink {
     }
 }
 
+#[tracing::instrument]
 pub fn start(console: Arc<ConsoleLink>) {
     let address = console.config.listen.clone();
 
@@ -102,6 +105,7 @@ pub fn start(console: Arc<ConsoleLink>) {
                 rouille::Response::json(&v)
            },
            (POST) (/logs) => {
+            info!("Reloading tracing filter");
             let data = try_or_400!(rouille::input::plain_text_body(request));
             if let Some(handle) = &console.config.filter_handle {
                 if handle.reload(&data).is_err() {

--- a/rumqttd/src/link/local.rs
+++ b/rumqttd/src/link/local.rs
@@ -287,6 +287,7 @@ impl LinkTx {
     }
 }
 
+#[derive(Debug)]
 pub struct LinkRx {
     connection_id: ConnectionId,
     router_tx: Sender<(ConnectionId, Event)>,

--- a/rumqttd/src/link/remote.rs
+++ b/rumqttd/src/link/remote.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::error::Elapsed;
 use tokio::{select, time};
-use tracing::debug;
+use tracing::trace;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -129,7 +129,7 @@ impl<P: Protocol> RemoteLink<P> {
                         buffer.len()
                     };
 
-                    debug!("Packets read from network for connection id {}, count = {}", self.connection_id, len);
+                    trace!("Packets read from network, count = {}", len);
                     self.link_tx.notify().await?;
                 }
                 // Receive from router when previous when state isn't in collision

--- a/rumqttd/src/link/remote.rs
+++ b/rumqttd/src/link/remote.rs
@@ -129,7 +129,7 @@ impl<P: Protocol> RemoteLink<P> {
                         buffer.len()
                     };
 
-                    debug!(buffercount=len, "packets");
+                    debug!("Packets read from network for connection id {}, count = {}", self.connection_id, len);
                     self.link_tx.notify().await?;
                 }
                 // Receive from router when previous when state isn't in collision

--- a/rumqttd/src/router/iobufs.rs
+++ b/rumqttd/src/router/iobufs.rs
@@ -2,7 +2,7 @@ use std::{collections::VecDeque, sync::Arc, time::Instant};
 
 use flume::{Receiver, Sender};
 use parking_lot::Mutex;
-use tracing::error;
+use tracing::{error, warn};
 
 use crate::{
     protocol::Packet,
@@ -146,7 +146,10 @@ impl Outgoing {
         let inflight_count = self.inflight_buffer.len();
 
         if inflight_count > MAX_INFLIGHT {
-            error!(inflight_count, MAX_INFLIGHT);
+            warn!(
+                "More inflight publishes than max allowed, inflight count = {}, max allowed = {}",
+                inflight_count, MAX_INFLIGHT
+            );
         }
 
         (buffer_count, inflight_count)

--- a/rumqttd/src/router/logs.rs
+++ b/rumqttd/src/router/logs.rs
@@ -159,6 +159,10 @@ impl DataLog {
         // reads will definitely happen on a valid filter.
         let data = self.native.get(filter_idx).unwrap();
         let mut o = Vec::new();
+        // TODO: `readv` is infallible but its current return type does not
+        // reflect that. Consequently, this method is also infallible.
+        // Encoding this information is important so that calling function
+        // has more information on how this method behaves.
         let next = data.log.readv(offset, len, &mut o)?;
         Ok((next, o))
     }

--- a/rumqttd/src/router/routing.rs
+++ b/rumqttd/src/router/routing.rs
@@ -198,8 +198,9 @@ impl Router {
     }
 
     fn events(&mut self, id: ConnectionId, data: Event) {
-        let span = tracing::info_span!("event", id);
+        let span = tracing::info_span!("[>] incoming", connection_id = id);
         let _guard = span.enter();
+
         match data {
             Event::Connect {
                 connection,
@@ -224,7 +225,7 @@ impl Router {
     ) {
         let client_id = outgoing.client_id.clone();
 
-        let span = tracing::info_span!("handle_new_conn", client_id);
+        let span = tracing::info_span!("incoming_connect", client_id);
         let _guard = span.enter();
 
         if self.connections.len() >= self.config.max_connections {
@@ -268,7 +269,7 @@ impl Router {
         assert_eq!(self.obufs.insert(outgoing), connection_id);
 
         self.connection_map.insert(client_id.clone(), connection_id);
-        info!(connection_id, "connect");
+        info!(connection_id, "Client connection registered");
 
         assert_eq!(self.ackslog.insert(ackslog), connection_id);
         assert_eq!(self.scheduler.add(tracker), connection_id);
@@ -299,13 +300,14 @@ impl Router {
             }
         };
 
-        let span = tracing::info_span!("handle_disconnection", client_id, id);
+        let span = tracing::info_span!("incoming_disconnect", client_id);
         let _guard = span.enter();
+
         if execute_last_will {
             self.handle_last_will(id);
         }
 
-        info!("disconnect");
+        info!("Disconnecting connection id {}", id);
 
         // Remove connection from router
         let mut connection = self.connections.remove(id);
@@ -367,8 +369,9 @@ impl Router {
         };
 
         let client_id = incoming.client_id.clone();
-        let span = tracing::info_span!("handle_payload", client_id, id);
+        let span = tracing::info_span!("incoming_payload", client_id);
         let _guard = span.enter();
+
         // Instead of exchanging, we should just append new incoming packets inside cache
         let mut packets = incoming.exchange(self.cache.take().unwrap());
 
@@ -382,10 +385,9 @@ impl Router {
         for packet in packets.drain(0..) {
             match packet {
                 Packet::Publish(publish, _) => {
-                    trace!(
-                        topic=?publish.topic,
-                        "publish"
-                    );
+                    let span =
+                        tracing::info_span!("publish", topic = ?publish.topic, pkid = publish.pkid);
+                    let _guard = span.enter();
 
                     let size = publish.len();
                     let qos = publish.qos;
@@ -451,7 +453,7 @@ impl Router {
                         Err(e) => {
                             // Disconnect on bad publishes
                             error!(
-                                reason=?e, "append-fail"
+                                reason = ?e, "Failed to append to commitlog for connection id {}", id
                             );
                             self.router_metrics.failed_publishes += 1;
                             disconnect = true;
@@ -477,11 +479,17 @@ impl Router {
                     // let len = s.len();
 
                     for f in s.filters {
-                        info!(filter = f.path, "subscribe");
+                        let span = tracing::info_span!("subscribe", topic = f.path, pkid = s.pkid);
+                        let _guard = span.enter();
+
+                        info!(
+                            "Adding subscription for connection id {} on topic {}",
+                            id, f.path
+                        );
                         let connection = self.connections.get_mut(id).unwrap();
 
                         if let Err(e) = validate_subscription(/*connection,*/ &f) {
-                            error!(reason=?e,"bad-subscription" );
+                            warn!(reason = ?e,"Subscription cannot be validated: {}", e);
                             disconnect = true;
                             break;
                         }
@@ -515,13 +523,16 @@ impl Router {
                     force_ack = true;
                 }
                 Packet::Unsubscribe(unsubscribe, _) => {
-                    debug!(
-                        filters=?unsubscribe.filters,
-                        "unsubscribe",
-                    );
                     let connection = self.connections.get_mut(id).unwrap();
                     let pkid = unsubscribe.pkid;
                     for filter in unsubscribe.filters {
+                        let span = tracing::info_span!("unsubscribe", topic = filter, pkid);
+                        let _guard = span.enter();
+
+                        debug!(
+                            "Removing subscription for connection id {} on filter {}",
+                            id, filter
+                        );
                         if let Some(connection_ids) = self.subscription_map.get_mut(&filter) {
                             let removed = connection_ids.remove(&id);
                             if !removed {
@@ -532,12 +543,14 @@ impl Router {
                             let meter = &mut self.ibufs.get_mut(id).unwrap().meter;
                             meter.subscribe_count -= 1;
 
-                            if connection.subscriptions.remove(&filter) {
-                                debug!(filter, "unsubscribe");
-                            } else {
-                                error!(pkid = unsubscribe.pkid, "unsubscribe-failed");
+                            if !connection.subscriptions.remove(&filter) {
+                                warn!(
+                                    pkid = unsubscribe.pkid,
+                                    "Unsubscribe failed as filter was not subscribed previously"
+                                );
                                 continue;
                             }
+
                             let unsuback = UnsubAck {
                                 pkid,
                                 // reasons are used in MQTTv5
@@ -552,10 +565,16 @@ impl Router {
                     }
                 }
                 Packet::PubAck(puback, _) => {
+                    let span = tracing::info_span!("puback", pkid = puback.pkid);
+                    let _guard = span.enter();
+
                     let outgoing = self.obufs.get_mut(id).unwrap();
                     let pkid = puback.pkid;
                     if outgoing.register_ack(pkid).is_none() {
-                        error!(pkid, "unsolicited/ooo ack");
+                        error!(
+                            pkid,
+                            "Unsolicited/ooo ack received for connection id {} pkid {}", id, pkid
+                        );
                         disconnect = true;
                         break;
                     }
@@ -563,10 +582,16 @@ impl Router {
                     self.scheduler.reschedule(id, ScheduleReason::IncomingAck);
                 }
                 Packet::PubRec(pubrec, _) => {
+                    let span = tracing::info_span!("pubrec", pkid = pubrec.pkid);
+                    let _guard = span.enter();
+
                     let outgoing = self.obufs.get_mut(id).unwrap();
                     let pkid = pubrec.pkid;
                     if outgoing.register_ack(pkid).is_none() {
-                        error!(pkid, "unsolicited/ooo ack");
+                        error!(
+                            pkid,
+                            "Unsolicited/ooo ack received for connection id {} pkid {}", id, pkid
+                        );
                         disconnect = true;
                         break;
                     }
@@ -581,6 +606,9 @@ impl Router {
                     self.scheduler.reschedule(id, ScheduleReason::IncomingAck);
                 }
                 Packet::PubRel(pubrel, None) => {
+                    let span = tracing::info_span!("pubrel", pkid = pubrel.pkid);
+                    let _guard = span.enter();
+
                     let ackslog = self.ackslog.get_mut(id).unwrap();
                     let pubcomp = PubComp {
                         pkid: pubrel.pkid,
@@ -612,7 +640,7 @@ impl Router {
                         Err(e) => {
                             // Disconnect on bad publishes
                             error!(
-                                reason=?e,"append-fail"
+                                reason = ?e, "Failed to append to commitlog for connection id {}", id
                             );
                             self.router_metrics.failed_publishes += 1;
                             disconnect = true;
@@ -628,6 +656,9 @@ impl Router {
                     force_ack = true;
                 }
                 Packet::Disconnect(_, _) => {
+                    let span = tracing::info_span!("disconnect");
+                    let _guard = span.enter();
+
                     disconnect = true;
                     execute_will = false;
                     break;
@@ -715,25 +746,24 @@ impl Router {
     fn consume(&mut self) -> Option<()> {
         let (id, mut requests) = self.scheduler.poll()?;
 
+        let span = tracing::info_span!("[<] outgoing", connection_id = id);
+        let _guard = span.enter();
+
         let outgoing = match self.obufs.get_mut(id) {
             Some(v) => v,
             None => {
-                error!("no-connection id {} is already gone", id);
+                error!("Connection id {} had already disconnected", id);
                 return Some(());
             }
         };
 
-        let span = tracing::info_span!("consume", client_id = outgoing.client_id);
-        let _guard = span.enter();
         let ackslog = self.ackslog.get_mut(id).unwrap();
         let datalog = &mut self.datalog;
 
-        trace!(id, "consume");
+        trace!("Consuming requests for connection id {id}");
 
         // We always try to ack when ever a connection is scheduled
-        if ack_device_data(ackslog, outgoing) {
-            trace!("acks-done");
-        }
+        ack_device_data(ackslog, outgoing);
 
         // A new connection's tracker is always initialized with acks request.
         // A subscribe will register data request.
@@ -764,7 +794,10 @@ impl Router {
                 }
                 ConsumeStatus::FilterCaughtup => {
                     let filter = &request.filter;
-                    trace!(filter, "caughtup-park");
+                    trace!(
+                        filter,
+                        "Filter caughtup {filter}, parking connection id {id}"
+                    );
 
                     // When all the data in the log is caught up, current request is
                     // registered in waiters and not added back to the tracker. This
@@ -814,7 +847,7 @@ impl Router {
             Err(e) => {
                 // Disconnect on bad publishes
                 error!(
-                    reason=?e,"append-fail"
+                    reason = ?e, "Failed to append to commitlog for connection id {}", id
                 );
                 self.router_metrics.failed_publishes += 1;
                 // Removed disconnect = true from here because we disconnect anyways
@@ -823,7 +856,6 @@ impl Router {
     }
 }
 
-#[tracing::instrument(skip_all)]
 fn append_to_commitlog(
     id: ConnectionId,
     mut publish: Publish,
@@ -868,7 +900,10 @@ fn append_to_commitlog(
     for filter_idx in filter_idxs {
         let datalog = datalog.native.get_mut(filter_idx).unwrap();
         let (offset, filter) = datalog.append(publish.clone(), notifications);
-        debug!(pkid, "append = {}[{}, {})", filter, offset.0, offset.1,);
+        debug!(
+            pkid,
+            "Appended to commitlog: {}[{}, {})", filter, offset.0, offset.1,
+        );
 
         o = offset;
     }
@@ -880,11 +915,14 @@ fn append_to_commitlog(
 /// Sweep ackslog for all the pending acks.
 /// We write everything to outgoing buf with out worrying about buffer size
 /// because acks most certainly won't cause memory bloat
-#[tracing::instrument(skip_all)]
 fn ack_device_data(ackslog: &mut AckLog, outgoing: &mut Outgoing) -> bool {
+    let span = tracing::info_span!("outgoing_ack", client_id = outgoing.client_id);
+    let _guard = span.enter();
+
     let acks = ackslog.readv();
     if acks.is_empty() {
-        return true;
+        debug!("No acks pending");
+        return false;
     }
 
     let mut count = 0;
@@ -894,130 +932,140 @@ fn ack_device_data(ackslog: &mut AckLog, outgoing: &mut Outgoing) -> bool {
     // At any given point of time, there can be a max of connection's buffer size
     for ack in acks.drain(..) {
         let pkid = packetid(&ack);
-        trace!(pkid, "ack");
+        trace!(pkid, "Ack added for pkid {}", pkid);
         let message = Notification::DeviceAck(ack);
         buffer.push_back(message);
         count += 1;
     }
 
-    debug!(acks_count = count);
+    debug!(acks_count = count, "Acks sent to device");
     outgoing.handle.try_send(()).ok();
     true
 }
 
 enum ConsumeStatus {
+    /// Limit for publishes on outgoing channel reached
     BufferFull,
+    /// Limit for inflight publishes on outgoing channel reached
     InflightFull,
+    /// All publishes on topic forwarded
     FilterCaughtup,
+    /// Some publishes on topic have been forwarded
     PartialRead,
 }
 
 /// Sweep datalog from offset in DataRequest and updates DataRequest
-/// for next sweep. Returns (busy, caughtup) status
-/// Returned arguments:
-/// 1. `busy`: whether the data request was completed or not.
-/// 2. `done`: whether the connection was busy or not.
-/// 3. `inflight_full`: whether the inflight requests were completely filled
-#[tracing::instrument(skip_all)]
+/// for next sweep. Returns `ConsumeStatus` indicating whether forward
+/// was successful or not.
 fn forward_device_data(
     request: &mut DataRequest,
     datalog: &DataLog,
     outgoing: &mut Outgoing,
 ) -> ConsumeStatus {
+    let span = tracing::info_span!("outgoing_publish", client_id = outgoing.client_id);
+    let _guard = span.enter();
     trace!(
-        message = "data-request",
-        "cursor = {}[{}, {}]",
+        "Reading from datalog: {}[{}, {}]",
         request.filter,
         request.cursor.0,
         request.cursor.1
     );
 
+    // Determine read size
     let inflight_slots = if request.qos == 1 {
         let len = outgoing.free_slots();
         if len == 0 {
+            trace!("Aborting read from datalog: inflight capacity reached");
             return ConsumeStatus::InflightFull;
         }
-
         len as u64
     } else {
         datalog.config.max_read_len
     };
 
-    let (next, publishes) =
-        match datalog.native_readv(request.filter_idx, request.cursor, inflight_slots) {
-            Ok(v) => v,
-            Err(e) => {
-                error!(error=?e, "Failed to read from commitlog.");
-                return ConsumeStatus::FilterCaughtup;
+    // Read publishes from commitlog
+    let (publishes, next, caughtup) = {
+        let (position, publishes) =
+            match datalog.native_readv(request.filter_idx, request.cursor, inflight_slots) {
+                Ok((pos, publishes)) => {
+                    if publishes.is_empty() {
+                        return ConsumeStatus::FilterCaughtup;
+                    }
+                    (pos, publishes)
+                }
+                Err(e) => {
+                    // TODO: native_readv should not err as per its current implemenation
+                    error!(error = ?e, "Failed to read from commitlog {}", e);
+                    return ConsumeStatus::FilterCaughtup;
+                }
+            };
+
+        let (next, caughtup) = {
+            let (start, next, caughtup) = match position {
+                Position::Next { start, end } => (start, end, false),
+                Position::Done { start, end } => (start, end, true),
+            };
+            if start != request.cursor {
+                warn!(
+                    request_cursor = ?request.cursor,
+                    start_cursor = ?start,
+                    "Read cursor start jumped from {:?} to {:?}", request.cursor, start,
+                );
             }
+            (next, caughtup)
         };
 
-    let (start, next, caughtup) = match next {
-        Position::Next { start, end } => (start, end, false),
-        Position::Done { start, end } => (start, end, true),
+        trace!(
+            "Read from commitlog, cursor = {}[{}, {}), read count = {}",
+            request.filter,
+            next.0,
+            next.1,
+            publishes.len()
+        );
+        request.read_count += publishes.len();
+        request.cursor = next;
+        (publishes, next, caughtup)
     };
 
-    if start != request.cursor {
-        error!(
-            cursor=?request.cursor,
-            ?start,
-            "Read cursor jump.",
+    // Prepare forwards and push them to outgoing buffer
+    let forward_buffer_len = {
+        let qos = request.qos;
+        let filter_idx = request.filter_idx;
+        let forwards = publishes.into_iter().map(|mut publish| {
+            publish.qos = protocol::qos(qos).unwrap();
+            Forward {
+                cursor: next,
+                size: 0,
+                publish,
+            }
+        });
+
+        let (len, inflight) = outgoing.push_forwards(forwards, qos, filter_idx);
+        debug!(
+            inflight_count = inflight,
+            forward_count = len,
+            "Forwarding publishes, cursor = {}[{}, {}) forward count = {}",
+            request.filter,
+            request.cursor.0,
+            request.cursor.1,
+            len
         );
-    }
+        len
+    };
 
-    trace!(
-        message = "data-response",
-        "cursor = {}[{}, {})",
-        request.filter,
-        next.0,
-        next.1,
-    );
-
-    let qos = request.qos;
-    let filter_idx = request.filter_idx;
-    request.read_count += publishes.len();
-    request.cursor = next;
-    // println!("{:?} {:?} {}", start, next, request.read_count);
-
-    if publishes.is_empty() {
-        return ConsumeStatus::FilterCaughtup;
-    }
-
-    // Fill and notify device data
-    debug!(
-        message = "data-proxy",
-        "cursor = {}[{}, {}) count = {}",
-        request.filter,
-        request.cursor.0,
-        request.cursor.1,
-        publishes.len()
-    );
-
-    let forwards = publishes.into_iter().map(|mut publish| {
-        publish.qos = protocol::qos(qos).unwrap();
-        Forward {
-            cursor: next,
-            size: 0,
-            publish,
-        }
-    });
-
-    let (len, inflight) = outgoing.push_forwards(forwards, qos, filter_idx);
-
-    trace!(inflight, buffer = len);
-
-    if len >= MAX_CHANNEL_CAPACITY - 1 {
+    let return_status = if forward_buffer_len >= MAX_CHANNEL_CAPACITY - 1 {
+        debug!("Outgoing channel reached its capacity");
         outgoing.push_notification(Notification::Unschedule);
-        outgoing.handle.try_send(()).ok();
-        return ConsumeStatus::BufferFull;
-    }
-
-    outgoing.handle.try_send(()).ok();
-    if caughtup {
+        ConsumeStatus::BufferFull
+    } else if caughtup {
         ConsumeStatus::FilterCaughtup
     } else {
         ConsumeStatus::PartialRead
-    }
+    };
+
+    outgoing.handle.try_send(()).ok();
+
+    return_status
 }
 
 fn retrieve_shadow(datalog: &mut DataLog, outgoing: &mut Outgoing, shadow: ShadowRequest) {

--- a/rumqttd/src/server/broker.rs
+++ b/rumqttd/src/server/broker.rs
@@ -266,7 +266,6 @@ impl<P: Protocol + Clone + Send + 'static> Server<P> {
         Ok(/*(*/ Box::new(stream) /*, None)*/)
     }
 
-    #[tracing::instrument(skip(self))]
     async fn start(&self, shadow: bool) -> Result<(), Error> {
         let listener = TcpListener::bind(&self.config.listen).await?;
         let delay = Duration::from_millis(self.config.next_connection_delay_ms);
@@ -275,7 +274,8 @@ impl<P: Protocol + Clone + Send + 'static> Server<P> {
         let config = Arc::new(self.config.connections.clone());
         info!(
             config = self.config.name,
-            "[>] waiting for remote connections > {}", self.config.listen
+            listen_addr = self.config.listen.to_string(),
+            "Listening for remote connections",
         );
         loop {
             // Await new network connection.
@@ -316,7 +316,7 @@ impl<P: Protocol + Clone + Send + 'static> Server<P> {
                 _ => task::spawn(
                     remote(config, /*tenant_id,*/ router_tx, network, protocol).instrument(
                         tracing::info_span!(
-                            "remote",
+                            "remote_link",
                             client_id = field::Empty,
                             connection_id = field::Empty
                         ),


### PR DESCRIPTION
Enhance tracing in rumqttd

- Re-organize spans basis of importance of context information they carry. The span tree has three levels. Level 0 has coarse, high-level information. Level 2 has fine, low-level information. The tree looks like:  
```
    |- incoming (level 0)
    |    |- incoming_connect (level 1)
    |    |- incoming_payload
    |    |    |- publish (level 2)
    |    |    |- subscribe
    |    |    |- ...
    |    |- incoming_disconnect
    |- outgoing (level 0)
    |    |- outgoing_ack (level 1)
    |    |- outgoing_publish
```

- ~Refactor `routing::forward_device_data()`~ (Added #507 for this)

- Make tracing events more human-readable

- Remove fields from tracing events that are present in enclosing tracing spans