### PR TITLE
doc: separate out v0.18.0 in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ misc
 ---
 - Remove rumqttd-old in favour of rumqttd (#530)
 
-rumqttc
+rumqttd
+-------
+- Make router::Meter public (#521)
+------
+
+### R18
+---
+rumqttc v0.18.0
 -------
 - Add support for native-tls within rumqttc (#501)
 - Fixed panicking in `recv_timeout` and `try_recv` by entering tokio runtime context (#492, #497)
@@ -12,7 +19,6 @@ rumqttc
 
 rumqttd
 -------
-- Make router::Meter public (#521)
 - Add meters related to router, subscriptions, and connections (#508)
 - Allow multi-tenancy validation for mtls clients with `Org` set in certificates (#505)
 - Add `tracing` for structured, context-aware logging (#499, #503)


### PR DESCRIPTION
Currently changelog entries for v0.18.0 remain within the unreleased section