### PR TITLE
fix(rumqttc): Add timeouts to network flushes and clean state properly on network failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2007,7 +2007,7 @@ dependencies = [
 
 [[package]]
 name = "rumqttd"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "bytes",
  "config",

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 use crate::mqttbytes::{v4::*, QoS};
-use crate::{valid_topic, ConnectionError, Event, EventLoop, MqttOptions, Request};
+use crate::{valid_topic, ConnectionError, Event, EventLoop, MqttOptions, NetworkOptions, Request};
 
 use bytes::Bytes;
 use flume::{SendError, Sender, TrySendError};
@@ -49,7 +49,8 @@ impl AsyncClient {
     ///
     /// `cap` specifies the capacity of the bounded async channel.
     pub fn new(options: MqttOptions, cap: usize) -> (AsyncClient, EventLoop) {
-        let eventloop = EventLoop::new(options, cap);
+        let network_options = NetworkOptions::new();
+        let eventloop = EventLoop::new(options, network_options, cap);
         let request_tx = eventloop.requests_tx.clone();
 
         let client = AsyncClient { request_tx };

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 use crate::mqttbytes::{v4::*, QoS};
-use crate::{valid_topic, ConnectionError, Event, EventLoop, MqttOptions, NetworkOptions, Request};
+use crate::{valid_topic, ConnectionError, Event, EventLoop, MqttOptions, Request};
 
 use bytes::Bytes;
 use flume::{SendError, Sender, TrySendError};
@@ -49,8 +49,7 @@ impl AsyncClient {
     ///
     /// `cap` specifies the capacity of the bounded async channel.
     pub fn new(options: MqttOptions, cap: usize) -> (AsyncClient, EventLoop) {
-        let network_options = NetworkOptions::new();
-        let eventloop = EventLoop::new(options, network_options, cap);
+        let eventloop = EventLoop::new(options, cap);
         let request_tx = eventloop.requests_tx.clone();
 
         let client = AsyncClient { request_tx };

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -238,13 +238,11 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
         Transport::Tcp => {
             let addr = format!("{}:{}", options.broker_addr, options.port);
             let socket = TcpSocket::new_v4()?;
-            if let Some(network_option) = options.network_option {
-                if let Some(send_buff_size) = network_option.tcp_send_buffer_size {
-                    socket.set_send_buffer_size(send_buff_size).unwrap();
-                }
-                if let Some(recv_buffer_size) = network_option.tcp_recv_buffer_size {
-                    socket.set_recv_buffer_size(recv_buffer_size).unwrap();
-                }
+            if let Some(send_buff_size) = options.network_option.tcp_send_buffer_size {
+                socket.set_send_buffer_size(send_buff_size).unwrap();
+            }
+            if let Some(recv_buffer_size) = options.network_option.tcp_recv_buffer_size {
+                socket.set_recv_buffer_size(recv_buffer_size).unwrap();
             }
 
             let stream = socket.connect(addr.to_string().parse().unwrap()).await?;

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -236,13 +236,11 @@ async fn connect(options: &MqttOptions) -> Result<(Network, Incoming), Connectio
 async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionError> {
     let network = match options.transport() {
         Transport::Tcp => {
-            let addr = options.broker_addr.as_str();
-            let port = options.port;
-            let addr2 = format!("{}:{}", addr, port);
+            let addr = format!("{}:{}", options.broker_addr, options.port);
             let socket = TcpSocket::new_v4()?;
-            socket.set_send_buffer_size(1024).unwrap();
+            // socket.set_send_buffer_size(1024).unwrap();
 
-            let stream = socket.connect(addr2.to_string().parse().unwrap()).await?;
+            let stream = socket.connect(addr.to_string().parse().unwrap()).await?;
             Network::new(stream, options.max_incoming_packet_size)
         }
         #[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -242,15 +242,10 @@ pub(crate) async fn get_tcp_stream(
     let mut last_err = None;
 
     for addr in addrs {
-        let socket;
-        match addr {
-            SocketAddr::V4(_) => {
-                socket = TcpSocket::new_v4()?;
-            }
-            SocketAddr::V6(_) => {
-                socket = TcpSocket::new_v6()?;
-            }
-        }
+        let socket = match addr {
+            SocketAddr::V4(_) => TcpSocket::new_v4()?,
+            SocketAddr::V6(_) => TcpSocket::new_v6()?,
+        };
 
         if let Some(send_buff_size) = network_options.tcp_send_buffer_size {
             socket.set_send_buffer_size(send_buff_size).unwrap();

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -238,7 +238,11 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
         Transport::Tcp => {
             let addr = format!("{}:{}", options.broker_addr, options.port);
             let socket = TcpSocket::new_v4()?;
-            // socket.set_send_buffer_size(1024).unwrap();
+            if let Some(network_option) = options.network_option {
+                socket
+                    .set_send_buffer_size(network_option.tcp_send_buffer_size)
+                    .unwrap();
+            }
 
             let stream = socket.connect(addr.to_string().parse().unwrap()).await?;
             Network::new(stream, options.max_incoming_packet_size)

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -630,7 +630,7 @@ impl MqttOptions {
     }
 
     pub fn network_option(&self) -> Option<NetworkOptions> {
-        self.network_option.clone()
+        self.network_option
     }
 
     pub fn set_network_option(&mut self, network_option: NetworkOptions) -> &mut Self {

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -351,14 +351,24 @@ impl From<ClientConfig> for TlsConfiguration {
 /// Provides a way to configure low level network connection configurations
 #[derive(Clone, Copy)]
 pub struct NetworkOptions {
-    tcp_send_buffer_size: u32,
+    tcp_send_buffer_size: Option<u32>,
+    tcp_recv_buffer_size: Option<u32>,
 }
 
 impl NetworkOptions {
-    pub fn new(tcp_send_buffer_size: u32) -> Self {
+    pub fn new() -> Self {
         NetworkOptions {
-            tcp_send_buffer_size,
+            tcp_send_buffer_size: None,
+            tcp_recv_buffer_size: None,
         }
+    }
+
+    pub fn set_tcp_send_buffer_size(&mut self, size: u32) {
+        self.tcp_send_buffer_size = Some(size);
+    }
+
+    pub fn set_tcp_recv_buffer_size(&mut self, size: u32) {
+        self.tcp_recv_buffer_size = Some(size);
     }
 }
 

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -415,7 +415,7 @@ pub struct MqttOptions {
     /// If set to `true` MQTT acknowledgements are not sent automatically.
     /// Every incoming publish packet must be manually acknowledged with `client.ack(...)` method.
     manual_acks: bool,
-    network_option: NetworkOptions,
+    network_options: NetworkOptions,
 }
 
 impl MqttOptions {
@@ -457,7 +457,7 @@ impl MqttOptions {
             last_will: None,
             conn_timeout: 5,
             manual_acks: false,
-            network_option: NetworkOptions::new(),
+            network_options: NetworkOptions::new(),
         }
     }
 
@@ -639,12 +639,12 @@ impl MqttOptions {
         self.manual_acks
     }
 
-    pub fn network_option(&self) -> NetworkOptions {
-        self.network_option
+    pub fn network_options(&self) -> NetworkOptions {
+        self.network_options
     }
 
-    pub fn set_network_option(&mut self, network_option: NetworkOptions) -> &mut Self {
-        self.network_option = network_option;
+    pub fn set_network_options(&mut self, network_options: NetworkOptions) -> &mut Self {
+        self.network_options = network_options;
         self
     }
 }

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -349,7 +349,7 @@ impl From<ClientConfig> for TlsConfiguration {
 }
 
 /// Provides a way to configure low level network connection configurations
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 pub struct NetworkOptions {
     tcp_send_buffer_size: Option<u32>,
     tcp_recv_buffer_size: Option<u32>,
@@ -415,7 +415,7 @@ pub struct MqttOptions {
     /// If set to `true` MQTT acknowledgements are not sent automatically.
     /// Every incoming publish packet must be manually acknowledged with `client.ack(...)` method.
     manual_acks: bool,
-    network_option: Option<NetworkOptions>,
+    network_option: NetworkOptions,
 }
 
 impl MqttOptions {
@@ -457,7 +457,7 @@ impl MqttOptions {
             last_will: None,
             conn_timeout: 5,
             manual_acks: false,
-            network_option: None,
+            network_option: NetworkOptions::new(),
         }
     }
 
@@ -639,12 +639,12 @@ impl MqttOptions {
         self.manual_acks
     }
 
-    pub fn network_option(&self) -> Option<NetworkOptions> {
+    pub fn network_option(&self) -> NetworkOptions {
         self.network_option
     }
 
     pub fn set_network_option(&mut self, network_option: NetworkOptions) -> &mut Self {
-        self.network_option = Some(network_option);
+        self.network_option = network_option;
         self
     }
 }

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -670,9 +670,6 @@ pub enum OptionError {
     #[error("Invalid inflight value.")]
     Inflight,
 
-    #[error("Invalid conn-timeout value.")]
-    ConnTimeout,
-
     #[error("Unknown option: {0}")]
     Unknown(String),
 
@@ -797,14 +794,6 @@ impl std::convert::TryFrom<url::Url> for MqttOptions {
             options.set_inflight(inflight);
         }
 
-        if let Some(conn_timeout) = queries
-            .remove("conn_timeout_secs")
-            .map(|v| v.parse::<u64>().map_err(|_| OptionError::ConnTimeout))
-            .transpose()?
-        {
-            options.set_connection_timeout(conn_timeout);
-        }
-
         if let Some((opt, _)) = queries.into_iter().next() {
             return Err(OptionError::Unknown(opt.into_owned()));
         }
@@ -925,10 +914,6 @@ mod test {
         assert_eq!(
             err("mqtt://host:42?client_id=foo&inflight_num=foo"),
             OptionError::Inflight
-        );
-        assert_eq!(
-            err("mqtt://host:42?client_id=foo&conn_timeout_secs=foo"),
-            OptionError::ConnTimeout
         );
     }
 

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -348,6 +348,20 @@ impl From<ClientConfig> for TlsConfiguration {
     }
 }
 
+/// Provides a way to configure low level network connection configurations
+#[derive(Clone, Copy)]
+pub struct NetworkOptions {
+    tcp_send_buffer_size: u32,
+}
+
+impl NetworkOptions {
+    pub fn new(tcp_send_buffer_size: u32) -> Self {
+        NetworkOptions {
+            tcp_send_buffer_size,
+        }
+    }
+}
+
 // TODO: Should all the options be exposed as public? Drawback
 // would be loosing the ability to panic when the user options
 // are wrong (e.g empty client id) or aggressive (keep alive time)
@@ -391,6 +405,7 @@ pub struct MqttOptions {
     /// If set to `true` MQTT acknowledgements are not sent automatically.
     /// Every incoming publish packet must be manually acknowledged with `client.ack(...)` method.
     manual_acks: bool,
+    network_option: Option<NetworkOptions>,
 }
 
 impl MqttOptions {
@@ -432,6 +447,7 @@ impl MqttOptions {
             last_will: None,
             conn_timeout: 5,
             manual_acks: false,
+            network_option: None,
         }
     }
 
@@ -611,6 +627,15 @@ impl MqttOptions {
     /// get manual acknowledgements
     pub fn manual_acks(&self) -> bool {
         self.manual_acks
+    }
+
+    pub fn network_option(&self) -> Option<NetworkOptions> {
+        self.network_option.clone()
+    }
+
+    pub fn set_network_option(&mut self, network_option: NetworkOptions) -> &mut Self {
+        self.network_option = Some(network_option);
+        self
     }
 }
 

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -34,7 +34,7 @@ pub enum StateError {
 
 /// State of the mqtt connection.
 // Design: Methods will just modify the state of the object without doing any network operations
-// Design: All inflight queues are maintained in a pre initialized vec with index as packet id.
+// Design: All inflight queues are maintained in a pre initialized vec with indexnas packet id.
 // This is done for 2 reasons
 // Bad acks or out of order acks aren't O(n) causing cpu spikes
 // Any missing acks from the broker are detected during the next recycled use of packet ids
@@ -52,6 +52,8 @@ pub struct MqttState {
     last_outgoing: Instant,
     /// Packet id of the last outgoing packet
     pub(crate) last_pkid: u16,
+    /// Packet id of the last acked publish
+    pub(crate) last_acked_publish_pkid: u16,
     /// Number of outgoing inflight publishes
     pub(crate) inflight: u16,
     /// Maximum number of allowed inflight
@@ -83,6 +85,7 @@ impl MqttState {
             last_incoming: Instant::now(),
             last_outgoing: Instant::now(),
             last_pkid: 0,
+            last_acked_publish_pkid: 0,
             inflight: 0,
             max_inflight,
             // index 0 is wasted as 0 is not a valid packet id
@@ -100,8 +103,11 @@ impl MqttState {
     /// Returns inflight outgoing packets and clears internal queues
     pub fn clean(&mut self) -> Vec<Request> {
         let mut pending = Vec::with_capacity(100);
-        // remove and collect pending publishes
-        for publish in self.outgoing_pub.iter_mut() {
+        let (first_half, second_half) = self
+            .outgoing_pub
+            .split_at_mut(self.last_acked_publish_pkid as usize + 1);
+
+        for publish in second_half.iter_mut().chain(first_half) {
             if let Some(publish) = publish.take() {
                 let request = Request::Publish(publish);
                 pending.push(request);
@@ -124,6 +130,8 @@ impl MqttState {
         self.await_pingresp = false;
         self.collision_ping_count = 0;
         self.inflight = 0;
+        self.write.clear();
+        self.events.clear();
         pending
     }
 
@@ -216,6 +224,8 @@ impl MqttState {
             .outgoing_pub
             .get_mut(puback.pkid as usize)
             .ok_or(StateError::Unsolicited(puback.pkid))?;
+
+        self.last_acked_publish_pkid = puback.pkid;
         let v = match publish.take() {
             Some(_) => {
                 self.inflight -= 1;
@@ -505,6 +515,7 @@ mod test {
     use crate::mqttbytes::v4::*;
     use crate::mqttbytes::*;
     use crate::{Event, Incoming, Outgoing, Request};
+    use bytes::BufMut;
 
     fn build_outgoing_publish(qos: QoS) -> Publish {
         let topic = "hello/world".to_owned();
@@ -799,5 +810,97 @@ mod test {
 
         // should ping
         mqtt.outgoing_ping().unwrap();
+    }
+
+    #[test]
+    fn state_should_be_clean_properly() {
+        let mut mqtt = build_mqttstate();
+        mqtt.write.put(&b"test"[..]);
+        mqtt.events.push_back(Event::Outgoing(Outgoing::Disconnect));
+        // After this clean state.write and state.events should be empty
+        mqtt.clean();
+        assert!(mqtt.write.is_empty());
+        assert!(mqtt.events.is_empty());
+    }
+
+    #[test]
+    fn clean_is_calculating_pending_correctly() {
+        let mut mqtt = build_mqttstate();
+
+        fn build_outgoing_pub() -> Vec<Option<Publish>> {
+            vec![
+                None,
+                Some(Publish {
+                    dup: false,
+                    qos: QoS::AtMostOnce,
+                    retain: false,
+                    topic: "test".to_string(),
+                    pkid: 1,
+                    payload: "".into(),
+                }),
+                Some(Publish {
+                    dup: false,
+                    qos: QoS::AtMostOnce,
+                    retain: false,
+                    topic: "test".to_string(),
+                    pkid: 2,
+                    payload: "".into(),
+                }),
+                Some(Publish {
+                    dup: false,
+                    qos: QoS::AtMostOnce,
+                    retain: false,
+                    topic: "test".to_string(),
+                    pkid: 3,
+                    payload: "".into(),
+                }),
+                None,
+                None,
+                Some(Publish {
+                    dup: false,
+                    qos: QoS::AtMostOnce,
+                    retain: false,
+                    topic: "test".to_string(),
+                    pkid: 6,
+                    payload: "".into(),
+                }),
+            ]
+        }
+
+        mqtt.outgoing_pub = build_outgoing_pub();
+        mqtt.last_acked_publish_pkid = 3;
+        let requests = mqtt.clean();
+        let res = vec![6, 1, 2, 3];
+        for (req, idx) in requests.iter().zip(res) {
+            if let Request::Publish(publish) = req {
+                assert_eq!(publish.pkid, idx);
+            } else {
+                unreachable!()
+            }
+        }
+
+        mqtt.outgoing_pub = build_outgoing_pub();
+        mqtt.last_acked_publish_pkid = 0;
+        let requests = mqtt.clean();
+        let res = vec![1, 2, 3, 6];
+        for (req, idx) in requests.iter().zip(res) {
+            if let Request::Publish(publish) = req {
+                assert_eq!(publish.pkid, idx);
+            } else {
+                unreachable!()
+            }
+        }
+
+        mqtt.outgoing_pub = build_outgoing_pub();
+        mqtt.last_acked_publish_pkid = 6;
+        let requests = mqtt.clean();
+        let res = vec![1, 2, 3, 6];
+        for (req, idx) in requests.iter().zip(res) {
+            if let Request::Publish(publish) = req {
+                assert_eq!(publish.pkid, idx);
+            } else {
+                unreachable!()
+            }
+        }
     }
 }

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -34,7 +34,7 @@ pub enum StateError {
 
 /// State of the mqtt connection.
 // Design: Methods will just modify the state of the object without doing any network operations
-// Design: All inflight queues are maintained in a pre initialized vec with indexnas packet id.
+// Design: All inflight queues are maintained in a pre initialized vec with index as packet id.
 // This is done for 2 reasons
 // Bad acks or out of order acks aren't O(n) causing cpu spikes
 // Any missing acks from the broker are detected during the next recycled use of packet ids

--- a/rumqttc/src/tls.rs
+++ b/rumqttc/src/tls.rs
@@ -1,5 +1,3 @@
-use tokio::net::TcpStream;
-
 #[cfg(feature = "use-rustls")]
 use tokio_rustls::rustls;
 #[cfg(feature = "use-rustls")]
@@ -13,6 +11,7 @@ use tokio_rustls::webpki;
 #[cfg(feature = "use-rustls")]
 use tokio_rustls::TlsConnector as RustlsConnector;
 
+use crate::eventloop::get_tcp_stream;
 #[cfg(feature = "use-rustls")]
 use crate::Key;
 #[cfg(feature = "use-rustls")]
@@ -23,7 +22,7 @@ use std::io::{BufReader, Cursor};
 use std::sync::Arc;
 
 use crate::framed::N;
-use crate::TlsConfiguration;
+use crate::{NetworkOptions, TlsConfiguration};
 
 #[cfg(feature = "use-native-tls")]
 use tokio_native_tls::TlsConnector as NativeTlsConnector;
@@ -176,8 +175,10 @@ pub async fn tls_connect(
     addr: &str,
     port: u16,
     tls_config: &TlsConfiguration,
+    network_options: NetworkOptions,
 ) -> Result<Box<dyn N>, Error> {
-    let tcp = TcpStream::connect((addr, port)).await?;
+    let addrs = format!("{}:{}", addr, port);
+    let tcp = get_tcp_stream(addrs, network_options).await?;
 
     let tls: Box<dyn N> = match tls_config {
         #[cfg(feature = "use-rustls")]

--- a/rumqttc/src/tls.rs
+++ b/rumqttc/src/tls.rs
@@ -1,3 +1,4 @@
+use tokio::net::TcpStream;
 #[cfg(feature = "use-rustls")]
 use tokio_rustls::rustls;
 #[cfg(feature = "use-rustls")]
@@ -11,7 +12,6 @@ use tokio_rustls::webpki;
 #[cfg(feature = "use-rustls")]
 use tokio_rustls::TlsConnector as RustlsConnector;
 
-use crate::eventloop::get_tcp_stream;
 #[cfg(feature = "use-rustls")]
 use crate::Key;
 #[cfg(feature = "use-rustls")]
@@ -22,7 +22,7 @@ use std::io::{BufReader, Cursor};
 use std::sync::Arc;
 
 use crate::framed::N;
-use crate::{NetworkOptions, TlsConfiguration};
+use crate::TlsConfiguration;
 
 #[cfg(feature = "use-native-tls")]
 use tokio_native_tls::TlsConnector as NativeTlsConnector;
@@ -173,13 +173,10 @@ pub async fn native_tls_connector(
 
 pub async fn tls_connect(
     addr: &str,
-    port: u16,
+    _port: u16,
     tls_config: &TlsConfiguration,
-    network_options: NetworkOptions,
+    tcp: TcpStream,
 ) -> Result<Box<dyn N>, Error> {
-    let addrs = format!("{}:{}", addr, port);
-    let tcp = get_tcp_stream(addrs, network_options).await?;
-
     let tls: Box<dyn N> = match tls_config {
         #[cfg(feature = "use-rustls")]
         TlsConfiguration::Simple { .. } | TlsConfiguration::Rustls(_) => {

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -1,6 +1,7 @@
 use super::framed::Network;
 use super::mqttbytes::{v5::*, *};
 use super::{Incoming, MqttOptions, MqttState, Outgoing, Request, StateError, Transport};
+use crate::eventloop::get_tcp_stream;
 #[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]
 use crate::tls;
 
@@ -9,7 +10,6 @@ use async_tungstenite::tokio::connect_async;
 #[cfg(all(feature = "use-rustls", feature = "websocket"))]
 use async_tungstenite::tokio::connect_async_with_tls_connector;
 use flume::{bounded, Receiver, Sender};
-use tokio::net::TcpStream;
 #[cfg(unix)]
 use tokio::net::UnixStream;
 use tokio::select;
@@ -236,14 +236,19 @@ async fn connect(options: &MqttOptions) -> Result<(Network, Incoming), Connectio
 async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionError> {
     let network = match options.transport() {
         Transport::Tcp => {
-            let addr = options.broker_addr.as_str();
-            let port = options.port;
-            let socket = TcpStream::connect((addr, port)).await?;
-            Network::new(socket, options.max_incoming_packet_size)
+            let addr = format!("{}:{}", options.broker_addr, options.port);
+            let stream = get_tcp_stream(addr, options.network_options()).await?;
+            Network::new(stream, options.max_incoming_packet_size)
         }
         #[cfg(any(feature = "use-native-tls", feature = "use-rustls"))]
         Transport::Tls(tls_config) => {
-            let socket = tls::tls_connect(&options.broker_addr, options.port, &tls_config).await?;
+            let socket = tls::tls_connect(
+                &options.broker_addr,
+                options.port,
+                &tls_config,
+                options.network_options(),
+            )
+            .await?;
             Network::new(socket, options.max_incoming_packet_size)
         }
         #[cfg(unix)]

--- a/rumqttc/src/v5/mod.rs
+++ b/rumqttc/src/v5/mod.rs
@@ -9,7 +9,7 @@ mod state;
 
 #[cfg(feature = "use-rustls")]
 pub use crate::tls::Error as TlsError;
-use crate::Transport;
+use crate::{NetworkOptions, Transport};
 pub use client::{AsyncClient, Client, ClientError, Connection, Iter};
 pub use eventloop::{ConnectionError, Event, EventLoop};
 pub use state::{MqttState, StateError};
@@ -81,6 +81,7 @@ pub struct MqttOptions {
     /// If set to `true` MQTT acknowledgements are not sent automatically.
     /// Every incoming publish packet must be manually acknowledged with `client.ack(...)` method.
     manual_acks: bool,
+    network_options: NetworkOptions,
 }
 
 impl MqttOptions {
@@ -122,6 +123,7 @@ impl MqttOptions {
             last_will: None,
             conn_timeout: 5,
             manual_acks: false,
+            network_options: NetworkOptions::new(),
         }
     }
 
@@ -301,6 +303,15 @@ impl MqttOptions {
     /// get manual acknowledgements
     pub fn manual_acks(&self) -> bool {
         self.manual_acks
+    }
+
+    pub fn network_options(&self) -> NetworkOptions {
+        self.network_options
+    }
+
+    pub fn set_network_options(&mut self, network_options: NetworkOptions) -> &mut Self {
+        self.network_options = network_options;
+        self
     }
 }
 

--- a/rumqttc/tests/broker.rs
+++ b/rumqttc/tests/broker.rs
@@ -91,16 +91,19 @@ impl Broker {
     }
 
     /// Reads next packet from the stream
-    pub async fn read_packet(&mut self) -> Packet {
-        time::timeout(Duration::from_secs(30), async {
+    pub async fn read_packet(&mut self) -> Option<Packet> {
+        let _ = time::timeout(Duration::from_secs(30), async {
             let p = self.framed.readb(&mut self.incoming).await;
-            // println!("Broker read = {:?}", p);
-            p.unwrap();
+            if p.is_err() {
+                println!("Broker read = {:?}", p);
+            }
+            // Sometimes there can be a timeout on the connection so instead of unwrapping return
+            // an Option<Packet>
+            // p.unwrap()
         })
-        .await
-        .unwrap();
+        .await;
 
-        self.incoming.pop_front().unwrap()
+        self.incoming.pop_front()
     }
 
     /// Reads next packet from the stream

--- a/rumqttc/tests/reliability.rs
+++ b/rumqttc/tests/reliability.rs
@@ -528,7 +528,9 @@ async fn reconnection_resends_unacked_packets_from_the_previous_connection_first
 async fn state_is_being_cleaned_properly_and_pending_request_calculated_properly() {
     let mut options = MqttOptions::new("dummy", "127.0.0.1", 3004);
     options.set_keep_alive(Duration::from_secs(5));
-    options.set_network_option(NetworkOptions::new(1024));
+    let mut network_option = NetworkOptions::new();
+    network_option.set_tcp_send_buffer_size(1024);
+    options.set_network_option(network_option);
 
     let (client, mut eventloop) = AsyncClient::new(options, 5);
     task::spawn(async move {
@@ -549,7 +551,6 @@ async fn state_is_being_cleaned_properly_and_pending_request_calculated_properly
             match e {
                 ConnectionError::Timeout(_) => {
                     assert!(eventloop.state.write.is_empty());
-                    assert!(eventloop.state.events.is_empty());
                     println!("State is being clean properly");
                 }
                 _ => {

--- a/rumqttc/tests/reliability.rs
+++ b/rumqttc/tests/reliability.rs
@@ -78,8 +78,7 @@ async fn connection_should_timeout_on_time() {
 
     time::sleep(Duration::from_secs(1)).await;
     let options = MqttOptions::new("dummy", "127.0.0.1", 1880);
-    let network_options = NetworkOptions::new();
-    let mut eventloop = EventLoop::new(options, network_options, 5);
+    let mut eventloop = EventLoop::new(options, 5);
 
     let start = Instant::now();
     let o = eventloop.poll().await;
@@ -103,8 +102,7 @@ async fn idle_connection_triggers_pings_on_time() {
 
     // Create client eventloop and poll
     task::spawn(async move {
-        let network_options = NetworkOptions::new();
-        let mut eventloop = EventLoop::new(options, network_options, 5);
+        let mut eventloop = EventLoop::new(options, 5);
         run(&mut eventloop, false).await.unwrap();
     });
 
@@ -183,8 +181,7 @@ async fn some_incoming_and_no_outgoing_should_trigger_pings_on_time() {
     options.set_keep_alive(Duration::from_secs(keep_alive));
 
     task::spawn(async move {
-        let network_options = NetworkOptions::new();
-        let mut eventloop = EventLoop::new(options, network_options, 5);
+        let mut eventloop = EventLoop::new(options, 5);
         run(&mut eventloop, false).await.unwrap();
     });
 
@@ -228,8 +225,7 @@ async fn detects_halfopen_connections_in_the_second_ping_request() {
 
     time::sleep(Duration::from_secs(1)).await;
     let start = Instant::now();
-    let network_options = NetworkOptions::new();
-    let mut eventloop = EventLoop::new(options, network_options, 5);
+    let mut eventloop = EventLoop::new(options, 5);
     loop {
         if let Err(e) = eventloop.poll().await {
             match e {
@@ -440,8 +436,7 @@ async fn next_poll_after_connect_failure_reconnects() {
     });
 
     time::sleep(Duration::from_secs(1)).await;
-    let network_options = NetworkOptions::new();
-    let mut eventloop = EventLoop::new(options, network_options, 5);
+    let mut eventloop = EventLoop::new(options, 5);
 
     match eventloop.poll().await {
         Err(ConnectionError::ConnectionRefused(ConnectReturnCode::BadUserNamePassword)) => (),
@@ -538,7 +533,7 @@ async fn state_is_being_cleaned_properly_and_pending_request_calculated_properly
     network_options.set_tcp_send_buffer_size(1024);
 
     let (client, mut eventloop) = AsyncClient::new(options, 5);
-    eventloop.network_options = network_options;
+    eventloop.set_network_options(network_options);
     task::spawn(async move {
         start_requests_with_payload(100, QoS::AtLeastOnce, 0, client, 5000).await;
         time::sleep(Duration::from_secs(10)).await;

--- a/rumqttc/tests/reliability.rs
+++ b/rumqttc/tests/reliability.rs
@@ -526,8 +526,9 @@ async fn reconnection_resends_unacked_packets_from_the_previous_connection_first
 
 #[tokio::test]
 async fn state_is_being_cleaned_properly_and_pending_request_calculated_properly() {
-    let mut options = MqttOptions::new("dummy", "127.0.0.1", 3002);
+    let mut options = MqttOptions::new("dummy", "127.0.0.1", 3004);
     options.set_keep_alive(Duration::from_secs(5));
+    options.set_network_option(NetworkOptions::new(1024));
 
     let (client, mut eventloop) = AsyncClient::new(options, 5);
     task::spawn(async move {
@@ -536,7 +537,7 @@ async fn state_is_being_cleaned_properly_and_pending_request_calculated_properly
     });
 
     task::spawn(async move {
-        let mut broker = Broker::new(3002, 0).await;
+        let mut broker = Broker::new(3004, 0).await;
         while let Some(_) = broker.read_packet().await {
             time::sleep(Duration::from_secs_f64(0.5)).await;
         }


### PR DESCRIPTION
changes made:
- connection_timeout is moved to `NetworkOptions`
- connection_timeout is removed from `Url` feature.
- `ConnectionError` now has specific variant for type of Timeout, `FlushTimeout` and `NetworkTimeout` instead of generic `Timeout` for both.