### PR TITLE
rumqttc: Enforce max packet size

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -11,14 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Added `outgoing_inflight_upper_limit` to MQTT5 `MqttOptions`. This sets the upper bound for the number of outgoing publish messages.
 
 ### Changed
+ - `MqttState::new` takes `max_outgoing_packet_size` which was set in `MqttOptions` but not used (#622)
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
-
- - Enforce `max_outgoing_packet_size` on v3 client
+ - Enforce `max_outgoing_packet_size` on v3 client (#622)
 
 ### Security
 

--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+ - Enforce `max_outgoing_packet_size` on v3 client
+
 ### Security
 
 ---

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -202,14 +202,14 @@ impl AsyncClient {
 
     /// Sends a MQTT disconnect to the `EventLoop`
     pub async fn disconnect(&self) -> Result<(), ClientError> {
-        let request = Request::Disconnect;
+        let request = Request::Disconnect(Disconnect);
         self.request_tx.send_async(request).await?;
         Ok(())
     }
 
     /// Attempts to send a MQTT disconnect to the `EventLoop`
     pub fn try_disconnect(&self) -> Result<(), ClientError> {
-        let request = Request::Disconnect;
+        let request = Request::Disconnect(Disconnect);
         self.request_tx.try_send(request)?;
         Ok(())
     }
@@ -361,7 +361,7 @@ impl Client {
 
     /// Sends a MQTT disconnect to the `EventLoop`
     pub fn disconnect(&mut self) -> Result<(), ClientError> {
-        let request = Request::Disconnect;
+        let request = Request::Disconnect(Disconnect);
         self.client.request_tx.send(request)?;
         Ok(())
     }

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -101,10 +101,11 @@ impl EventLoop {
         let pending = pending.into_iter();
         let max_inflight = mqtt_options.inflight;
         let manual_acks = mqtt_options.manual_acks;
+        let max_outgoing_packet_size = mqtt_options.max_outgoing_packet_size;
 
         EventLoop {
             mqtt_options,
-            state: MqttState::new(max_inflight, manual_acks),
+            state: MqttState::new(max_inflight, manual_acks, max_outgoing_packet_size),
             requests_tx,
             requests_rx,
             pending,
@@ -229,7 +230,7 @@ impl EventLoop {
                 let timeout = self.keepalive_timeout.as_mut().unwrap();
                 timeout.as_mut().reset(Instant::now() + self.mqtt_options.keep_alive);
 
-                self.state.handle_outgoing_packet(Request::PingReq)?;
+                self.state.handle_outgoing_packet(Request::PingReq(PingReq))?;
                 match time::timeout(network_timeout, network.flush(&mut self.state.write)).await {
                     Ok(inner) => inner?,
                     Err(_)=> return Err(ConnectionError::FlushTimeout),

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -176,13 +176,32 @@ pub enum Request {
     PubRec(PubRec),
     PubComp(PubComp),
     PubRel(PubRel),
-    PingReq,
-    PingResp,
+    PingReq(PingReq),
+    PingResp(PingResp),
     Subscribe(Subscribe),
     SubAck(SubAck),
     Unsubscribe(Unsubscribe),
     UnsubAck(UnsubAck),
-    Disconnect,
+    Disconnect(Disconnect),
+}
+
+impl Request {
+    fn size(&self) -> usize {
+        match &self {
+            Request::Publish(publish) => publish.size(),
+            Request::PubAck(puback) => puback.size(),
+            Request::PubRec(pubrec) => pubrec.size(),
+            Request::PubComp(pubcomp) => pubcomp.size(),
+            Request::PubRel(pubrel) => pubrel.size(),
+            Request::PingReq(pingreq) => pingreq.size(),
+            Request::PingResp(pingresp) => pingresp.size(),
+            Request::Subscribe(subscribe) => subscribe.size(),
+            Request::SubAck(suback) => suback.size(),
+            Request::Unsubscribe(unsubscribe) => unsubscribe.size(),
+            Request::UnsubAck(unsuback) => unsuback.size(),
+            Request::Disconnect(disconn) => disconn.size(),
+        }
+    }
 }
 
 /// Key type for TLS authentication
@@ -418,9 +437,6 @@ pub struct MqttOptions {
     /// maximum incoming packet size (verifies remaining length of the packet)
     max_incoming_packet_size: usize,
     /// Maximum outgoing packet size (only verifies publish payload size)
-    // TODO Verify this with all packets. This can be packet.write but message left in
-    // the state might be a footgun as user has to explicitly clean it. Probably state
-    // has to be moved to network
     max_outgoing_packet_size: usize,
     /// request (publish, subscribe) channel capacity
     request_channel_capacity: usize,

--- a/rumqttc/src/mqttbytes/v4/disconnect.rs
+++ b/rumqttc/src/mqttbytes/v4/disconnect.rs
@@ -1,9 +1,14 @@
 use super::*;
 use bytes::{BufMut, BytesMut};
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Disconnect;
 
 impl Disconnect {
+    pub fn size(&self) -> usize {
+        2
+    }
+
     pub fn write(&self, payload: &mut BytesMut) -> Result<usize, Error> {
         payload.put_slice(&[0xE0, 0x00]);
         Ok(2)

--- a/rumqttc/src/mqttbytes/v4/mod.rs
+++ b/rumqttc/src/mqttbytes/v4/mod.rs
@@ -85,3 +85,16 @@ pub fn read(stream: &mut BytesMut, max_size: usize) -> Result<Packet, Error> {
 
     Ok(packet)
 }
+
+/// Return number of remaining length bytes required for encoding length
+fn len_len(len: usize) -> usize {
+    if len >= 2_097_152 {
+        4
+    } else if len >= 16_384 {
+        3
+    } else if len >= 128 {
+        2
+    } else {
+        1
+    }
+}

--- a/rumqttc/src/mqttbytes/v4/ping.rs
+++ b/rumqttc/src/mqttbytes/v4/ping.rs
@@ -1,18 +1,28 @@
 use super::*;
 use bytes::{BufMut, BytesMut};
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PingReq;
 
 impl PingReq {
+    pub fn size(&self) -> usize {
+        2
+    }
+
     pub fn write(&self, payload: &mut BytesMut) -> Result<usize, Error> {
         payload.put_slice(&[0xC0, 0x00]);
         Ok(2)
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PingResp;
 
 impl PingResp {
+    pub fn size(&self) -> usize {
+        2
+    }
+
     pub fn write(&self, payload: &mut BytesMut) -> Result<usize, Error> {
         payload.put_slice(&[0xD0, 0x00]);
         Ok(2)

--- a/rumqttc/src/mqttbytes/v4/puback.rs
+++ b/rumqttc/src/mqttbytes/v4/puback.rs
@@ -17,6 +17,13 @@ impl PubAck {
         2
     }
 
+    pub fn size(&self) -> usize {
+        let len = self.len();
+        let remaining_len_size = len_len(len);
+
+        1 + remaining_len_size + len
+    }
+
     pub fn read(fixed_header: FixedHeader, mut bytes: Bytes) -> Result<Self, Error> {
         let variable_header_index = fixed_header.fixed_header_len;
         bytes.advance(variable_header_index);

--- a/rumqttc/src/mqttbytes/v4/pubcomp.rs
+++ b/rumqttc/src/mqttbytes/v4/pubcomp.rs
@@ -12,6 +12,12 @@ impl PubComp {
         PubComp { pkid }
     }
 
+    pub fn size(&self) -> usize {
+        let len = self.len();
+        let remaining_len_size = len_len(len);
+        1 + remaining_len_size + len
+    }
+
     fn len(&self) -> usize {
         // pkid
         2

--- a/rumqttc/src/mqttbytes/v4/publish.rs
+++ b/rumqttc/src/mqttbytes/v4/publish.rs
@@ -44,6 +44,13 @@ impl Publish {
         }
     }
 
+    pub fn size(&self) -> usize {
+        let len = self.len();
+        let remaining_len_size = len_len(len);
+
+        1 + remaining_len_size + len
+    }
+
     pub fn read(fixed_header: FixedHeader, mut bytes: Bytes) -> Result<Self, Error> {
         let qos = qos((fixed_header.byte1 & 0b0110) >> 1)?;
         let dup = (fixed_header.byte1 & 0b1000) != 0;

--- a/rumqttc/src/mqttbytes/v4/pubrec.rs
+++ b/rumqttc/src/mqttbytes/v4/pubrec.rs
@@ -17,6 +17,13 @@ impl PubRec {
         2
     }
 
+    pub fn size(&self) -> usize {
+        let len = self.len();
+        let remaining_len_size = len_len(len);
+
+        1 + remaining_len_size + len
+    }
+
     pub fn read(fixed_header: FixedHeader, mut bytes: Bytes) -> Result<Self, Error> {
         let variable_header_index = fixed_header.fixed_header_len;
         bytes.advance(variable_header_index);

--- a/rumqttc/src/mqttbytes/v4/pubrel.rs
+++ b/rumqttc/src/mqttbytes/v4/pubrel.rs
@@ -17,6 +17,13 @@ impl PubRel {
         2
     }
 
+    pub fn size(&self) -> usize {
+        let len = self.len();
+        let remaining_len_size = len_len(len);
+
+        1 + remaining_len_size + len
+    }
+
     pub fn read(fixed_header: FixedHeader, mut bytes: Bytes) -> Result<Self, Error> {
         let variable_header_index = fixed_header.fixed_header_len;
         bytes.advance(variable_header_index);

--- a/rumqttc/src/mqttbytes/v4/suback.rs
+++ b/rumqttc/src/mqttbytes/v4/suback.rs
@@ -18,6 +18,12 @@ impl SubAck {
         2 + self.return_codes.len()
     }
 
+    pub fn size(&self) -> usize {
+        let len = self.len();
+        let remaining_len_size = len_len(len);
+        1 + remaining_len_size + len
+    }
+
     pub fn read(fixed_header: FixedHeader, mut bytes: Bytes) -> Result<Self, Error> {
         let variable_header_index = fixed_header.fixed_header_len;
         bytes.advance(variable_header_index);

--- a/rumqttc/src/mqttbytes/v4/subscribe.rs
+++ b/rumqttc/src/mqttbytes/v4/subscribe.rs
@@ -42,6 +42,13 @@ impl Subscribe {
         2 + self.filters.iter().fold(0, |s, t| s + t.len())
     }
 
+    pub fn size(&self) -> usize {
+        let len = self.len();
+        let remaining_len_size = len_len(len);
+
+        1 + remaining_len_size + len
+    }
+
     pub fn read(fixed_header: FixedHeader, mut bytes: Bytes) -> Result<Self, Error> {
         let variable_header_index = fixed_header.fixed_header_len;
         bytes.advance(variable_header_index);

--- a/rumqttc/src/mqttbytes/v4/unsuback.rs
+++ b/rumqttc/src/mqttbytes/v4/unsuback.rs
@@ -13,6 +13,10 @@ impl UnsubAck {
         UnsubAck { pkid }
     }
 
+    pub fn size(&self) -> usize {
+        4
+    }
+
     pub fn read(fixed_header: FixedHeader, mut bytes: Bytes) -> Result<Self, Error> {
         if fixed_header.remaining_len != 2 {
             return Err(Error::PayloadSizeIncorrect);

--- a/rumqttc/src/mqttbytes/v4/unsubscribe.rs
+++ b/rumqttc/src/mqttbytes/v4/unsubscribe.rs
@@ -16,6 +16,18 @@ impl Unsubscribe {
         }
     }
 
+    fn len(&self) -> usize {
+        // len of pkid + vec![subscribe topics len]
+        2 + self.topics.iter().fold(0, |s, t| s + t.len())
+    }
+
+    pub fn size(&self) -> usize {
+        let len = self.len();
+        let remaining_len_size = len_len(len);
+
+        1 + remaining_len_size + len
+    }
+
     pub fn read(fixed_header: FixedHeader, mut bytes: Bytes) -> Result<Self, Error> {
         let variable_header_index = fixed_header.fixed_header_len;
         bytes.advance(variable_header_index);
@@ -35,7 +47,7 @@ impl Unsubscribe {
     }
 
     pub fn write(&self, payload: &mut BytesMut) -> Result<usize, Error> {
-        let remaining_len = 2 + self.topics.iter().fold(0, |s, topic| s + topic.len() + 2);
+        let remaining_len = self.len();
 
         payload.put_u8(0xA2);
         let remaining_len_bytes = write_remaining_length(payload, remaining_len)?;

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -30,6 +30,8 @@ pub enum StateError {
     EmptySubscription,
     #[error("Mqtt serialization/deserialization error: {0}")]
     Deserialization(#[from] mqttbytes::Error),
+    #[error("Cannot recieve packet of size '{pkt_size:?}'. It's greater than the client's maximum packet size of: '{max:?}'")]
+    OutgoingPacketTooLarge { pkt_size: usize, max: usize },
 }
 
 /// State of the mqtt connection.
@@ -72,13 +74,15 @@ pub struct MqttState {
     pub write: BytesMut,
     /// Indicates if acknowledgements should be send immediately
     pub manual_acks: bool,
+    /// Maximum outgoing packet size, set via MqttOptions
+    pub max_outgoing_packet_size: usize,
 }
 
 impl MqttState {
     /// Creates new mqtt state. Same state should be used during a
     /// connection for persistent sessions while new state should
     /// instantiated for clean sessions
-    pub fn new(max_inflight: u16, manual_acks: bool) -> Self {
+    pub fn new(max_inflight: u16, manual_acks: bool, max_outgoing_packet_size: usize) -> Self {
         MqttState {
             await_pingresp: false,
             collision_ping_count: 0,
@@ -97,6 +101,7 @@ impl MqttState {
             events: VecDeque::with_capacity(100),
             write: BytesMut::with_capacity(10 * 1024),
             manual_acks,
+            max_outgoing_packet_size,
         }
     }
 
@@ -141,13 +146,15 @@ impl MqttState {
     /// Consolidates handling of all outgoing mqtt packet logic. Returns a packet which should
     /// be put on to the network by the eventloop
     pub fn handle_outgoing_packet(&mut self, request: Request) -> Result<(), StateError> {
+        // Enforce max outgoing packet size
+        self.check_size(request.size())?;
         match request {
             Request::Publish(publish) => self.outgoing_publish(publish)?,
             Request::PubRel(pubrel) => self.outgoing_pubrel(pubrel)?,
             Request::Subscribe(subscribe) => self.outgoing_subscribe(subscribe)?,
             Request::Unsubscribe(unsubscribe) => self.outgoing_unsubscribe(unsubscribe)?,
-            Request::PingReq => self.outgoing_ping()?,
-            Request::Disconnect => self.outgoing_disconnect()?,
+            Request::PingReq(_) => self.outgoing_ping()?,
+            Request::Disconnect(_) => self.outgoing_disconnect()?,
             Request::PubAck(puback) => self.outgoing_puback(puback)?,
             Request::PubRec(pubrec) => self.outgoing_pubrec(pubrec)?,
             _ => unimplemented!(),
@@ -473,6 +480,17 @@ impl MqttState {
         None
     }
 
+    fn check_size(&self, pkt_size: usize) -> Result<(), StateError> {
+        if pkt_size > self.max_outgoing_packet_size {
+            Err(StateError::OutgoingPacketTooLarge {
+                pkt_size,
+                max: self.max_outgoing_packet_size,
+            })
+        } else {
+            Ok(())
+        }
+    }
+
     fn save_pubrel(&mut self, mut pubrel: PubRel) -> Result<PubRel, StateError> {
         let pubrel = match pubrel.pkid {
             // consider PacketIdentifier(0) as uninitialized packets
@@ -536,7 +554,7 @@ mod test {
     }
 
     fn build_mqttstate() -> MqttState {
-        MqttState::new(100, false)
+        MqttState::new(100, false, usize::MAX)
     }
 
     #[test]
@@ -554,6 +572,17 @@ mod test {
 
             assert_eq!(expected, pkid);
         }
+    }
+
+    #[test]
+    fn outgoing_max_packet_size_check() {
+        let mut mqtt = MqttState::new(100, false, 200);
+
+        let small_publish = Publish::new("hello/world", QoS::AtLeastOnce, vec![1;100]);
+        assert_eq!(mqtt.handle_outgoing_packet(Request::Publish(small_publish)).is_ok(), true);
+
+        let large_publish = Publish::new("hello/world", QoS::AtLeastOnce, vec![1;265]);
+        assert_eq!(mqtt.handle_outgoing_packet(Request::Publish(large_publish)).is_ok(), false);
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for this Pull Request. Please provide a description of your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

 - Bug fix (non-breaking change which fixes an issue)
   - ~~Stop `.poll()` from reconnecting after an `disconnect()` call~~
   - Enforce `max_outgoing_packet_size` on v3 client
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintanance) -->

## Checklist:

- [X] Formatted with `cargo fmt`
- [X] Make an entry to `CHANGELOG.md` if its relevant of user of the library. If its not relevant mention why.
