### PR TITLE
fix(CI): Optimize Github CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,29 +20,18 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
-        features:
-          - --no-default-features
-          - --features url
-          - --features use-rustls
-          - --features websocket
-          - --no-default-features --features url
-          - --no-default-features --features use-rustls
-          - --no-default-features --features websocket
-          - --all-features
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-          override: true
-          profile: minimal
-          toolchain: stable
 
-      - name: Fetch dependencies
-        uses: actions-rs/cargo@v1
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: taiki-e/install-action@v1
         with:
-          command: fetch
-          args: --verbose
+          tool: cargo-hack
 
       # - name: Check benchmarks
       #   uses: actions-rs/cargo@v1
@@ -55,23 +44,13 @@ jobs:
       #     args: --verbose --all-targets -p benchmarks
 
       - name: Check rumqttc and rumqttd
-        uses: actions-rs/cargo@v1
+        run: cargo hack clippy --verbose --each-feature --no-dev-deps --optional-deps url -p rumqttc -p rumqttd
         env:
           RUSTFLAGS: "-D warnings"
-        with:
-          command: clippy
-          args: --verbose --all-targets ${{ matrix.features }} -p rumqttc -p rumqttd
 
       - name: Check docs
         if: ${{ matrix.os != 'windows-latest' }}
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --verbose --no-deps ${{ matrix.features }}
+        run: cargo hack doc --verbose --no-deps --each-feature --no-dev-deps --optional-deps url -p rumqttc -p rumqttd
 
-        # NOTE: Tests for rumqttc and rumqttd on all platforms
       - name: Test rumqttc and rumqttd
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --release ${{ matrix.features }} -p rumqttc -p rumqttd
+        run: cargo hack test --verbose --each-feature --optional-deps url -p rumqttc -p rumqttd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,13 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --all-features
+          components: clippy
+      - run: cargo test --all-features
 
           # deploy:
     # name: Source build, docker build and deploy


### PR DESCRIPTION
Instead of running a different job for each combination of os and feature flag (i.e. 24 jobs in total). It is changed so it run all the feature flag tests in the same job using [cargo-hack](https://github.com/taiki-e/cargo-hack) (i.e. 3 jobs in total). Also use [rust-cache](https://github.com/Swatinem/rust-cache) to cache builds of dependencies.

Current runtime of CI could take anywhere from 45-60 mins. Optimized flow take around 25-30 min depending on if things are cached or not. This can be optimized further by removing things like doc tests and moving those to workflow of main branch because currently there are not alot of changes in doc tests and its something that can be fixed easily after PR is merged. But will do a separate PR for that.

Note: This workflow tests for more feature flags then previously tested.

Test run here: https://github.com/henil/rumqtt/actions
![image](https://user-images.githubusercontent.com/71698300/205829020-0e3d7fea-2cf4-4004-b2c9-6a96dd7f840c.png)
