### PR TITLE
refactor: custom `NetworkError` and move code into relevant modules

### DIFF
--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -1,10 +1,3 @@
-use crate::framed::{Network, NetworkError};
-#[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]
-use crate::tls;
-use crate::{Incoming, MqttState, NetworkOptions, Packet, Request, StateError, Transport};
-use crate::{MqttOptions, Outgoing};
-
-use crate::mqttbytes::v4::*;
 #[cfg(feature = "websocket")]
 use async_tungstenite::tokio::connect_async;
 #[cfg(all(feature = "use-rustls", feature = "websocket"))]
@@ -18,13 +11,16 @@ use tokio::time::{self, Instant, Sleep};
 #[cfg(feature = "websocket")]
 use ws_stream_tungstenite::WsStream;
 
-use std::io;
-use std::net::SocketAddr;
 #[cfg(unix)]
 use std::path::Path;
-use std::pin::Pin;
-use std::time::Duration;
-use std::vec::IntoIter;
+use std::{io, net::SocketAddr, pin::Pin, time::Duration, vec::IntoIter};
+
+use crate::framed::{Network, NetworkError};
+use crate::mqttbytes::v4::*;
+#[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]
+use crate::tls;
+use crate::{Incoming, MqttOptions, MqttState, NetworkOptions, Outgoing, Packet};
+use crate::{Request, StateError, Transport};
 
 /// Critical errors during eventloop polling
 #[derive(Debug, thiserror::Error)]

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -27,8 +27,8 @@ use crate::{Request, StateError, Transport};
 pub enum ConnectionError {
     #[error("Mqtt state: {0}")]
     MqttState(#[from] StateError),
-    #[error("Network timeout")]
-    NetworkTimeout,
+    #[error("Connect timeout")]
+    ConnectTimeout,
     #[cfg(feature = "websocket")]
     #[error("Websocket: {0}")]
     Websocket(#[from] async_tungstenite::tungstenite::error::Error),
@@ -120,7 +120,7 @@ impl EventLoop {
             .await
             {
                 Ok(inner) => inner?,
-                Err(_) => return Err(ConnectionError::NetworkTimeout),
+                Err(_) => return Err(ConnectionError::ConnectTimeout),
             };
             self.network = Some(network);
 

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -112,21 +112,21 @@ mod state;
 mod tls;
 pub mod v5;
 
-pub use client::{
-    AsyncClient, Client, ClientError, Connection, Iter, RecvError, RecvTimeoutError, TryRecvError,
-};
-pub use eventloop::{ConnectionError, Event, EventLoop};
-pub use mqttbytes::v4::*;
-pub use mqttbytes::*;
 #[cfg(feature = "use-rustls")]
 use rustls_native_certs::load_native_certs;
-pub use state::{MqttState, StateError};
-#[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]
-pub use tls::Error as TlsError;
 #[cfg(feature = "use-rustls")]
 pub use tokio_rustls;
 #[cfg(feature = "use-rustls")]
 use tokio_rustls::rustls::{Certificate, ClientConfig, RootCertStore};
+
+pub use client::{AsyncClient, Client, ClientError, Connection, Iter};
+pub use client::{RecvError, RecvTimeoutError, TryRecvError};
+pub use eventloop::{ConnectionError, Event, EventLoop};
+pub use framed::NetworkError;
+pub use mqttbytes::{v4::*, *};
+pub use state::{MqttState, StateError};
+#[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]
+pub use tls::Error as TlsError;
 
 pub type Incoming = Packet;
 

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -1,12 +1,11 @@
-use crate::{Event, Incoming, Outgoing, Request};
-
-use crate::mqttbytes::v4::*;
-use crate::mqttbytes::{self, *};
 use bytes::BytesMut;
+
 use std::collections::VecDeque;
 use std::{io, time::Instant};
 
 use crate::framed::{Network, NetworkError};
+use crate::mqttbytes::{self, v4::*, *};
+use crate::{Event, Incoming, Outgoing, Request};
 
 /// Errors during state handling
 #[derive(Debug, thiserror::Error)]

--- a/rumqttc/tests/reliability.rs
+++ b/rumqttc/tests/reliability.rs
@@ -550,7 +550,7 @@ async fn state_is_being_cleaned_properly_and_pending_request_calculated_properly
         let res = run(&mut eventloop, false).await;
         if let Err(e) = res {
             match e {
-                ConnectionError::FlushTimeout => {
+                ConnectionError::Network(NetworkError::FlushTimeout) => {
                     assert!(eventloop.state.write.is_empty());
                     println!("State is being clean properly");
                 }

--- a/rumqttc/tests/reliability.rs
+++ b/rumqttc/tests/reliability.rs
@@ -85,7 +85,7 @@ async fn connection_should_timeout_on_time() {
     let elapsed = start.elapsed();
 
     dbg!(&o);
-    assert_matches!(o, Err(ConnectionError::NetworkTimeout));
+    assert_matches!(o, Err(ConnectionError::ConnectTimeout));
     assert_eq!(elapsed.as_secs(), 5);
 }
 


### PR DESCRIPTION
### Changes
- Create custom `NetworkError` type
- Move `readb` from `Network` into `MqttState`
- Move timeouts into `Network::flush()`
- Reorganize imports