### PR TITLE
fix(example): Stop printing error in loop

### DIFF
--- a/rumqttc/examples/async_manual_acks.rs
+++ b/rumqttc/examples/async_manual_acks.rs
@@ -36,7 +36,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
     loop {
         // get subscribed messages without acking
         let event = eventloop.poll().await;
-        println!("{:?}", event);
+        match &event {
+            Ok(notif) => {
+                println!("Event = {:?}", notif);
+            }
+            Err(error) => {
+                println!("Error = {:?}", error);
+                return Ok(());
+            }
+        }
         if let Err(_err) = event {
             // break loop on disconnection
             break;
@@ -49,7 +57,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
     loop {
         // previously published messages should be republished after reconnection.
         let event = eventloop.poll().await;
-        println!("{:?}", event);
+        match &event {
+            Ok(notif) => {
+                println!("Event = {:?}", notif);
+            }
+            Err(error) => {
+                println!("Error = {:?}", error);
+                return Ok(());
+            }
+        }
 
         if let Ok(Event::Incoming(Incoming::Publish(publish))) = event {
             // this time we will ack incoming publishes.

--- a/rumqttc/examples/async_manual_acks_v5.rs
+++ b/rumqttc/examples/async_manual_acks_v5.rs
@@ -8,7 +8,7 @@ use std::error::Error;
 use std::time::Duration;
 
 fn create_conn() -> (AsyncClient, EventLoop) {
-    let mut mqttoptions = MqttOptions::new("test-1", "localhost", 1883);
+    let mut mqttoptions = MqttOptions::new("test-1", "localhost", 1884);
     mqttoptions
         .set_keep_alive(Duration::from_secs(5))
         .set_manual_acks(true)
@@ -38,8 +38,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
     });
 
     // get subscribed messages without acking
-    while let Ok(event) = eventloop.poll().await {
-        println!("{:?}", event);
+    loop {
+        let event = eventloop.poll().await;
+        match &event {
+            Ok(v) => {
+                println!("Event = {:?}", v);
+            }
+            Err(e) => {
+                println!("Error = {:?}", e);
+                break;
+            }
+        }
     }
 
     // create new broker connection

--- a/rumqttc/examples/asyncpubsub.rs
+++ b/rumqttc/examples/asyncpubsub.rs
@@ -20,7 +20,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     loop {
         let event = eventloop.poll().await;
-        println!("{:?}", event.unwrap());
+        match &event {
+            Ok(v) => {
+                println!("Event = {:?}", v);
+            }
+            Err(e) => {
+                println!("Error = {:?}", e);
+                return Ok(());
+            }
+        }
     }
 }
 

--- a/rumqttc/examples/asyncpubsub_v5.rs
+++ b/rumqttc/examples/asyncpubsub_v5.rs
@@ -19,11 +19,18 @@ async fn main() -> Result<(), Box<dyn Error>> {
         time::sleep(Duration::from_secs(3)).await;
     });
 
-    while let Ok(event) = eventloop.poll().await {
-        println!("{:?}", event);
+    loop {
+        let event = eventloop.poll().await;
+        match &event {
+            Ok(v) => {
+                println!("Event = {:?}", v);
+            }
+            Err(e) => {
+                println!("Error = {:?}", e);
+                return Ok(());
+            }
+        }
     }
-
-    Ok(())
 }
 
 async fn requests(client: AsyncClient) {

--- a/rumqttc/examples/syncpubsub.rs
+++ b/rumqttc/examples/syncpubsub.rs
@@ -15,13 +15,22 @@ fn main() {
     thread::spawn(move || publish(client));
 
     for (i, notification) in connection.iter().enumerate() {
-        println!("{}. Notification = {:?}", i, notification);
+        match notification {
+            Ok(notif) => {
+                println!("{}. Notification = {:?}", i, notif);
+            }
+            Err(error) => {
+                println!("{}. Notification = {:?}", i, error);
+                return;
+            }
+        }
     }
 
     println!("Done with the stream!!");
 }
 
 fn publish(mut client: Client) {
+    thread::sleep(Duration::from_secs(1));
     client.subscribe("hello/+/world", QoS::AtMostOnce).unwrap();
     for i in 0..10_usize {
         let payload = vec![1; i];

--- a/rumqttc/examples/syncrecv_v5.rs
+++ b/rumqttc/examples/syncrecv_v5.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 fn main() {
     pretty_env_logger::init();
 
-    let mut mqttoptions = MqttOptions::new("test-1", "localhost", 1883);
+    let mut mqttoptions = MqttOptions::new("test-1", "localhost", 1884);
     let will = LastWill::new("hello/world", "good bye", QoS::AtMostOnce, false);
     mqttoptions
         .set_keep_alive(Duration::from_secs(5))

--- a/rumqttc/examples/tls.rs
+++ b/rumqttc/examples/tls.rs
@@ -40,6 +40,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             Ok(Event::Outgoing(o)) => println!("Outgoing = {:?}", o),
             Err(e) => {
                 println!("Error = {:?}", e);
+                return Ok(());
             }
         }
     }

--- a/rumqttc/examples/websocket.rs
+++ b/rumqttc/examples/websocket.rs
@@ -28,8 +28,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
     loop {
         let event = eventloop.poll().await;
         match event {
-            Ok(ev) => println!("{:?}", ev),
-            Err(err) => println!("{:?}", err),
+            Ok(notif) => {
+                println!("Event = {:?}", notif);
+            }
+            Err(err) => {
+                println!("Error = {:?}", err);
+                return Ok(());
+            }
         }
     }
 }


### PR DESCRIPTION
`.poll()` method on rumqttc clients tries to reconnect to the server incase of any error. and we where printing events in a loop, which was causing client to print error in an infinite loop on terminal if broker was not running. 

it is now changed to stop the program and print it in the case client gets an error.

Also change port to `1884` for MQTTv5 examples.