### PR TITLE
feat: read unsubscribe packet in v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ rumqttc v0.19.0
 - Fix examples to stop printing error in loop (#540)
 - MQTTv5!: Remove `Connect` from `ConnectionError::StateError` (#541)
 - MQTTv5: Send last_will and login info with connect (#478)
-- MQTTv5: Read the Unsubscribe package in match arms (#625)
 
 rumqttd v0.12.1
 -------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ rumqttc v0.19.0
 - Fix examples to stop printing error in loop (#540)
 - MQTTv5!: Remove `Connect` from `ConnectionError::StateError` (#541)
 - MQTTv5: Send last_will and login info with connect (#478)
+- MQTTv5: Read the Unsubscribe package in match arms (#625)
 
 rumqttd v0.12.1
 -------

--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -20,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - MQTTv5: Read the Unsubscribe package in match arms (#625)
 
-
 ### Security
 
 ---

--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- MQTTv5: Read the Unsubscribe package in match arms (#625)
+
 
 ### Security
 

--- a/rumqttd/src/protocol/v5/mod.rs
+++ b/rumqttd/src/protocol/v5/mod.rs
@@ -400,13 +400,13 @@ impl Protocol for V5 {
                 let (subscribe, properties) = subscribe::read(fixed_header, packet)?;
                 Packet::Subscribe(subscribe, properties)
             }
-            Packet::Unsubscribe => {
-                let (unsubscribe, properties) = unsubscribe::read(fixed_header, packet)?;
-                Packet::Unsubscribe(unsubscribe, properties)
-            }
             PacketType::SubAck => {
                 let (suback, properties) = suback::read(fixed_header, packet)?;
                 Packet::SubAck(suback, properties)
+            }
+            Packet::Unsubscribe => {
+                let (unsubscribe, properties) = unsubscribe::read(fixed_header, packet)?;
+                Packet::Unsubscribe(unsubscribe, properties)
             }
             PacketType::PingReq => Packet::PingReq(PingReq),
             PacketType::PingResp => Packet::PingResp(PingResp),

--- a/rumqttd/src/protocol/v5/mod.rs
+++ b/rumqttd/src/protocol/v5/mod.rs
@@ -400,6 +400,10 @@ impl Protocol for V5 {
                 let (subscribe, properties) = subscribe::read(fixed_header, packet)?;
                 Packet::Subscribe(subscribe, properties)
             }
+            Packet::Unsubscribe => {
+                let (unsubscribe, properties) = unsubscribe::read(fixed_header, packet)?;
+                Packet::Unsubscribe(unsubscribe, properties)
+            }
             PacketType::SubAck => {
                 let (suback, properties) = suback::read(fixed_header, packet)?;
                 Packet::SubAck(suback, properties)


### PR DESCRIPTION
fix (v5):  **Include unsubscribe package**

- Unsubscribe packet included in match arms
- Such packets will not proceeds to `unreachable!()`