### PR TITLE
fix(ci): only remove parts which had dependency on rumqttd-old

### DIFF
--- a/benchmarks/clients/common.rs
+++ b/benchmarks/clients/common.rs
@@ -1,0 +1,23 @@
+use pprof::{protos::Message, ProfilerGuard};
+use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::io::Write;
+
+pub fn profile(name: &str, guard: ProfilerGuard) {
+    if let Ok(report) = guard.report().build() {
+        let mut file = File::create(name).unwrap();
+        let profile = report.pprof().unwrap();
+
+        let mut content = Vec::new();
+        profile.encode(&mut content).unwrap();
+        file.write_all(&content).unwrap();
+    };
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Print {
+    pub id: String,
+    pub messages: usize,
+    pub payload_size: usize,
+    pub throughput: usize,
+}


### PR DESCRIPTION
This was remove in #530 by mistake because it had dependency on `ruqmttd-old`, and pull request's CI only runs `cargo check` on `rumqttd` and `rumqttc` so it was not caught there.

So add back the parts that are used by other tests.