### PR TITLE
refactor: make router::Meter public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ rumqttc
 
 rumqttd
 -------
+- Make router::Meter public (#521)
 - Add meters related to router, subscriptions, and connections (#508)
 - Allow multi-tenancy validation for mtls clients with `Org` set in certificates (#505)
 - Add `tracing` for structured, context-aware logging (#499, #503)

--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -34,8 +34,7 @@ pub type Cursor = (u64, u64);
 pub use link::local;
 pub use link::meters;
 
-pub use router::GetMeter;
-pub use router::Notification;
+pub use router::{Notification, GetMeter, Meter};
 pub use server::Broker;
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
required so consumer of meter requests can match over the type of `Meter` that was received back