### PR TITLE
feat: Synchronous Client: Remove mut from methods

### DIFF
--- a/benchmarks/clients/rumqttsync.rs
+++ b/benchmarks/clients/rumqttsync.rs
@@ -17,7 +17,7 @@ pub fn start(id: &str, payload_size: usize, count: usize) -> Result<(), Box<dyn 
     mqttoptions.set_keep_alive(Duration::from_secs(20));
     mqttoptions.set_inflight(100);
 
-    let (mut client, mut connection) = Client::new(mqttoptions, 10);
+    let (client, mut connection) = Client::new(mqttoptions, 10);
     thread::spawn(move || {
         for _i in 0..count {
             let payload = vec![0; payload_size];

--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expose `EventLoop::clean` to allow triggering shutdown and subsequent storage of pending requests
 
 ### Changed
+- Synchronous client methods take `&self` instead of `&mut self` (#646)
 
 ### Deprecated
 

--- a/rumqttc/examples/serde.rs
+++ b/rumqttc/examples/serde.rs
@@ -34,7 +34,7 @@ impl TryFrom<&[u8]> for Message {
 fn main() {
     let mqqt_opts = MqttOptions::new("test-1", "localhost", 1883);
 
-    let (mut client, mut connection) = Client::new(mqqt_opts, 10);
+    let (client, mut connection) = Client::new(mqqt_opts, 10);
     client.subscribe("hello/rumqtt", QoS::AtMostOnce).unwrap();
     thread::spawn(move || {
         for i in 0..10 {

--- a/rumqttc/examples/syncpubsub.rs
+++ b/rumqttc/examples/syncpubsub.rs
@@ -29,7 +29,7 @@ fn main() {
     println!("Done with the stream!!");
 }
 
-fn publish(mut client: Client) {
+fn publish(client: Client) {
     thread::sleep(Duration::from_secs(1));
     client.subscribe("hello/+/world", QoS::AtMostOnce).unwrap();
     for i in 0..10_usize {

--- a/rumqttc/examples/syncrecv.rs
+++ b/rumqttc/examples/syncrecv.rs
@@ -27,7 +27,7 @@ fn main() {
     }
 }
 
-fn publish(mut client: Client) {
+fn publish(client: Client) {
     client.subscribe("hello/+/world", QoS::AtMostOnce).unwrap();
     for i in 0..3 {
         let payload = vec![1; i];

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -257,7 +257,7 @@ impl Client {
 
     /// Sends a MQTT Publish to the `EventLoop`
     pub fn publish<S, V>(
-        &mut self,
+        &self,
         topic: S,
         qos: QoS,
         retain: bool,
@@ -279,7 +279,7 @@ impl Client {
     }
 
     pub fn try_publish<S, V>(
-        &mut self,
+        &self,
         topic: S,
         qos: QoS,
         retain: bool,
@@ -310,7 +310,7 @@ impl Client {
     }
 
     /// Sends a MQTT Subscribe to the `EventLoop`
-    pub fn subscribe<S: Into<String>>(&mut self, topic: S, qos: QoS) -> Result<(), ClientError> {
+    pub fn subscribe<S: Into<String>>(&self, topic: S, qos: QoS) -> Result<(), ClientError> {
         let subscribe = Subscribe::new(topic.into(), qos);
         let request = Request::Subscribe(subscribe);
         self.client.request_tx.send(request)?;
@@ -318,17 +318,13 @@ impl Client {
     }
 
     /// Sends a MQTT Subscribe to the `EventLoop`
-    pub fn try_subscribe<S: Into<String>>(
-        &mut self,
-        topic: S,
-        qos: QoS,
-    ) -> Result<(), ClientError> {
+    pub fn try_subscribe<S: Into<String>>(&self, topic: S, qos: QoS) -> Result<(), ClientError> {
         self.client.try_subscribe(topic, qos)?;
         Ok(())
     }
 
     /// Sends a MQTT Subscribe for multiple topics to the `EventLoop`
-    pub fn subscribe_many<T>(&mut self, topics: T) -> Result<(), ClientError>
+    pub fn subscribe_many<T>(&self, topics: T) -> Result<(), ClientError>
     where
         T: IntoIterator<Item = SubscribeFilter>,
     {
@@ -338,7 +334,7 @@ impl Client {
         Ok(())
     }
 
-    pub fn try_subscribe_many<T>(&mut self, topics: T) -> Result<(), ClientError>
+    pub fn try_subscribe_many<T>(&self, topics: T) -> Result<(), ClientError>
     where
         T: IntoIterator<Item = SubscribeFilter>,
     {
@@ -346,7 +342,7 @@ impl Client {
     }
 
     /// Sends a MQTT Unsubscribe to the `EventLoop`
-    pub fn unsubscribe<S: Into<String>>(&mut self, topic: S) -> Result<(), ClientError> {
+    pub fn unsubscribe<S: Into<String>>(&self, topic: S) -> Result<(), ClientError> {
         let unsubscribe = Unsubscribe::new(topic.into());
         let request = Request::Unsubscribe(unsubscribe);
         self.client.request_tx.send(request)?;
@@ -354,20 +350,20 @@ impl Client {
     }
 
     /// Sends a MQTT Unsubscribe to the `EventLoop`
-    pub fn try_unsubscribe<S: Into<String>>(&mut self, topic: S) -> Result<(), ClientError> {
+    pub fn try_unsubscribe<S: Into<String>>(&self, topic: S) -> Result<(), ClientError> {
         self.client.try_unsubscribe(topic)?;
         Ok(())
     }
 
     /// Sends a MQTT disconnect to the `EventLoop`
-    pub fn disconnect(&mut self) -> Result<(), ClientError> {
+    pub fn disconnect(&self) -> Result<(), ClientError> {
         let request = Request::Disconnect(Disconnect);
         self.client.request_tx.send(request)?;
         Ok(())
     }
 
     /// Sends a MQTT disconnect to the `EventLoop`
-    pub fn try_disconnect(&mut self) -> Result<(), ClientError> {
+    pub fn try_disconnect(&self) -> Result<(), ClientError> {
         self.client.try_disconnect()?;
         Ok(())
     }


### PR DESCRIPTION
I realized that the synchronous client might not actually need to take `&mut` self instead of `&self` here. I think reducing the requirements on this would make it more ergonomic. 

Also with respect to a breaking change, I'm not actually sure that this is one. I don't think it is, but am not really sure how to tell.

<!--
Thank you for this Pull Request. Please provide a description of your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
Breaking change (fix or feature that would cause existing functionality to not work as expected)
<!-- - Miscellaneous (related to maintanance) -->

## Checklist:

- [X] Formatted with `cargo fmt`
- [X] Make an entry to `CHANGELOG.md` if its relevant of user of the library. If its not relevant mention why.
