### PR TITLE
feat: allow sync/async requests with `Client`

### DIFF
--- a/benchmarks/clients/rumqttasync.rs
+++ b/benchmarks/clients/rumqttasync.rs
@@ -1,4 +1,4 @@
-use rumqttc::{AsyncClient, Event, Incoming, MqttOptions, QoS};
+use rumqttc::{Client, Event, Incoming, MqttOptions, QoS};
 
 use std::error::Error;
 use std::time::{Duration, Instant};
@@ -21,7 +21,7 @@ pub async fn start(id: &str, payload_size: usize, count: usize) -> Result<(), Bo
     mqttoptions.set_keep_alive(Duration::from_secs(20));
     mqttoptions.set_inflight(100);
 
-    let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    let (client, mut eventloop) = Client::new(mqttoptions, 10);
     task::spawn(async move {
         for _i in 0..count {
             let payload = vec![0; payload_size];

--- a/benchmarks/clients/rumqttasyncqos0.rs
+++ b/benchmarks/clients/rumqttasyncqos0.rs
@@ -1,4 +1,4 @@
-use rumqttc::{AsyncClient, Event, Incoming, MqttOptions, QoS};
+use rumqttc::{Client, Event, Incoming, MqttOptions, QoS};
 
 use std::error::Error;
 use std::time::{Duration, Instant};
@@ -21,7 +21,7 @@ pub async fn start(id: &str, payload_size: usize, count: usize) -> Result<(), Bo
     mqttoptions.set_keep_alive(Duration::from_secs(20));
     mqttoptions.set_inflight(100);
 
-    let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    let (client, mut eventloop) = Client::new(mqttoptions, 10);
     task::spawn(async move {
         for _i in 0..count {
             let payload = vec![0; payload_size];

--- a/benchmarks/clients/rumqttsync.rs
+++ b/benchmarks/clients/rumqttsync.rs
@@ -17,13 +17,14 @@ pub fn start(id: &str, payload_size: usize, count: usize) -> Result<(), Box<dyn 
     mqttoptions.set_keep_alive(Duration::from_secs(20));
     mqttoptions.set_inflight(100);
 
-    let (mut client, mut connection) = Client::new(mqttoptions, 10);
+    let (client, eventloop) = Client::new(mqttoptions, 10);
+    let mut connection = eventloop.sync();
     thread::spawn(move || {
         for _i in 0..count {
             let payload = vec![0; payload_size];
             let qos = QoS::AtLeastOnce;
             let topic = "hello/benchmarks/world";
-            client.publish(topic, qos, false, payload).unwrap();
+            client.publish_sync(topic, qos, false, payload).unwrap();
         }
 
         thread::sleep(Duration::from_secs(1));

--- a/rumqttc/examples/async_manual_acks.rs
+++ b/rumqttc/examples/async_manual_acks.rs
@@ -1,17 +1,17 @@
 use tokio::{task, time};
 
-use rumqttc::{self, AsyncClient, Event, EventLoop, Incoming, MqttOptions, QoS};
+use rumqttc::{self, Client, Event, EventLoop, Incoming, MqttOptions, QoS};
 use std::error::Error;
 use std::time::Duration;
 
-fn create_conn() -> (AsyncClient, EventLoop) {
+fn create_conn() -> (Client, EventLoop) {
     let mut mqttoptions = MqttOptions::new("test-1", "localhost", 1883);
     mqttoptions
         .set_keep_alive(Duration::from_secs(5))
         .set_manual_acks(true)
         .set_clean_session(false);
 
-    AsyncClient::new(mqttoptions, 10)
+    Client::new(mqttoptions, 10)
 }
 
 #[tokio::main(worker_threads = 1)]
@@ -78,7 +78,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 }
 
-async fn requests(client: AsyncClient) {
+async fn requests(client: Client) {
     for i in 1..=10 {
         client
             .publish("hello/world", QoS::AtLeastOnce, false, vec![1; i])

--- a/rumqttc/examples/asyncpubsub.rs
+++ b/rumqttc/examples/asyncpubsub.rs
@@ -1,6 +1,6 @@
 use tokio::{task, time};
 
-use rumqttc::{self, AsyncClient, MqttOptions, QoS};
+use rumqttc::{self, Client, MqttOptions, QoS};
 use std::error::Error;
 use std::time::Duration;
 
@@ -12,7 +12,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut mqttoptions = MqttOptions::new("test-1", "localhost", 1883);
     mqttoptions.set_keep_alive(Duration::from_secs(5));
 
-    let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    let (client, mut eventloop) = Client::new(mqttoptions, 10);
     task::spawn(async move {
         requests(client).await;
         time::sleep(Duration::from_secs(3)).await;
@@ -32,7 +32,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 }
 
-async fn requests(client: AsyncClient) {
+async fn requests(client: Client) {
     client
         .subscribe("hello/world", QoS::AtMostOnce)
         .await

--- a/rumqttc/examples/syncpubsub.rs
+++ b/rumqttc/examples/syncpubsub.rs
@@ -11,7 +11,8 @@ fn main() {
         .set_keep_alive(Duration::from_secs(5))
         .set_last_will(will);
 
-    let (client, mut connection) = Client::new(mqttoptions, 10);
+    let (client, eventloop) = Client::new(mqttoptions, 10);
+    let mut connection = eventloop.sync();
     thread::spawn(move || publish(client));
 
     for (i, notification) in connection.iter().enumerate() {
@@ -29,15 +30,17 @@ fn main() {
     println!("Done with the stream!!");
 }
 
-fn publish(mut client: Client) {
+fn publish(client: Client) {
     thread::sleep(Duration::from_secs(1));
-    client.subscribe("hello/+/world", QoS::AtMostOnce).unwrap();
+    client
+        .subscribe_sync("hello/+/world", QoS::AtMostOnce)
+        .unwrap();
     for i in 0..10_usize {
         let payload = vec![1; i];
         let topic = format!("hello/{i}/world");
         let qos = QoS::AtLeastOnce;
 
-        client.publish(topic, qos, true, payload).unwrap();
+        client.publish_sync(topic, qos, true, payload).unwrap();
     }
 
     thread::sleep(Duration::from_secs(1));

--- a/rumqttc/examples/tls.rs
+++ b/rumqttc/examples/tls.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 #[cfg(feature = "use-rustls")]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    use rumqttc::{self, AsyncClient, Event, Incoming, MqttOptions, Transport};
+    use rumqttc::{self, Client, Event, Incoming, MqttOptions, Transport};
     use rustls::ClientConfig;
 
     pretty_env_logger::init();
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     mqttoptions.set_transport(Transport::tls_with_config(client_config.into()));
 
-    let (_client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    let (_client, mut eventloop) = Client::new(mqttoptions, 10);
 
     loop {
         match eventloop.poll().await {

--- a/rumqttc/examples/tls2.rs
+++ b/rumqttc/examples/tls2.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 #[cfg(feature = "use-rustls")]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    use rumqttc::{self, AsyncClient, Key, MqttOptions, TlsConfiguration, Transport};
+    use rumqttc::{self, Client, Key, MqttOptions, TlsConfiguration, Transport};
 
     pretty_env_logger::init();
     color_backtrace::install();
@@ -28,7 +28,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     mqttoptions.set_transport(transport);
 
-    let (_client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    let (_client, mut eventloop) = Client::new(mqttoptions, 10);
 
     loop {
         match eventloop.poll().await {

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -1,15 +1,9 @@
-//! This module offers a high level synchronous and asynchronous abstraction to
-//! async eventloop.
-use std::time::Duration;
-
+//! This module offers a high level abstraction to communicate with the `EventLoop`.
 use crate::mqttbytes::{v4::*, QoS};
-use crate::{valid_topic, ConnectionError, Event, EventLoop, MqttOptions, Request};
+use crate::{valid_topic, EventLoop, MqttOptions, Request};
 
 use bytes::Bytes;
 use flume::{SendError, Sender, TrySendError};
-use futures::FutureExt;
-use tokio::runtime::{self, Runtime};
-use tokio::time::timeout;
 
 /// Client Error
 #[derive(Debug, thiserror::Error)]
@@ -34,33 +28,48 @@ impl From<TrySendError<Request>> for ClientError {
 
 /// An asynchronous client, communicates with MQTT `EventLoop`.
 ///
-/// This is cloneable and can be used to asynchronously [`publish`](`AsyncClient::publish`),
-/// [`subscribe`](`AsyncClient::subscribe`) through the `EventLoop`, which is to be polled parallelly.
-///
-/// **NOTE**: The `EventLoop` must be regularly polled in order to send, receive and process packets
-/// from the broker, i.e. move ahead.
+/// This is cloneable and can be used to send [`publish`](`Client::publish`), [`subscribe`](`Client::subscribe`),
+/// [`unsubscribe`](`Client::unsubscribe`) through the `EventLoop`/`Connection`, which is to be polled parallelly.
 #[derive(Clone, Debug)]
-pub struct AsyncClient {
+pub struct Client {
     request_tx: Sender<Request>,
 }
 
-impl AsyncClient {
-    /// Create a new `AsyncClient`.
+impl Client {
+    /// Construct a Client and `EventLoop`.
     ///
     /// `cap` specifies the capacity of the bounded async channel.
-    pub fn new(options: MqttOptions, cap: usize) -> (AsyncClient, EventLoop) {
+    ///
+    /// **NOTE**: The `EventLoop` must be regularly polled in order to send, receive and process packets
+    /// from the broker, i.e. move ahead.
+    pub fn new(options: MqttOptions, cap: usize) -> (Client, EventLoop) {
         let eventloop = EventLoop::new(options, cap);
         let request_tx = eventloop.requests_tx.clone();
 
-        let client = AsyncClient { request_tx };
+        let client = Client { request_tx };
 
         (client, eventloop)
     }
 
-    /// Create a new `AsyncClient` from a pair of async channel `Sender`s. This is mostly useful for
+    /// Create a new `Client` from a pair of async channel `Sender`s. This is mostly useful for
     /// creating a test instance.
-    pub fn from_senders(request_tx: Sender<Request>) -> AsyncClient {
-        AsyncClient { request_tx }
+    pub fn from_senders(request_tx: Sender<Request>) -> Client {
+        Client { request_tx }
+    }
+
+    pub fn send(&self, request: Request) -> Result<(), ClientError> {
+        self.request_tx.send(request)?;
+        Ok(())
+    }
+
+    pub async fn send_async(&self, request: Request) -> Result<(), ClientError> {
+        self.request_tx.send_async(request).await?;
+        Ok(())
+    }
+
+    pub fn try_send(&self, request: Request) -> Result<(), ClientError> {
+        self.request_tx.try_send(request)?;
+        Ok(())
     }
 
     /// Sends a MQTT Publish to the `EventLoop`.
@@ -82,7 +91,30 @@ impl AsyncClient {
         if !valid_topic(&topic) {
             return Err(ClientError::Request(publish));
         }
-        self.request_tx.send_async(publish).await?;
+        self.send_async(publish).await?;
+        Ok(())
+    }
+
+    /// Sends a MQTT Publish to the `EventLoop`.
+    pub fn publish_sync<S, V>(
+        &self,
+        topic: S,
+        qos: QoS,
+        retain: bool,
+        payload: V,
+    ) -> Result<(), ClientError>
+    where
+        S: Into<String>,
+        V: Into<Vec<u8>>,
+    {
+        let topic = topic.into();
+        let mut publish = Publish::new(&topic, qos, payload);
+        publish.retain = retain;
+        let publish = Request::Publish(publish);
+        if !valid_topic(&topic) {
+            return Err(ClientError::Request(publish));
+        }
+        self.send(publish)?;
         Ok(())
     }
 
@@ -105,7 +137,7 @@ impl AsyncClient {
         if !valid_topic(&topic) {
             return Err(ClientError::TryRequest(publish));
         }
-        self.request_tx.try_send(publish)?;
+        self.try_send(publish)?;
         Ok(())
     }
 
@@ -114,7 +146,17 @@ impl AsyncClient {
         let ack = get_ack_req(publish);
 
         if let Some(ack) = ack {
-            self.request_tx.send_async(ack).await?;
+            self.send_async(ack).await?;
+        }
+        Ok(())
+    }
+
+    /// Sends a MQTT PubAck to the `EventLoop`. Only needed in if `manual_acks` flag is set.
+    pub fn ack_sync(&self, publish: &Publish) -> Result<(), ClientError> {
+        let ack = get_ack_req(publish);
+
+        if let Some(ack) = ack {
+            self.send(ack)?;
         }
         Ok(())
     }
@@ -123,7 +165,7 @@ impl AsyncClient {
     pub fn try_ack(&self, publish: &Publish) -> Result<(), ClientError> {
         let ack = get_ack_req(publish);
         if let Some(ack) = ack {
-            self.request_tx.try_send(ack)?;
+            self.try_send(ack)?;
         }
         Ok(())
     }
@@ -142,7 +184,7 @@ impl AsyncClient {
         let mut publish = Publish::from_bytes(topic, qos, payload);
         publish.retain = retain;
         let publish = Request::Publish(publish);
-        self.request_tx.send_async(publish).await?;
+        self.send_async(publish).await?;
         Ok(())
     }
 
@@ -150,7 +192,15 @@ impl AsyncClient {
     pub async fn subscribe<S: Into<String>>(&self, topic: S, qos: QoS) -> Result<(), ClientError> {
         let subscribe = Subscribe::new(topic.into(), qos);
         let request = Request::Subscribe(subscribe);
-        self.request_tx.send_async(request).await?;
+        self.send_async(request).await?;
+        Ok(())
+    }
+
+    /// Sends a MQTT Subscribe to the `EventLoop`
+    pub fn subscribe_sync<S: Into<String>>(&self, topic: S, qos: QoS) -> Result<(), ClientError> {
+        let subscribe = Subscribe::new(topic.into(), qos);
+        let request = Request::Subscribe(subscribe);
+        self.send(request)?;
         Ok(())
     }
 
@@ -158,7 +208,7 @@ impl AsyncClient {
     pub fn try_subscribe<S: Into<String>>(&self, topic: S, qos: QoS) -> Result<(), ClientError> {
         let subscribe = Subscribe::new(topic.into(), qos);
         let request = Request::Subscribe(subscribe);
-        self.request_tx.try_send(request)?;
+        self.try_send(request)?;
         Ok(())
     }
 
@@ -169,7 +219,18 @@ impl AsyncClient {
     {
         let subscribe = Subscribe::new_many(topics);
         let request = Request::Subscribe(subscribe);
-        self.request_tx.send_async(request).await?;
+        self.send_async(request).await?;
+        Ok(())
+    }
+
+    /// Sends a MQTT Subscribe for multiple topics to the `EventLoop`
+    pub fn subscribe_many_sync<T>(&self, topics: T) -> Result<(), ClientError>
+    where
+        T: IntoIterator<Item = SubscribeFilter>,
+    {
+        let subscribe = Subscribe::new_many(topics);
+        let request = Request::Subscribe(subscribe);
+        self.send(request)?;
         Ok(())
     }
 
@@ -180,7 +241,7 @@ impl AsyncClient {
     {
         let subscribe = Subscribe::new_many(topics);
         let request = Request::Subscribe(subscribe);
-        self.request_tx.try_send(request)?;
+        self.try_send(request)?;
         Ok(())
     }
 
@@ -188,7 +249,15 @@ impl AsyncClient {
     pub async fn unsubscribe<S: Into<String>>(&self, topic: S) -> Result<(), ClientError> {
         let unsubscribe = Unsubscribe::new(topic.into());
         let request = Request::Unsubscribe(unsubscribe);
-        self.request_tx.send_async(request).await?;
+        self.send_async(request).await?;
+        Ok(())
+    }
+
+    /// Sends a MQTT Unsubscribe to the `EventLoop`
+    pub fn unsubscribe_sync<S: Into<String>>(&self, topic: S) -> Result<(), ClientError> {
+        let unsubscribe = Unsubscribe::new(topic.into());
+        let request = Request::Unsubscribe(unsubscribe);
+        self.send(request)?;
         Ok(())
     }
 
@@ -196,21 +265,28 @@ impl AsyncClient {
     pub fn try_unsubscribe<S: Into<String>>(&self, topic: S) -> Result<(), ClientError> {
         let unsubscribe = Unsubscribe::new(topic.into());
         let request = Request::Unsubscribe(unsubscribe);
-        self.request_tx.try_send(request)?;
+        self.try_send(request)?;
         Ok(())
     }
 
     /// Sends a MQTT disconnect to the `EventLoop`
     pub async fn disconnect(&self) -> Result<(), ClientError> {
         let request = Request::Disconnect;
-        self.request_tx.send_async(request).await?;
+        self.send_async(request).await?;
+        Ok(())
+    }
+
+    /// Sends a MQTT disconnect to the `EventLoop`
+    pub fn disconnect_sync(&self) -> Result<(), ClientError> {
+        let request = Request::Disconnect;
+        self.send(request)?;
         Ok(())
     }
 
     /// Attempts to send a MQTT disconnect to the `EventLoop`
     pub fn try_disconnect(&self) -> Result<(), ClientError> {
         let request = Request::Disconnect;
-        self.request_tx.try_send(request)?;
+        self.try_send(request)?;
         Ok(())
     }
 }
@@ -222,266 +298,6 @@ fn get_ack_req(publish: &Publish) -> Option<Request> {
         QoS::ExactlyOnce => Request::PubRec(PubRec::new(publish.pkid)),
     };
     Some(ack)
-}
-
-/// A synchronous client, communicates with MQTT `EventLoop`.
-///
-/// This is cloneable and can be used to synchronously [`publish`](`AsyncClient::publish`),
-/// [`subscribe`](`AsyncClient::subscribe`) through the `EventLoop`/`Connection`, which is to be polled in parallel
-/// by iterating over the object returned by [`Connection.iter()`](Connection::iter) in a separate thread.
-///
-/// **NOTE**: The `EventLoop`/`Connection` must be regularly polled(`.next()` in case of `Connection`) in order
-/// to send, receive and process packets from the broker, i.e. move ahead.
-///
-/// An asynchronous channel handle can also be extracted if necessary.
-#[derive(Clone)]
-pub struct Client {
-    client: AsyncClient,
-}
-
-impl Client {
-    /// Create a new `Client`
-    ///
-    /// `cap` specifies the capacity of the bounded async channel.
-    pub fn new(options: MqttOptions, cap: usize) -> (Client, Connection) {
-        let (client, eventloop) = AsyncClient::new(options, cap);
-        let client = Client { client };
-        let runtime = runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-
-        let connection = Connection::new(eventloop, runtime);
-        (client, connection)
-    }
-
-    /// Sends a MQTT Publish to the `EventLoop`
-    pub fn publish<S, V>(
-        &mut self,
-        topic: S,
-        qos: QoS,
-        retain: bool,
-        payload: V,
-    ) -> Result<(), ClientError>
-    where
-        S: Into<String>,
-        V: Into<Vec<u8>>,
-    {
-        let topic = topic.into();
-        let mut publish = Publish::new(&topic, qos, payload);
-        publish.retain = retain;
-        let publish = Request::Publish(publish);
-        if !valid_topic(&topic) {
-            return Err(ClientError::Request(publish));
-        }
-        self.client.request_tx.send(publish)?;
-        Ok(())
-    }
-
-    pub fn try_publish<S, V>(
-        &mut self,
-        topic: S,
-        qos: QoS,
-        retain: bool,
-        payload: V,
-    ) -> Result<(), ClientError>
-    where
-        S: Into<String>,
-        V: Into<Vec<u8>>,
-    {
-        self.client.try_publish(topic, qos, retain, payload)?;
-        Ok(())
-    }
-
-    /// Sends a MQTT PubAck to the `EventLoop`. Only needed in if `manual_acks` flag is set.
-    pub fn ack(&self, publish: &Publish) -> Result<(), ClientError> {
-        let ack = get_ack_req(publish);
-
-        if let Some(ack) = ack {
-            self.client.request_tx.send(ack)?;
-        }
-        Ok(())
-    }
-
-    /// Sends a MQTT PubAck to the `EventLoop`. Only needed in if `manual_acks` flag is set.
-    pub fn try_ack(&self, publish: &Publish) -> Result<(), ClientError> {
-        self.client.try_ack(publish)?;
-        Ok(())
-    }
-
-    /// Sends a MQTT Subscribe to the `EventLoop`
-    pub fn subscribe<S: Into<String>>(&mut self, topic: S, qos: QoS) -> Result<(), ClientError> {
-        let subscribe = Subscribe::new(topic.into(), qos);
-        let request = Request::Subscribe(subscribe);
-        self.client.request_tx.send(request)?;
-        Ok(())
-    }
-
-    /// Sends a MQTT Subscribe to the `EventLoop`
-    pub fn try_subscribe<S: Into<String>>(
-        &mut self,
-        topic: S,
-        qos: QoS,
-    ) -> Result<(), ClientError> {
-        self.client.try_subscribe(topic, qos)?;
-        Ok(())
-    }
-
-    /// Sends a MQTT Subscribe for multiple topics to the `EventLoop`
-    pub fn subscribe_many<T>(&mut self, topics: T) -> Result<(), ClientError>
-    where
-        T: IntoIterator<Item = SubscribeFilter>,
-    {
-        let subscribe = Subscribe::new_many(topics);
-        let request = Request::Subscribe(subscribe);
-        self.client.request_tx.send(request)?;
-        Ok(())
-    }
-
-    pub fn try_subscribe_many<T>(&mut self, topics: T) -> Result<(), ClientError>
-    where
-        T: IntoIterator<Item = SubscribeFilter>,
-    {
-        self.client.try_subscribe_many(topics)
-    }
-
-    /// Sends a MQTT Unsubscribe to the `EventLoop`
-    pub fn unsubscribe<S: Into<String>>(&mut self, topic: S) -> Result<(), ClientError> {
-        let unsubscribe = Unsubscribe::new(topic.into());
-        let request = Request::Unsubscribe(unsubscribe);
-        self.client.request_tx.send(request)?;
-        Ok(())
-    }
-
-    /// Sends a MQTT Unsubscribe to the `EventLoop`
-    pub fn try_unsubscribe<S: Into<String>>(&mut self, topic: S) -> Result<(), ClientError> {
-        self.client.try_unsubscribe(topic)?;
-        Ok(())
-    }
-
-    /// Sends a MQTT disconnect to the `EventLoop`
-    pub fn disconnect(&mut self) -> Result<(), ClientError> {
-        let request = Request::Disconnect;
-        self.client.request_tx.send(request)?;
-        Ok(())
-    }
-
-    /// Sends a MQTT disconnect to the `EventLoop`
-    pub fn try_disconnect(&mut self) -> Result<(), ClientError> {
-        self.client.try_disconnect()?;
-        Ok(())
-    }
-}
-
-/// Error type returned by [`Connection::recv`]
-#[derive(Debug, Eq, PartialEq)]
-pub struct RecvError;
-
-/// Error type returned by [`Connection::try_recv`]
-#[derive(Debug, Eq, PartialEq)]
-pub enum TryRecvError {
-    /// User has closed requests channel
-    Disconnected,
-    /// Did not resolve
-    Empty,
-}
-
-/// Error type returned by [`Connection::recv_timeout`]
-#[derive(Debug, Eq, PartialEq)]
-pub enum RecvTimeoutError {
-    /// User has closed requests channel
-    Disconnected,
-    /// Recv request timedout
-    Timeout,
-}
-
-///  MQTT connection. Maintains all the necessary state
-pub struct Connection {
-    pub eventloop: EventLoop,
-    runtime: Runtime,
-}
-impl Connection {
-    fn new(eventloop: EventLoop, runtime: Runtime) -> Connection {
-        Connection { eventloop, runtime }
-    }
-
-    /// Returns an iterator over this connection. Iterating over this is all that's
-    /// necessary to make connection progress and maintain a robust connection.
-    /// Just continuing to loop will reconnect
-    /// **NOTE** Don't block this while iterating
-    // ideally this should be named iter_mut because it requires a mutable reference
-    // Also we can implement IntoIter for this to make it easy to iterate over it
-    #[must_use = "Connection should be iterated over a loop to make progress"]
-    pub fn iter(&mut self) -> Iter<'_> {
-        Iter { connection: self }
-    }
-
-    /// Attempt to fetch an incoming [`Event`] on the [`EvenLoop`], returning an error
-    /// if all clients/users have closed requests channel.
-    ///
-    /// [`EvenLoop`]: super::EventLoop
-    pub fn recv(&mut self) -> Result<Result<Event, ConnectionError>, RecvError> {
-        let f = self.eventloop.poll();
-        let event = self.runtime.block_on(f);
-
-        resolve_event(event).ok_or(RecvError)
-    }
-
-    /// Attempt to fetch an incoming [`Event`] on the [`EvenLoop`], returning an error
-    /// if none immediately present or all clients/users have closed requests channel.
-    ///
-    /// [`EvenLoop`]: super::EventLoop
-    pub fn try_recv(&mut self) -> Result<Result<Event, ConnectionError>, TryRecvError> {
-        let f = self.eventloop.poll();
-        // Enters the runtime context so we can poll the future, as required by `now_or_never()`.
-        // ref: https://docs.rs/tokio/latest/tokio/runtime/struct.Runtime.html#method.enter
-        let _guard = self.runtime.enter();
-        let event = f.now_or_never().ok_or(TryRecvError::Empty)?;
-
-        resolve_event(event).ok_or(TryRecvError::Disconnected)
-    }
-
-    /// Attempt to fetch an incoming [`Event`] on the [`EvenLoop`], returning an error
-    /// if all clients/users have closed requests channel or the timeout has expired.
-    ///
-    /// [`EvenLoop`]: super::EventLoop
-    pub fn recv_timeout(
-        &mut self,
-        duration: Duration,
-    ) -> Result<Result<Event, ConnectionError>, RecvTimeoutError> {
-        let f = self.eventloop.poll();
-        let event = self
-            .runtime
-            .block_on(async { timeout(duration, f).await })
-            .map_err(|_| RecvTimeoutError::Timeout)?;
-
-        resolve_event(event).ok_or(RecvTimeoutError::Disconnected)
-    }
-}
-
-fn resolve_event(event: Result<Event, ConnectionError>) -> Option<Result<Event, ConnectionError>> {
-    match event {
-        Ok(v) => Some(Ok(v)),
-        // closing of request channel should stop the iterator
-        Err(ConnectionError::RequestsDone) => {
-            trace!("Done with requests");
-            None
-        }
-        Err(e) => Some(Err(e)),
-    }
-}
-
-/// Iterator which polls the `EventLoop` for connection progress
-pub struct Iter<'a> {
-    connection: &'a mut Connection,
-}
-
-impl Iterator for Iter<'_> {
-    type Item = Result<Event, ConnectionError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.connection.recv().ok()
-    }
 }
 
 #[cfg(test)]
@@ -498,7 +314,8 @@ mod test {
             .set_keep_alive(Duration::from_secs(5))
             .set_last_will(will);
 
-        let (_, mut connection) = Client::new(mqttoptions, 10);
+        let (_, eventloop) = Client::new(mqttoptions, 10);
+        let mut connection = eventloop.sync();
         let _ = connection.iter();
         let _ = connection.iter();
     }

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -112,10 +112,10 @@ mod state;
 mod tls;
 pub mod v5;
 
-pub use client::{
-    AsyncClient, Client, ClientError, Connection, Iter, RecvError, RecvTimeoutError, TryRecvError,
+pub use client::{Client, ClientError};
+pub use eventloop::{
+    Connection, ConnectionError, Event, EventLoop, Iter, RecvError, RecvTimeoutError, TryRecvError,
 };
-pub use eventloop::{ConnectionError, Event, EventLoop};
 pub use mqttbytes::v4::*;
 pub use mqttbytes::*;
 #[cfg(feature = "use-rustls")]

--- a/rumqttc/tests/reliability.rs
+++ b/rumqttc/tests/reliability.rs
@@ -7,7 +7,7 @@ mod broker;
 use broker::*;
 use rumqttc::*;
 
-async fn start_requests(count: u8, qos: QoS, delay: u64, client: AsyncClient) {
+async fn start_requests(count: u8, qos: QoS, delay: u64, client: Client) {
     for i in 1..=count {
         let topic = "hello/world".to_owned();
         let payload = vec![i, 1, 2, 3];
@@ -21,7 +21,7 @@ async fn start_requests_with_payload(
     count: u8,
     qos: QoS,
     delay: u64,
-    client: AsyncClient,
+    client: Client,
     payload: usize,
 ) {
     for i in 1..=count {
@@ -138,7 +138,7 @@ async fn some_outgoing_and_no_incoming_should_trigger_pings_on_time() {
 
     // start sending qos0 publishes. this makes sure that there is
     // outgoing activity but no incoming activity
-    let (client, mut eventloop) = AsyncClient::new(options, 5);
+    let (client, mut eventloop) = Client::new(options, 5);
 
     // Start sending publishes
     task::spawn(async move {
@@ -250,7 +250,7 @@ async fn requests_are_blocked_after_max_inflight_queue_size() {
 
     // start sending qos0 publishes. this makes sure that there is
     // outgoing activity but no incoming activity
-    let (client, mut eventloop) = AsyncClient::new(options, 5);
+    let (client, mut eventloop) = Client::new(options, 5);
     task::spawn(async move {
         start_requests(10, QoS::AtLeastOnce, 1, client).await;
     });
@@ -275,7 +275,7 @@ async fn requests_are_recovered_after_inflight_queue_size_falls_below_max() {
     let mut options = MqttOptions::new("dummy", "127.0.0.1", 1888);
     options.set_inflight(3);
 
-    let (client, mut eventloop) = AsyncClient::new(options, 5);
+    let (client, mut eventloop) = Client::new(options, 5);
 
     task::spawn(async move {
         start_requests(5, QoS::AtLeastOnce, 1, client).await;
@@ -314,7 +314,7 @@ async fn packet_id_collisions_are_detected_and_flow_control_is_applied() {
     let mut options = MqttOptions::new("dummy", "127.0.0.1", 1891);
     options.set_inflight(10);
 
-    let (client, mut eventloop) = AsyncClient::new(options, 5);
+    let (client, mut eventloop) = Client::new(options, 5);
 
     task::spawn(async move {
         start_requests(15, QoS::AtLeastOnce, 0, client).await;
@@ -458,7 +458,7 @@ async fn reconnection_resumes_from_the_previous_state() {
     options.set_keep_alive(Duration::from_secs(5));
 
     // start sending qos0 publishes. Makes sure that there is out activity but no in activity
-    let (client, mut eventloop) = AsyncClient::new(options, 5);
+    let (client, mut eventloop) = Client::new(options, 5);
     task::spawn(async move {
         start_requests(10, QoS::AtLeastOnce, 1, client).await;
         time::sleep(Duration::from_secs(10)).await;
@@ -499,7 +499,7 @@ async fn reconnection_resends_unacked_packets_from_the_previous_connection_first
 
     // start sending qos0 publishes. this makes sure that there is
     // outgoing activity but no incoming activity
-    let (client, mut eventloop) = AsyncClient::new(options, 5);
+    let (client, mut eventloop) = Client::new(options, 5);
     task::spawn(async move {
         start_requests(10, QoS::AtLeastOnce, 1, client).await;
         time::sleep(Duration::from_secs(10)).await;
@@ -532,7 +532,7 @@ async fn state_is_being_cleaned_properly_and_pending_request_calculated_properly
     let mut network_options = NetworkOptions::new();
     network_options.set_tcp_send_buffer_size(1024);
 
-    let (client, mut eventloop) = AsyncClient::new(options, 5);
+    let (client, mut eventloop) = Client::new(options, 5);
     eventloop.set_network_options(network_options);
     task::spawn(async move {
         start_requests_with_payload(100, QoS::AtLeastOnce, 0, client, 5000).await;


### PR DESCRIPTION
- Single `Client` replaces sync/async alternatives, add new methods and expose `send`, `send_async` and `try_send` handles to send generic requests to the `EventLoop`.
- Move `Connection` definition in with `EventLoop`, create `sync()` method to construct a `Connection` from an `EventLoop`.

<!--
Thank you for this Pull Request. Please provide a description of your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
<!-- - New feature (non-breaking change which adds functionality) -->
Breaking change (fix or feature that would cause existing functionality to not work as expected)
<!-- - Miscellaneous (related to maintanance) -->

## Checklist:

- [x] Formatted with `cargo fmt`
- [ ] Make an entry to `CHANGELOG.md` if its relevant of user of the library. If its not relevant mention why.
