### PR TITLE
Disconnect clients that send QoS2 publishes

### DIFF
--- a/rumqttd/src/router/logs.rs
+++ b/rumqttd/src/router/logs.rs
@@ -303,6 +303,8 @@ impl AckLog {
         self.committed.push_back(ack);
     }
 
+    // TODO: Remove this allow once we support QoS::ExactlyOnce
+    #[allow(dead_code)]
     pub fn pubrec(&mut self, publish: Publish, ack: PubRec) {
         let ack = Ack::PubRec(ack);
         self.recorded.push_back(publish);

--- a/rumqttd/src/router/routing.rs
+++ b/rumqttd/src/router/routing.rs
@@ -437,15 +437,18 @@ impl Router {
                             force_ack = true;
                         }
                         QoS::ExactlyOnce => {
-                            let pubrec = PubRec {
-                                pkid,
-                                reason: PubRecReason::Success,
-                            };
-
-                            let ackslog = self.ackslog.get_mut(id).unwrap();
-                            ackslog.pubrec(publish, pubrec);
-                            force_ack = true;
-                            continue;
+                            error!("QoS::ExactlyOnce is not yet supported");
+                            disconnect = true;
+                            break;
+                            // let pubrec = PubRec {
+                            //     pkid,
+                            //     reason: PubRecReason::Success,
+                            // };
+                            //
+                            // let ackslog = self.ackslog.get_mut(id).unwrap();
+                            // ackslog.pubrec(publish, pubrec);
+                            // force_ack = true;
+                            // continue;
                         }
                         QoS::AtMostOnce => {
                             // Do nothing

--- a/rumqttd/src/router/routing.rs
+++ b/rumqttd/src/router/routing.rs
@@ -1,7 +1,6 @@
 use crate::protocol::{
     ConnAck, ConnectReturnCode, Packet, PingResp, PubAck, PubAckReason, PubComp, PubCompReason,
-    PubRec, PubRecReason, PubRel, PubRelReason, Publish, QoS, SubAck, SubscribeReasonCode,
-    UnsubAck,
+    PubRel, PubRelReason, Publish, QoS, SubAck, SubscribeReasonCode, UnsubAck,
 };
 use crate::router::graveyard::SavedState;
 use crate::router::scheduler::{PauseReason, Tracker};


### PR DESCRIPTION
we where already not allowing subscriptions with QoS::Exactlyonce https://github.com/bytebeamio/rumqtt/blob/fad4882356230365d707d9093a7a26cd66cb7e89/rumqttd/src/router/routing.rs#L1192-L1194

disallow QoS::EactlyOnce publishes as well for now.