### PR TITLE
Allow modifying websocket requests.

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `MqttOptions::set_request_modifier` for setting a handler for modifying a websocket request before sending it.
+
 ### Changed
 
 ### Deprecated

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -332,6 +332,10 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
                 .headers_mut()
                 .insert("Sec-WebSocket-Protocol", "mqtt".parse().unwrap());
 
+            if let Some(request_modifier) = options.request_modifier() {
+                request = request_modifier(request).await;
+            }
+
             let (socket, _) = async_tungstenite::tokio::client_async(request, tcp_stream).await?;
 
             Network::new(WsStream::new(socket), max_incoming_pkt_size)
@@ -342,6 +346,10 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
             request
                 .headers_mut()
                 .insert("Sec-WebSocket-Protocol", "mqtt".parse().unwrap());
+
+            if let Some(request_modifier) = options.request_modifier() {
+                request = request_modifier(request).await;
+            }
 
             let connector = tls::rustls_connector(&tls_config).await?;
 


### PR DESCRIPTION
<!--
Thank you for this Pull Request. Please provide a description of your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

I am trying to connect to an AWS IoT Shadow via MQTT and SigV4 but couldn't find any way to add additional headers to the request. This adds a way to modify the request before connecting.

Example usage:

```rust
    mqtt_options.set_request_modifier(move |request| {
      let credential_provider = credential_provider.clone();
      let region = region.clone();

      async move {
          let request_config = RequestConfig {
              request_ts: SystemTime::now(),
              region: &SigningRegion::from(region.clone()),
              service: &SigningService::from_static("iotdata"),
              payload_override: None,
          };

        let (parts, body) = request.into_parts();
        let mut request: http::Request<SdkBody> = http::Request::from_parts(parts, SdkBody::empty());

        let signer = SigV4Signer::new();
        signer.sign(
          &OperationSigningConfig::default_config(),
          &request_config,
          &credential_provider.provide_credentials().await.unwrap(),
          &mut request,
        ).unwrap();

        let (parts, _) = request.into_parts();
        http::Request::from_parts(parts, body)
      }
    });
```

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintanance) -->

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if its relevant of user of the library. If its not relevant mention why.
