### PR TITLE
Topic alias and message expiry support in broker

### DIFF
--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Support for topic alias and message expiry in v5
 
 ### Changed
 - Certificate paths configured in config file are checked during startup and throws a panic if it is not valid.

--- a/rumqttd/src/link/bridge.rs
+++ b/rumqttd/src/link/bridge.rs
@@ -59,7 +59,7 @@ where
         "Starting bridge with subscription on filter \"{}\"",
         &config.sub_path,
     );
-    let (mut tx, mut rx, _ack) = Link::new(None, &config.name, router_tx, true, None, true)?;
+    let (mut tx, mut rx, _ack) = Link::new(None, &config.name, router_tx, true, None, true, None)?;
 
     'outer: loop {
         let mut network = match network_connect(&config, &config.addr, protocol.clone()).await {

--- a/rumqttd/src/link/console.rs
+++ b/rumqttd/src/link/console.rs
@@ -23,7 +23,8 @@ impl ConsoleLink {
     /// Requires the corresponding Router to be running to complete
     pub fn new(config: ConsoleSettings, router_tx: Sender<(ConnectionId, Event)>) -> ConsoleLink {
         let tx = router_tx.clone();
-        let (link_tx, link_rx, _ack) = Link::new(None, "console", tx, true, None, true).unwrap();
+        let (link_tx, link_rx, _ack) =
+            Link::new(None, "console", tx, true, None, true, None).unwrap();
         let connection_id = link_tx.connection_id;
         ConsoleLink {
             config,

--- a/rumqttd/src/link/local.rs
+++ b/rumqttd/src/link/local.rs
@@ -123,7 +123,7 @@ impl Link {
         // Right now link identifies failure with dropped rx in router,
         // which is probably ok. We need this here to get id assigned by router
         let (id, ack) = match notification {
-            Notification::DeviceAck(Ack::ConnAck(id, ack)) => (id, ack),
+            Notification::DeviceAck(Ack::ConnAck(id, ack, _)) => (id, ack),
             _message => return Err(LinkError::NotConnectionAck),
         };
 

--- a/rumqttd/src/link/local.rs
+++ b/rumqttd/src/link/local.rs
@@ -45,6 +45,7 @@ impl Link {
         clean: bool,
         last_will: Option<LastWill>,
         dynamic_filters: bool,
+        topic_alias_max: u16,
     ) -> (
         Event,
         Arc<Mutex<VecDeque<Packet>>>,
@@ -57,6 +58,7 @@ impl Link {
             clean,
             last_will,
             dynamic_filters,
+            topic_alias_max,
         );
         let incoming = Incoming::new(connection.client_id.to_owned());
         let (outgoing, link_rx) = Outgoing::new(connection.client_id.to_owned());
@@ -80,12 +82,19 @@ impl Link {
         clean: bool,
         last_will: Option<LastWill>,
         dynamic_filters: bool,
+        topic_alias_max: Option<u16>,
     ) -> Result<(LinkTx, LinkRx, Notification), LinkError> {
         // Connect to router
         // Local connections to the router shall have access to all subscriptions
 
-        let (message, i, o, link_rx) =
-            Link::prepare(tenant_id, client_id, clean, last_will, dynamic_filters);
+        let (message, i, o, link_rx) = Link::prepare(
+            tenant_id,
+            client_id,
+            clean,
+            last_will,
+            dynamic_filters,
+            topic_alias_max.unwrap_or(0),
+        );
         router_tx.send((0, message))?;
 
         link_rx.recv()?;
@@ -110,12 +119,19 @@ impl Link {
         clean: bool,
         last_will: Option<LastWill>,
         dynamic_filters: bool,
+        topic_alias_max: Option<u16>,
     ) -> Result<(LinkTx, LinkRx, ConnAck), LinkError> {
         // Connect to router
         // Local connections to the router shall have access to all subscriptions
 
-        let (message, i, o, link_rx) =
-            Link::prepare(tenant_id, client_id, clean, last_will, dynamic_filters);
+        let (message, i, o, link_rx) = Link::prepare(
+            tenant_id,
+            client_id,
+            clean,
+            last_will,
+            dynamic_filters,
+            topic_alias_max.unwrap_or(0),
+        );
         router_tx.send_async((0, message)).await?;
 
         link_rx.recv_async().await?;

--- a/rumqttd/src/link/shadow.rs
+++ b/rumqttd/src/link/shadow.rs
@@ -78,6 +78,7 @@ impl ShadowLink {
             true,
             None,
             config.dynamic_filters,
+            None,
         )?;
         let connection_id = link_rx.id();
 

--- a/rumqttd/src/protocol/mod.rs
+++ b/rumqttd/src/protocol/mod.rs
@@ -146,7 +146,7 @@ pub struct ConnAck {
     pub code: ConnectReturnCode,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ConnAckProperties {
     pub session_expiry_interval: Option<u32>,
     pub receive_max: Option<u16>,

--- a/rumqttd/src/protocol/mod.rs
+++ b/rumqttd/src/protocol/mod.rs
@@ -246,7 +246,7 @@ impl Publish {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct PublishProperties {
     pub payload_format_indicator: Option<u8>,
     pub message_expiry_interval: Option<u32>,

--- a/rumqttd/src/protocol/v4/mod.rs
+++ b/rumqttd/src/protocol/v4/mod.rs
@@ -345,7 +345,10 @@ impl Protocol for V4 {
             Packet::Connect(connect, None, last_will, None, login) => {
                 connect::write(&connect, &login, &last_will, buffer)?
             }
-            Packet::ConnAck(connack, None) => connack::write(&connack, buffer)?,
+            // TODO: set ConnAckProperties conditionally based on version
+            // currently we can't conditionally set them based on v5 or v4,
+            // so we ignore them, as properties can't be there in v4.
+            Packet::ConnAck(connack, _) => connack::write(&connack, buffer)?,
             Packet::Publish(publish, None) => publish::write(&publish, buffer)?,
             Packet::PubAck(puback, None) => puback::write(&puback, buffer)?,
             Packet::Subscribe(subscribe, None) => subscribe::write(&subscribe, buffer)?,

--- a/rumqttd/src/router/connection.rs
+++ b/rumqttd/src/router/connection.rs
@@ -1,6 +1,6 @@
 use crate::protocol::LastWill;
 use crate::Filter;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use super::ConnectionEvents;
 
@@ -22,6 +22,8 @@ pub struct Connection {
     pub last_will: Option<LastWill>,
     /// Connection events
     pub events: ConnectionEvents,
+    /// Topic aliases set by clients
+    pub(crate) topic_aliases: HashMap<u16, Filter>,
 }
 
 impl Connection {
@@ -52,6 +54,7 @@ impl Connection {
             subscriptions: HashSet::default(),
             last_will,
             events: ConnectionEvents::default(),
+            topic_aliases: HashMap::new(),
         }
     }
 }

--- a/rumqttd/src/router/connection.rs
+++ b/rumqttd/src/router/connection.rs
@@ -27,7 +27,7 @@ pub struct Connection {
     /// Topic aliases set by clients
     pub(crate) topic_aliases: HashMap<u16, Filter>,
     /// Topic aliases used by broker
-    pub(crate) broker_topic_aliases: HashMap<Filter, u16>,
+    pub(crate) broker_topic_aliases: Option<HashMap<Filter, u16>>,
     pub topic_alias_max: u16,
     pub(crate) used_aliases: Slab<()>,
 }
@@ -57,6 +57,13 @@ impl Connection {
         // occupy 0th index as 0 is invalid topic alias
         assert_eq!(0, used_aliases.insert(()));
 
+        // topic_alias_max is 0, that means client doesn't want to use / support topic alias
+        let broker_topic_aliases = if topic_alias_max == 0 {
+            None
+        } else {
+            Some(HashMap::new())
+        };
+
         Connection {
             client_id,
             tenant_prefix,
@@ -66,7 +73,7 @@ impl Connection {
             last_will,
             events: ConnectionEvents::default(),
             topic_aliases: HashMap::new(),
-            broker_topic_aliases: HashMap::new(),
+            broker_topic_aliases,
             topic_alias_max,
             used_aliases,
         }

--- a/rumqttd/src/router/connection.rs
+++ b/rumqttd/src/router/connection.rs
@@ -51,7 +51,7 @@ impl Connection {
             None => (client_id, None),
         };
 
-        // topic_alias_max is 0, that means client doesn't want to use / support topic alias
+        // if topic_alias_max is 0, that means client doesn't want to use / support topic alias
         let broker_topic_aliases = if topic_alias_max == 0 {
             None
         } else {
@@ -106,7 +106,7 @@ impl BrokerAliases {
         self.broker_topic_aliases.get(topic).copied()
     }
 
-    // Set new alias for a topic and reutrn the alias
+    // Set new alias for a topic and return the alias
     // returns None if can't set new alias
     pub fn set_new_alias(&mut self, topic: &str) -> Option<u16> {
         let alias_to_use = self.used_aliases.insert(());

--- a/rumqttd/src/router/connection.rs
+++ b/rumqttd/src/router/connection.rs
@@ -1,7 +1,7 @@
 use slab::Slab;
 
-use crate::protocol::LastWill;
 use crate::Filter;
+use crate::{protocol::LastWill, Topic};
 use std::collections::{HashMap, HashSet};
 
 use super::ConnectionEvents;
@@ -25,11 +25,9 @@ pub struct Connection {
     /// Connection events
     pub events: ConnectionEvents,
     /// Topic aliases set by clients
-    pub(crate) topic_aliases: HashMap<u16, Filter>,
+    pub(crate) topic_aliases: HashMap<u16, Topic>,
     /// Topic aliases used by broker
-    pub(crate) broker_topic_aliases: Option<HashMap<Filter, u16>>,
-    pub topic_alias_max: u16,
-    pub(crate) used_aliases: Slab<()>,
+    pub(crate) broker_topic_aliases: Option<BrokerAliases>,
 }
 
 impl Connection {
@@ -53,15 +51,11 @@ impl Connection {
             None => (client_id, None),
         };
 
-        let mut used_aliases = Slab::new();
-        // occupy 0th index as 0 is invalid topic alias
-        assert_eq!(0, used_aliases.insert(()));
-
         // topic_alias_max is 0, that means client doesn't want to use / support topic alias
         let broker_topic_aliases = if topic_alias_max == 0 {
             None
         } else {
-            Some(HashMap::new())
+            Some(BrokerAliases::new(topic_alias_max))
         };
 
         Connection {
@@ -74,8 +68,59 @@ impl Connection {
             events: ConnectionEvents::default(),
             topic_aliases: HashMap::new(),
             broker_topic_aliases,
-            topic_alias_max,
-            used_aliases,
         }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct BrokerAliases {
+    pub(crate) broker_topic_aliases: HashMap<Filter, u16>,
+    pub(crate) used_aliases: Slab<()>,
+    pub(crate) topic_alias_max: u16,
+}
+
+impl BrokerAliases {
+    fn new(topic_alias_max: u16) -> BrokerAliases {
+        let mut used_aliases = Slab::new();
+        // occupy 0th index as 0 is invalid topic alias
+        assert_eq!(0, used_aliases.insert(()));
+
+        let broker_topic_aliases = HashMap::new();
+
+        BrokerAliases {
+            broker_topic_aliases,
+            used_aliases,
+            topic_alias_max,
+        }
+    }
+
+    // unset / remove the alias for topic
+    pub fn remove_alias(&mut self, topic: &str) {
+        if let Some(alias) = self.broker_topic_aliases.remove(topic) {
+            self.used_aliases.remove(alias as usize);
+        }
+    }
+
+    // Get alias used for the topic, if it exists
+    pub fn get_alias(&self, topic: &str) -> Option<u16> {
+        self.broker_topic_aliases.get(topic).copied()
+    }
+
+    // Set new alias for a topic and reutrn the alias
+    // returns None if can't set new alias
+    pub fn set_new_alias(&mut self, topic: &str) -> Option<u16> {
+        let alias_to_use = self.used_aliases.insert(());
+
+        // NOTE: maybe we can use self.used_aliases.len()
+        // to check for availability of alias
+        if alias_to_use > self.topic_alias_max as usize {
+            self.used_aliases.remove(alias_to_use);
+            return None;
+        }
+
+        let alias_to_use = alias_to_use as u16;
+        self.broker_topic_aliases
+            .insert(topic.to_owned(), alias_to_use);
+        Some(alias_to_use)
     }
 }

--- a/rumqttd/src/router/logs.rs
+++ b/rumqttd/src/router/logs.rs
@@ -36,6 +36,7 @@ impl From<PubWithProp> for PublishData {
 
 // TODO: remove this from here
 impl Storage for PublishData {
+    // TODO: calculate size of publish properties as well!
     fn size(&self) -> usize {
         let publish = &self.publish;
         4 + publish.topic.len() + publish.payload.len()
@@ -209,6 +210,7 @@ impl DataLog {
             // ignore expired messages
             if is_valid {
                 // set message_expiry_interval to (original value - time spent waiting in server)
+                // ref: https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901112
                 *t -= time_spent;
             }
 

--- a/rumqttd/src/router/logs.rs
+++ b/rumqttd/src/router/logs.rs
@@ -197,6 +197,12 @@ impl DataLog {
         // Encoding this information is important so that calling function
         // has more information on how this method behaves.
         let next = data.log.readv(offset, len, &mut o)?;
+
+        // ignore expired messages
+        let now = Instant::now();
+        o.retain(|x| x.0.expiry > Some(now));
+
+        // no need to include expiry when returning
         let o = o.into_iter().map(|x| (x.0.publish, x.1)).collect();
         Ok((next, o))
     }

--- a/rumqttd/src/router/logs.rs
+++ b/rumqttd/src/router/logs.rs
@@ -200,7 +200,7 @@ impl DataLog {
 
         // ignore expired messages
         let now = Instant::now();
-        o.retain(|x| x.0.expiry > Some(now));
+        o.retain(|x| x.0.expiry.map_or(true, |exp| exp > now));
 
         // no need to include expiry when returning
         let o = o.into_iter().map(|x| (x.0.publish, x.1)).collect();

--- a/rumqttd/src/router/logs.rs
+++ b/rumqttd/src/router/logs.rs
@@ -203,7 +203,7 @@ impl DataLog {
                 let time_spent = (now - pubdata.timestamp).as_secs() as u32;
 
                 // ignore expired messages
-                if time_spent > *t {
+                if time_spent >= *t {
                     return false;
                 }
 

--- a/rumqttd/src/router/logs.rs
+++ b/rumqttd/src/router/logs.rs
@@ -3,8 +3,8 @@ use slab::Slab;
 use tracing::trace;
 
 use crate::protocol::{
-    matches, ConnAck, PingResp, PubAck, PubComp, PubRec, PubRel, Publish, PublishProperties,
-    SubAck, UnsubAck,
+    matches, ConnAck, ConnAckProperties, PingResp, PubAck, PubComp, PubRec, PubRel, Publish,
+    PublishProperties, SubAck, UnsubAck,
 };
 use crate::router::{DataRequest, FilterIdx, SubscriptionMeter, Waiters};
 use crate::{ConnectionId, Filter, Offset, RouterConfig, Topic};
@@ -332,8 +332,8 @@ impl AckLog {
         }
     }
 
-    pub fn connack(&mut self, id: ConnectionId, ack: ConnAck) {
-        let ack = Ack::ConnAck(id, ack);
+    pub fn connack(&mut self, id: ConnectionId, ack: ConnAck, props: Option<ConnAckProperties>) {
+        let ack = Ack::ConnAck(id, ack, props);
         self.committed.push_back(ack);
     }
 

--- a/rumqttd/src/router/mod.rs
+++ b/rumqttd/src/router/mod.rs
@@ -8,9 +8,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     protocol::{
-        ConnAck, ConnAckProperties, Packet, PingResp, PubAck, PubAckProperties, PubComp,
-        PubCompProperties, PubRec, PubRecProperties, PubRel, PubRelProperties, Publish,
-        PublishProperties, SubAck, SubAckProperties, UnsubAck,
+        ConnAck, ConnAckProperties, Disconnect, DisconnectProperties, Packet, PingResp, PubAck,
+        PubAckProperties, PubComp, PubCompProperties, PubRec, PubRecProperties, PubRel,
+        PubRelProperties, Publish, PublishProperties, SubAck, SubAckProperties, UnsubAck,
     },
     ConnectionId, Filter, RouterId, Topic,
 };
@@ -85,6 +85,7 @@ pub enum Notification {
     /// Shadow
     Shadow(ShadowReply),
     Unschedule,
+    Disconnect(Disconnect, Option<DisconnectProperties>),
 }
 
 type MaybePacket = Option<Packet>;
@@ -96,6 +97,7 @@ impl From<Notification> for MaybePacket {
             Notification::Forward(forward) => Packet::Publish(forward.publish, forward.properties),
             Notification::DeviceAck(ack) => ack.into(),
             Notification::Unschedule => return None,
+            Notification::Disconnect(disconnct, props) => Packet::Disconnect(disconnct, props),
             v => {
                 tracing::error!("Unexpected notification here, it cannot be converted into Packet, Notification: {:?}", v);
                 return None;

--- a/rumqttd/src/router/mod.rs
+++ b/rumqttd/src/router/mod.rs
@@ -8,9 +8,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     protocol::{
-        ConnAck, Packet, PingResp, PubAck, PubAckProperties, PubComp, PubCompProperties, PubRec,
-        PubRecProperties, PubRel, PubRelProperties, Publish, PublishProperties, SubAck,
-        SubAckProperties, UnsubAck,
+        ConnAck, ConnAckProperties, Packet, PingResp, PubAck, PubAckProperties, PubComp,
+        PubCompProperties, PubRec, PubRecProperties, PubRel, PubRelProperties, Publish,
+        PublishProperties, SubAck, SubAckProperties, UnsubAck,
     },
     ConnectionId, Filter, RouterId, Topic,
 };
@@ -69,8 +69,6 @@ pub enum Event {
 pub enum Notification {
     /// Data reply
     Forward(Forward),
-    /// Data reply
-    ForwardWithProperties(Forward, PublishProperties),
     /// Acks reply for connection data
     DeviceAck(Ack),
     /// Data reply
@@ -95,7 +93,7 @@ type MaybePacket = Option<Packet>;
 impl From<Notification> for MaybePacket {
     fn from(notification: Notification) -> Self {
         let packet: Packet = match notification {
-            Notification::Forward(forward) => Packet::Publish(forward.publish, None),
+            Notification::Forward(forward) => Packet::Publish(forward.publish, forward.properties),
             Notification::DeviceAck(ack) => ack.into(),
             Notification::Unschedule => return None,
             v => {
@@ -112,12 +110,15 @@ pub struct Forward {
     pub cursor: (u64, u64),
     pub size: usize,
     pub publish: Publish,
+    pub properties: Option<PublishProperties>,
 }
 
 #[derive(Debug, Clone)]
 #[allow(clippy::enum_variant_names)]
 pub enum Ack {
-    ConnAck(ConnectionId, ConnAck),
+    ConnAck(ConnectionId, ConnAck, Option<ConnAckProperties>),
+    // NOTE: using Option may be a better choice than new variant
+    // ConnAckWithProperties(ConnectionId, ConnAck, ConnAckProperties),
     PubAck(PubAck),
     PubAckWithProperties(PubAck, PubAckProperties),
     SubAck(SubAck),
@@ -135,7 +136,7 @@ pub enum Ack {
 impl From<Ack> for Packet {
     fn from(value: Ack) -> Self {
         match value {
-            Ack::ConnAck(_id, connack) => Packet::ConnAck(connack, None),
+            Ack::ConnAck(_id, connack, props) => Packet::ConnAck(connack, props),
             Ack::PubAck(puback) => Packet::PubAck(puback, None),
             Ack::PubAckWithProperties(puback, prop) => Packet::PubAck(puback, Some(prop)),
             Ack::SubAck(suback) => Packet::SubAck(suback, None),

--- a/rumqttd/src/router/mod.rs
+++ b/rumqttd/src/router/mod.rs
@@ -97,7 +97,7 @@ impl From<Notification> for MaybePacket {
             Notification::Forward(forward) => Packet::Publish(forward.publish, forward.properties),
             Notification::DeviceAck(ack) => ack.into(),
             Notification::Unschedule => return None,
-            Notification::Disconnect(disconnct, props) => Packet::Disconnect(disconnct, props),
+            Notification::Disconnect(disconnect, props) => Packet::Disconnect(disconnect, props),
             v => {
                 tracing::error!("Unexpected notification here, it cannot be converted into Packet, Notification: {:?}", v);
                 return None;

--- a/rumqttd/src/router/mod.rs
+++ b/rumqttd/src/router/mod.rs
@@ -121,6 +121,7 @@ pub enum Ack {
     ConnAck(ConnectionId, ConnAck, Option<ConnAckProperties>),
     // NOTE: using Option may be a better choice than new variant
     // ConnAckWithProperties(ConnectionId, ConnAck, ConnAckProperties),
+    // TODO: merge the other variants as well using the same pattern
     PubAck(PubAck),
     PubAckWithProperties(PubAck, PubAckProperties),
     SubAck(SubAck),

--- a/rumqttd/src/router/routing.rs
+++ b/rumqttd/src/router/routing.rs
@@ -1023,6 +1023,8 @@ fn append_to_commitlog(
     notifications: &mut VecDeque<(ConnectionId, DataRequest)>,
     connections: &mut Slab<Connection>,
 ) -> Result<Offset, RouterError> {
+    let topic = std::str::from_utf8(&publish.topic)?;
+
     // Ensure that only clients associated with a tenant can publish to tenant's topic
     #[cfg(feature = "validate-tenant-prefix")]
     if let Some(tenant_prefix) = &connections[id].tenant_prefix {
@@ -1058,7 +1060,6 @@ fn append_to_commitlog(
             };
             publish.topic = alias_topic.to_owned().into();
         } else {
-            let topic = std::str::from_utf8(&publish.topic)?;
             connection.topic_aliases.insert(alias, topic.to_owned());
             trace!("set alias {alias} for topic {topic}");
         }

--- a/rumqttd/src/router/routing.rs
+++ b/rumqttd/src/router/routing.rs
@@ -383,6 +383,8 @@ impl Router {
         let span = tracing::info_span!("incoming_disconnect", client_id);
         let _guard = span.enter();
 
+        // must handle last will before sending disconnect packet
+        // as the disconnecting client might have subscribed to will topic.
         if execute_last_will {
             self.handle_last_will(id);
         }

--- a/rumqttd/src/router/routing.rs
+++ b/rumqttd/src/router/routing.rs
@@ -1246,10 +1246,10 @@ fn forward_device_data(
         .as_ref()
         .and_then(|aliases| aliases.get_alias(&request.filter));
 
-    let topic_alias_exists = topic_alias.is_some();
+    let topic_alias_already_exists = topic_alias.is_some();
 
     // if topic alias doesn't exists, try creating new one!
-    if !topic_alias_exists {
+    if !topic_alias_already_exists {
         topic_alias = broker_topic_aliases
             .as_mut()
             .and_then(|broker_aliases| broker_aliases.set_new_alias(&request.filter))
@@ -1269,7 +1269,7 @@ fn forward_device_data(
             }
 
             // We want to clear topic if we are using an existing alias
-            if topic_alias_exists {
+            if topic_alias_already_exists {
                 publish.topic.clear()
             }
 

--- a/rumqttd/src/router/routing.rs
+++ b/rumqttd/src/router/routing.rs
@@ -49,7 +49,7 @@ pub enum RouterError {
     InvalidFilterPrefix(Filter),
     #[error("Invalid client_id {0}")]
     InvalidClientId(String),
-    #[error("Disconnection")]
+    #[error("Disconnection (Reason: {0:?})")]
     Disconnect(DisconnectReasonCode),
 }
 

--- a/rumqttd/src/server/broker.rs
+++ b/rumqttd/src/server/broker.rs
@@ -139,8 +139,15 @@ impl Broker {
     pub fn link(&self, client_id: &str) -> Result<(LinkTx, LinkRx), local::LinkError> {
         // Register this connection with the router. Router replies with ack which if ok will
         // start the link. Router can sometimes reject the connection (ex max connection limit)
-        let (link_tx, link_rx, _ack) =
-            Link::new(None, client_id, self.router_tx.clone(), true, None, false)?;
+        let (link_tx, link_rx, _ack) = Link::new(
+            None,
+            client_id,
+            self.router_tx.clone(),
+            true,
+            None,
+            false,
+            None,
+        )?;
         Ok((link_tx, link_rx))
     }
 


### PR DESCRIPTION
This PR adds support for MQTTv5 related features, topic alias and message expiry.

### Topic alias
- Allow clients to set and use topic alias
- Broker can also set topic alias ( if supported by client ). If client specifies maximum topic alias to use, broker will use topic aliases for that client.

### Message Expiry
- Discard expired messages ( expired messaged mean time spent waiting >= message expiry interval )
- before forwarding publish packets, update message expiry interval to original value - time spent 

## Type of change

New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if its relevant of user of the library. If its not relevant mention why.
