### PR TITLE
fix(Event Loop): Allow keep-alives <= 5 secs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ rumqttc v0.19.0
 - Fix examples to stop printing error in loop (#540)
 - MQTTv5!: Remove `Connect` from `ConnectionError::StateError` (#541)
 - MQTTv5: Send last_will and login info with connect (#478)
+- Allow keep alive values <= 5 seconds (#643)
 
 rumqttd v0.12.1
 -------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ rumqttc v0.19.0
 - Fix examples to stop printing error in loop (#540)
 - MQTTv5!: Remove `Connect` from `ConnectionError::StateError` (#541)
 - MQTTv5: Send last_will and login info with connect (#478)
-- Allow keep alive values <= 5 seconds (#643)
 
 rumqttd v0.12.1
 -------

--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Allow keep alive values <= 5 seconds (#643)
 
 ### Security
 

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -140,7 +140,7 @@ impl EventLoop {
             };
             self.network = Some(network);
 
-            if self.keepalive_timeout.is_none() {
+            if self.keepalive_timeout.is_none() && !self.mqtt_options.keep_alive.is_zero() {
                 self.keepalive_timeout = Some(Box::pin(time::sleep(self.mqtt_options.keep_alive)));
             }
 
@@ -169,6 +169,7 @@ impl EventLoop {
             return Ok(event);
         }
 
+        let mut no_sleep = Box::pin(time::sleep(Duration::ZERO));
         // this loop is necessary since self.incoming.pop_front() might return None. In that case,
         // instead of returning a None event, we try again.
         select! {
@@ -227,7 +228,8 @@ impl EventLoop {
             },
             // We generate pings irrespective of network activity. This keeps the ping logic
             // simple. We can change this behavior in future if necessary (to prevent extra pings)
-            _ = self.keepalive_timeout.as_mut().unwrap() => {
+            _ = self.keepalive_timeout.as_mut().unwrap_or(&mut no_sleep),
+                if self.keepalive_timeout.is_some() && !self.mqtt_options.keep_alive.is_zero() => {
                 let timeout = self.keepalive_timeout.as_mut().unwrap();
                 timeout.as_mut().reset(Instant::now() + self.mqtt_options.keep_alive);
 

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -562,6 +562,12 @@ impl MqttOptions {
     /// Set number of seconds after which client should ping the broker
     /// if there is no other data exchange
     pub fn set_keep_alive(&mut self, duration: Duration) -> &mut Self {
+        assert!(
+            duration.is_zero() || duration >= Duration::from_secs(1),
+            "Keep alives should be specified in seconds. Durations less than \
+            a second are not allowed, except for Duration::ZERO."
+        );
+
         self.keep_alive = duration;
         self
     }

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -562,8 +562,6 @@ impl MqttOptions {
     /// Set number of seconds after which client should ping the broker
     /// if there is no other data exchange
     pub fn set_keep_alive(&mut self, duration: Duration) -> &mut Self {
-        assert!(duration.as_secs() >= 5, "Keep alives should be >= 5 secs");
-
         self.keep_alive = duration;
         self
     }

--- a/rumqttc/tests/reliability.rs
+++ b/rumqttc/tests/reliability.rs
@@ -93,6 +93,25 @@ async fn connection_should_timeout_on_time() {
 // All keep alive tests here
 //
 
+#[test]
+#[should_panic]
+fn test_invalid_keep_alive_value() {
+    let mut options = MqttOptions::new("dummy", "127.0.0.1", 1885);
+    options.set_keep_alive(Duration::from_millis(10));
+}
+
+#[test]
+fn test_zero_keep_alive_values() {
+    let mut options = MqttOptions::new("dummy", "127.0.0.1", 1885);
+    options.set_keep_alive(Duration::ZERO);
+}
+
+#[test]
+fn test_valid_keep_alive_values() {
+    let mut options = MqttOptions::new("dummy", "127.0.0.1", 1885);
+    options.set_keep_alive(Duration::from_secs(1));
+}
+
 #[tokio::test]
 async fn idle_connection_triggers_pings_on_time() {
     let keep_alive = 1;

--- a/rumqttc/tests/reliability.rs
+++ b/rumqttc/tests/reliability.rs
@@ -95,7 +95,7 @@ async fn connection_should_timeout_on_time() {
 
 #[tokio::test]
 async fn idle_connection_triggers_pings_on_time() {
-    let keep_alive = 5;
+    let keep_alive = 1;
 
     let mut options = MqttOptions::new("dummy", "127.0.0.1", 1885);
     options.set_keep_alive(Duration::from_secs(keep_alive));


### PR DESCRIPTION
This PR removes the requirement that the keep alive timeout be at
least 5 seconds. This is in keeping with the MQTT spec, which
states that the keep alive value should be between 0 and 65535.
A value of 0 indicates that no keep-alive pings are sent to the
broker.

Issue: #643 - Keep Alive has an arbitrary limit

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ X ] Formatted with `cargo fmt`
- [ X ] Make an entry to `CHANGELOG.md` if its relevant of user of the library. If its not relevant mention why.
