### PR TITLE
The server should not send DISCONNECT packets to MQTT v4 clients

### DIFF
--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Include reason code for UnsubAck in v5
+- The server should not send DISCONNECT packets to MQTT v4 clients
 
 ### Security
 

--- a/rumqttd/src/protocol/v4/disconnect.rs
+++ b/rumqttd/src/protocol/v4/disconnect.rs
@@ -2,7 +2,8 @@ use super::*;
 use bytes::{BufMut, BytesMut};
 
 // In v4 there are no Reason Code and properties
-pub fn write(_disconnect: &Disconnect, payload: &mut BytesMut) -> Result<usize, Error> {
-    payload.put_slice(&[0xE0, 0x00]);
-    Ok(2)
+pub fn write(_disconnect: &Disconnect, _payload: &mut BytesMut) -> Result<usize, Error> {
+    // The MQTT v4 (3.1.1) specification only mentions that DISCONNECT packages are sent
+    // from the client to the server (see section 3.14).
+    Ok(0)
 }


### PR DESCRIPTION
The server should not send DISCONNECT packets to MQTT v4 clients.

The MQTT v4 (3.1.1) specification only mentions that DISCONNECT packages are sent from the client to the server (see [section 3.14](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718090) and [section 2.1.1](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc353481061)).

> | Name | Value | Direction of flow | Description |
> |------|-------|-------------------|-------------|
> | ...  | ...   | ...               | ...         |
> | DISCONNECT | 14 | **Client to Server** | Client is disconnecting |



<!--
Thank you for this Pull Request. Please provide a description of your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

Bug fix (non-breaking change which fixes an issue)
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintanance) -->

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if its relevant of user of the library. If its not relevant mention why.
