### PR TITLE
feat: rumqttc Made it possible to convert async MQTT client to sync client using Client::new_from_async

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `NetworkOptions` added to provide a way to configure low level network configurations (#545)
+- Added `Client::new_from_async` to make it possible to convert from `AsyncClient` to `Client`
 
 ### Changed
 - `options` in `Eventloop` now is called `mqtt_options` (#545)

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -245,7 +245,11 @@ impl Client {
     /// `cap` specifies the capacity of the bounded async channel.
     pub fn new(options: MqttOptions, cap: usize) -> (Client, Connection) {
         let (client, eventloop) = AsyncClient::new(options, cap);
-        let client = Client { client };
+        Self::new_from_async(client, eventloop)
+    }
+
+    pub fn new_from_async(async_client: AsyncClient, eventloop: EventLoop) -> (Client, Connection) {
+        let client = Client { client: async_client };
         let runtime = runtime::Builder::new_current_thread()
             .enable_all()
             .build()

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -249,7 +249,9 @@ impl Client {
     }
 
     pub fn new_from_async(async_client: AsyncClient, eventloop: EventLoop) -> (Client, Connection) {
-        let client = Client { client: async_client };
+        let client = Client {
+            client: async_client,
+        };
         let runtime = runtime::Builder::new_current_thread()
             .enable_all()
             .build()

--- a/rumqttd/src/link/mod.rs
+++ b/rumqttd/src/link/mod.rs
@@ -8,4 +8,3 @@ pub mod remote;
 #[cfg(feature = "websockets")]
 pub mod shadow;
 pub mod timer;
-


### PR DESCRIPTION
In some cases it is useful to convert an AsyncClient to a sync Client - e.g. to keep the code DRY. This PR makes this possible

Signed off: Thomas Weyn

Attribute: Thomas Weyn