### PR TITLE
rumqttc: Add bind_device to NetworkOptions to enable TCPSocket.bind_device()

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `bind_device` to `NetworkOptions` to enable `TCPSocket.bind_device()`
 
 ### Changed
 

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -378,11 +378,13 @@ impl From<ClientConfig> for TlsConfiguration {
 }
 
 /// Provides a way to configure low level network connection configurations
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Default)]
 pub struct NetworkOptions {
     tcp_send_buffer_size: Option<u32>,
     tcp_recv_buffer_size: Option<u32>,
     conn_timeout: u64,
+    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    bind_device: Option<String>,
 }
 
 impl NetworkOptions {
@@ -391,6 +393,8 @@ impl NetworkOptions {
             tcp_send_buffer_size: None,
             tcp_recv_buffer_size: None,
             conn_timeout: 5,
+            #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+            bind_device: None,
         }
     }
 
@@ -411,6 +415,17 @@ impl NetworkOptions {
     /// get timeout in secs
     pub fn connection_timeout(&self) -> u64 {
         self.conn_timeout
+    }
+
+    /// bind connection to a specific network device by name
+    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))
+    )]
+    pub fn set_bind_device(&mut self, bind_device: &str) -> &mut Self {
+        self.bind_device = Some(bind_device.to_string());
+        self
     }
 }
 

--- a/rumqttc/src/v5/mod.rs
+++ b/rumqttc/src/v5/mod.rs
@@ -472,7 +472,7 @@ impl MqttOptions {
     }
 
     pub fn network_options(&self) -> NetworkOptions {
-        self.network_options
+        self.network_options.clone()
     }
 
     pub fn set_network_options(&mut self, network_options: NetworkOptions) -> &mut Self {


### PR DESCRIPTION
Allows the network connection to be optionally bound to a specific interface.
See also: https://docs.rs/tokio/latest/tokio/net/struct.TcpSocket.html#method.bind_device

## Type of change
New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if its relevant of user of the library. If its not relevant mention why.
