### PR TITLE
Disable unsused features from `flume` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,7 +664,6 @@ checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
 dependencies = [
  "futures-core",
  "futures-sink",
- "nanorand",
  "pin-project",
  "spin 0.9.8",
 ]
@@ -818,10 +817,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1269,15 +1266,6 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom",
-]
 
 [[package]]
 name = "native-tls"

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -25,7 +25,7 @@ futures-util = { version = "0.3", default_features = false, features = ["std"] }
 tokio = { version = "1.0", features = ["rt", "macros", "io-util", "net", "time"] }
 bytes = "1.0"
 log = "0.4"
-flume = "0.10"
+flume = { version = "0.10", default-features = false, features = ["async"]}
 thiserror = "1"
 
 # Optional

--- a/rumqttd/Cargo.toml
+++ b/rumqttd/Cargo.toml
@@ -14,7 +14,7 @@ tokio = { version = "1.0", features = ["rt", "time", "net", "io-util", "macros"]
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.66"
 bytes = { version = "1", features = ["serde"] }
-flume = "0.10.9"
+flume = { version = "0.10.9", default-features = false, features = ["async"]}
 slab = "0.4.3"
 thiserror = "1.0.24"
 tokio-util = { version = "0.7", features = ["codec"], optional = true }


### PR DESCRIPTION
<!--
Thank you for this Pull Request. Please provide a description of your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

This PR modifies the dependency on `flume` to only enable its `async` feature instead of all features that are enabled by default. The motivation for this change is that neither `rumqttc` nor `rumqttd` need to select between (i.e., wait for any one of multiple) messages from multiple channels. However, the `select` feature of `flume` is enabled by default, together with its `eventual-fairness` feature that ensures that channels in a selector cannot make other ones starve. To do so, a source of randomness is required which is obtained through additional dependencies that this PR aims to avoid for both users and developers of `rumqtt`.

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Miscellaneous (related to maintanance) 

## Checklist:

- [x] Formatted with `cargo fmt` (only `Cargo.toml`s are changed)
- [ ] Make an entry to `CHANGELOG.md` if its relevant of user of the library. If its not relevant mention why.
