### PR TITLE
fix: remove unnecessary box

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Remove `Box` on `Event::Incoming`
 
 ### Deprecated
 

--- a/rumqttc/examples/async_manual_acks_v5.rs
+++ b/rumqttc/examples/async_manual_acks_v5.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         println!("{event:?}");
 
         if let Event::Incoming(packet) = event {
-            let publish = match *packet {
+            let publish = match packet {
                 Packet::Publish(publish, _) => publish,
                 _ => continue,
             };

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -73,7 +73,7 @@ pub struct EventLoop {
 /// Events which can be yielded by the event loop
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Event {
-    Incoming(Box<Incoming>),
+    Incoming(Incoming),
     Outgoing(Outgoing),
 }
 
@@ -124,7 +124,7 @@ impl EventLoop {
                 self.keepalive_timeout = Some(Box::pin(time::sleep(self.options.keep_alive)));
             }
 
-            return Ok(Event::Incoming(Box::new(connack)));
+            return Ok(Event::Incoming(connack));
         }
 
         match self.select().await {

--- a/rumqttc/src/v5/state.rs
+++ b/rumqttc/src/v5/state.rs
@@ -175,7 +175,7 @@ impl MqttState {
         };
 
         out?;
-        self.events.push_back(Event::Incoming(Box::new(packet)));
+        self.events.push_back(Event::Incoming(packet));
         self.last_incoming = Instant::now();
         Ok(())
     }

--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -145,8 +145,10 @@ impl ConsoleSettings {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Default)]
 pub enum Transport {
     #[serde(rename = "tcp")]
+    #[default]
     Tcp,
     #[serde(rename = "tls")]
     Tls {
@@ -155,11 +157,7 @@ pub enum Transport {
     },
 }
 
-impl Default for Transport {
-    fn default() -> Self {
-        Transport::Tcp
-    }
-}
+
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ClientAuth {


### PR DESCRIPTION
Please read `CONTRIBUTING.md` if you are contributing for the first time.

# Description

Remove use of box for enclosing `Incoming` in `mod v5`

Fixes #581 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md`.
