### PR TITLE
Shared subscriptions with random strategy

### DIFF
--- a/rumqttd/src/router/logs.rs
+++ b/rumqttd/src/router/logs.rs
@@ -173,7 +173,9 @@ impl DataLog {
             }
         };
 
-        (filter_idx, data.log.next_offset())
+        let offset = data.log.next_offset();
+
+        (filter_idx, offset)
     }
 
     pub fn native_readv(
@@ -297,6 +299,7 @@ pub struct Data<T> {
     pub log: CommitLog<T>,
     pub waiters: Waiters<DataRequest>,
     meter: SubscriptionMeter,
+    pub(crate) shared_cursors: HashMap<String, (u64, u64)>,
 }
 
 impl<T> Data<T>
@@ -313,6 +316,7 @@ where
             log,
             waiters,
             meter: metrics,
+            shared_cursors: HashMap::new(),
         }
     }
 

--- a/rumqttd/src/router/mod.rs
+++ b/rumqttd/src/router/mod.rs
@@ -191,6 +191,8 @@ pub struct DataRequest {
     pub read_count: usize,
     /// Maximum count of payload buffer per replica
     max_count: usize,
+    /// Group name of shared subscription, if any
+    group: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/rumqttd/src/router/routing.rs
+++ b/rumqttd/src/router/routing.rs
@@ -459,6 +459,15 @@ impl Router {
             for request in tracker.data_requests.iter_mut() {
                 if let Some(cursor) = retransmissions.get(&request.filter_idx) {
                     request.cursor = *cursor;
+                    // reset the group cursor as well
+                    if let Some(group_name) = &request.group {
+                        self.datalog
+                            .native
+                            .get_mut(request.filter_idx)
+                            .unwrap()
+                            .shared_cursors
+                            .insert(group_name.to_string(), *cursor);
+                    }
                 }
             }
 
@@ -1288,7 +1297,7 @@ fn forward_device_data(
             .get_mut(request.filter_idx)
             .unwrap()
             .shared_cursors
-            .insert(group_name.to_string(), request.cursor);
+            .insert(group_name.to_string(), next);
     }
 
     if publishes.is_empty() {

--- a/rumqttd/src/router/routing.rs
+++ b/rumqttd/src/router/routing.rs
@@ -619,8 +619,9 @@ impl Router {
                         let connection = self.connections.get_mut(id).unwrap();
 
                         let mut group: Option<String> = None;
+                        let original_filter: String = f.path.clone();
 
-                        if let Some(share_filter) = f.path.strip_prefix("$share/") {
+                        if let Some(share_filter) = original_filter.strip_prefix("$share/") {
                             // TODO: handle error cases
                             let filter_path = share_filter
                                 .split_once('/')
@@ -632,6 +633,7 @@ impl Router {
                                 })
                                 .unwrap();
 
+                            // filter path without prefix and group name
                             f.path = filter_path;
                         }
 
@@ -648,7 +650,7 @@ impl Router {
                         let qos = f.qos;
 
                         let (idx, cursor) = self.datalog.next_native_offset(filter);
-                        self.prepare_filter(id, cursor, idx, filter.clone(), qos as u8, group);
+                        self.prepare_filter(id, cursor, idx, original_filter, qos as u8, group);
                         self.datalog
                             .handle_retained_messages(filter, &mut self.notifications);
 

--- a/rumqttd/src/router/routing.rs
+++ b/rumqttd/src/router/routing.rs
@@ -850,6 +850,16 @@ impl Router {
             }
         }
 
+        // set the shared cursor in case of shared subscription
+        if let Some(ref group_name) = group {
+            self.datalog
+                .native
+                .get_mut(filter_idx)
+                .unwrap()
+                .shared_cursors
+                .insert(group_name.to_string(), cursor);
+        }
+
         // Prepare consumer to pull data in case of subscription
         let connection = self.connections.get_mut(id).unwrap();
 


### PR DESCRIPTION
This PR adds support for shared subscriptions in broker with sticky strategy ( i.e. keep sending to one client in group until failure ).
Other strategies like round-robin, sticky, hash aren't included yet, as they might need significant refactoring. ( please let me know if you have any workarounds for it! )

## Type of change

New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Formatted with `cargo fmt`
- [ ] Make an entry to `CHANGELOG.md` if its relevant of user of the library. If its not relevant mention why. ( TODO )
