### PR TITLE
rumqttc: Fixed len() on v4 Unsubscribe packet

### DIFF
--- a/rumqttc/src/mqttbytes/v4/unsubscribe.rs
+++ b/rumqttc/src/mqttbytes/v4/unsubscribe.rs
@@ -18,7 +18,7 @@ impl Unsubscribe {
 
     fn len(&self) -> usize {
         // len of pkid + vec![subscribe topics len]
-        2 + self.topics.iter().fold(0, |s, t| s + t.len())
+        2 + self.topics.iter().fold(0, |s, t| s + t.len() + 2)
     }
 
     pub fn size(&self) -> usize {

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -578,11 +578,19 @@ mod test {
     fn outgoing_max_packet_size_check() {
         let mut mqtt = MqttState::new(100, false, 200);
 
-        let small_publish = Publish::new("hello/world", QoS::AtLeastOnce, vec![1;100]);
-        assert_eq!(mqtt.handle_outgoing_packet(Request::Publish(small_publish)).is_ok(), true);
+        let small_publish = Publish::new("hello/world", QoS::AtLeastOnce, vec![1; 100]);
+        assert_eq!(
+            mqtt.handle_outgoing_packet(Request::Publish(small_publish))
+                .is_ok(),
+            true
+        );
 
-        let large_publish = Publish::new("hello/world", QoS::AtLeastOnce, vec![1;265]);
-        assert_eq!(mqtt.handle_outgoing_packet(Request::Publish(large_publish)).is_ok(), false);
+        let large_publish = Publish::new("hello/world", QoS::AtLeastOnce, vec![1; 265]);
+        assert_eq!(
+            mqtt.handle_outgoing_packet(Request::Publish(large_publish))
+                .is_ok(),
+            false
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for this Pull Request. Please provide a description of your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

 - Fixed len() on v4 Unsubscribe packet
 - `cargo fmt` on `outgoing_max_packet_size_check` test

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintanance) -->

## Checklist:

- [X] Formatted with `cargo fmt`
- [X] Make an entry to `CHANGELOG.md` if its relevant of user of the library. If its not relevant mention why.
  - Not relevant. Fixing an unreleased bug.
