### PR TITLE
feat(prometheus): add a field in config file to specify listen socket address

### DIFF
--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -8,10 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `PrometheusSetting` now takes `listen` to specify listener address instead of default `127.0.0.1`. Do not use `listen` and `port` together.
 
 ### Changed
 
 ### Deprecated
+- `PrometheusSetting`'s `port` will be removed in favour of `listen`.
 
 ### Removed
 

--- a/rumqttd/rumqttd.toml
+++ b/rumqttd/rumqttd.toml
@@ -79,7 +79,7 @@ next_connection_delay_ms = 1
     max_inflight_size = 1024
 
 [prometheus]
-port = 9042
+listen = "127.0.0.1:9042"
 interval = 1
 
 [ws]

--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -54,7 +54,9 @@ pub struct Config {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PrometheusSetting {
-    port: u16,
+    #[deprecated(note = "Use listen instead")]
+    port: Option<u16>,
+    listen: Option<SocketAddr>,
     // How frequently to update metrics
     interval: u64,
 }
@@ -144,8 +146,7 @@ impl ConsoleSettings {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[derive(Default)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub enum Transport {
     #[serde(rename = "tcp")]
     #[default]
@@ -156,8 +157,6 @@ pub enum Transport {
         client_auth: Option<ClientAuth>,
     },
 }
-
-
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ClientAuth {

--- a/rumqttd/src/link/mod.rs
+++ b/rumqttd/src/link/mod.rs
@@ -8,4 +8,3 @@ pub mod remote;
 #[cfg(feature = "websockets")]
 pub mod shadow;
 pub mod timer;
-


### PR DESCRIPTION
# Description

- When `port` is specified `listen` is ignored.
- When both are not specific default socket address used is `127.0.0.1:9042`
- `port` is deprecated and will be removed in future breaking release.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md`.
