### PR TITLE
build: use stable release of rustls-pemfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,7 +1995,7 @@ dependencies = [
  "pretty_env_logger",
  "rustls",
  "rustls-native-certs",
- "rustls-pemfile 0.3.0",
+ "rustls-pemfile",
  "serde",
  "thiserror",
  "tokio",
@@ -2020,7 +2020,7 @@ dependencies = [
  "pretty_assertions",
  "pretty_env_logger",
  "rouille",
- "rustls-pemfile 0.3.0",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "slab",
@@ -2090,18 +2090,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.1",
+ "rustls-pemfile",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
-dependencies = [
- "base64",
 ]
 
 [[package]]

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -31,7 +31,7 @@ thiserror = "1"
 # Optional
 # rustls
 tokio-rustls = { version = "0.23", optional = true }
-rustls-pemfile = { version = "0.3", optional = true }
+rustls-pemfile = { version = "1", optional = true }
 rustls-native-certs = { version = "0.6", optional = true }
 # websockets
 async-tungstenite = { version = "0.16", default-features = false, features = ["tokio-rustls-native-certs"], optional = true }

--- a/rumqttd/Cargo.toml
+++ b/rumqttd/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "1.0.24"
 tokio-util = { version = "0.7", features = ["codec"], optional = true }
 tokio-rustls =  { version = "0.23.0", optional = true }
 tokio-native-tls = { version = "0.3", optional = true }
-rustls-pemfile = { version = "0.3.0", optional = true }
+rustls-pemfile = { version = "1", optional = true }
 tokio-tungstenite = { version = "0.15.0", optional = true }
 websocket-codec = { version = "0.5.1", optional = true }
 rouille = "3.1.1"


### PR DESCRIPTION
The [release history](https://github.com/rustls/pemfile#release-history) states no API changes. Using the current stable release means getting all the bugfixes.

As currently both `0.3` and `1` are used both dependencies are built when using rumqttc. Without `0.3` only `1` will be built, removing `0.3` from the lock file.

Other dependencies are also not the latest version but I havnt looked into them.