### PR TITLE
refactor!: Remove `Connect` from `ConnectionError::StateError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ rumqttc
 - Add support for native-tls within rumqttc (#501)
 - Fixed panicking in `recv_timeout` and `try_recv` by entering tokio runtime context (#492, #497)
 - Removed unused dependencies and updated version of some of used libraries to fix dependabots warning (#475)
+- Remove `Connect` from `ConnectionError::StateError` (#541)
 
 rumqttd
 -------

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -43,7 +43,7 @@ pub enum ConnectionError {
     Tls(#[from] tls::Error),
     #[error("I/O: {0}")]
     Io(#[from] io::Error),
-    #[error("Connection refused, return code: {0:?}")]
+    #[error("Connection refused, return code: `{0:?}`")]
     ConnectionRefused(ConnectReturnCode),
     #[error("Expected ConnAck packet, received: {0:?}")]
     NotConnAck(Packet),

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -12,9 +12,6 @@ pub enum StateError {
     /// Io Error while state is passed to network
     #[error("Io error: {0:?}")]
     Io(#[from] io::Error),
-    /// Broker's error reply to client's connect packet
-    #[error("Connect return code: `{0:?}`")]
-    Connect(ConnectReturnCode),
     /// Invalid state for a given operation
     #[error("Invalid state for a given operation")]
     InvalidState,

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -44,7 +44,7 @@ pub enum ConnectionError {
     Tls(#[from] tls::Error),
     #[error("I/O: {0}")]
     Io(#[from] io::Error),
-    #[error("Connection refused, return code: {0:?}")]
+    #[error("Connection refused, return code: `{0:?}`")]
     ConnectionRefused(ConnectReturnCode),
     #[error("Expected ConnAck packet, received: {0:?}")]
     NotConnAck(Box<Packet>),

--- a/rumqttc/src/v5/state.rs
+++ b/rumqttc/src/v5/state.rs
@@ -2,7 +2,7 @@ use crate::v5::mqttbytes::PingReq;
 
 use super::mqttbytes::v5::Packet;
 use super::mqttbytes::{
-    self, ConnectReturnCode, PubAck, PubComp, PubRec, PubRel, Publish, QoS, Subscribe, Unsubscribe,
+    self, PubAck, PubComp, PubRec, PubRel, Publish, QoS, Subscribe, Unsubscribe,
 };
 use super::{Event, Incoming, Outgoing, Request};
 
@@ -16,9 +16,6 @@ pub enum StateError {
     /// Io Error while state is passed to network
     #[error("Io error: {0:?}")]
     Io(#[from] io::Error),
-    /// Broker's error reply to client's connect packet
-    #[error("Connect return code: `{0:?}`")]
-    Connect(ConnectReturnCode),
     /// Invalid state for a given operation
     #[error("Invalid state for a given operation")]
     InvalidState,

--- a/rumqttd/src/router/iobufs.rs
+++ b/rumqttd/src/router/iobufs.rs
@@ -68,7 +68,7 @@ impl Outgoing {
     pub(crate) fn new(client_id: String) -> (Self, Receiver<()>) {
         let (handle, rx) = flume::bounded(MAX_CHANNEL_CAPACITY);
         let data_buffer = VecDeque::with_capacity(MAX_CHANNEL_CAPACITY);
-        let inflight_buffer = VecDeque::with_capacity(MAX_INFLIGHT as usize);
+        let inflight_buffer = VecDeque::with_capacity(MAX_INFLIGHT);
 
         // Ensure that there won't be any new allocations
         assert!(MAX_INFLIGHT <= inflight_buffer.capacity());

--- a/rumqttd/src/segments/mod.rs
+++ b/rumqttd/src/segments/mod.rs
@@ -127,7 +127,7 @@ where
     #[allow(dead_code)]
     #[inline]
     pub fn len(&self) -> usize {
-        self.segments.len() as usize
+        self.segments.len()
     }
 
     /// Number of packets


### PR DESCRIPTION
`ConnectionError` has a variant named `ConnectionRefused` which should be used instead. 