### PR TITLE
Builder pattern for constructing Link

### DIFF
--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support for Websocket connections (#633)
+- LinkBuilder for constructing LinkRx/LinkTx (#659)
+
 ### Changed
 
 ### Deprecated
+- Link and its implementation, use LinkBuilder instead
 
 ### Removed
 

--- a/rumqttd/src/link/bridge.rs
+++ b/rumqttd/src/link/bridge.rs
@@ -26,10 +26,7 @@ use tokio_rustls::{
 use tracing::*;
 
 use crate::{
-    link::{
-        local::{LinkError},
-        network::Network,
-    },
+    link::{local::LinkError, network::Network},
     local::LinkBuilder,
     protocol::{self, Connect, Packet, PingReq, Protocol, QoS, RetainForwardRule, Subscribe},
     router::Event,

--- a/rumqttd/src/link/bridge.rs
+++ b/rumqttd/src/link/bridge.rs
@@ -27,9 +27,10 @@ use tracing::*;
 
 use crate::{
     link::{
-        local::{Link, LinkError},
+        local::{LinkError},
         network::Network,
     },
+    local::LinkBuilder,
     protocol::{self, Connect, Packet, PingReq, Protocol, QoS, RetainForwardRule, Subscribe},
     router::Event,
     BridgeConfig, ConnectionId, Notification, Transport,
@@ -59,7 +60,9 @@ where
         "Starting bridge with subscription on filter \"{}\"",
         &config.sub_path,
     );
-    let (mut tx, mut rx, _ack) = Link::new(None, &config.name, router_tx, true, None, true, None)?;
+    let (mut tx, mut rx, _ack) = LinkBuilder::new(&config.name, router_tx)
+        .dynamic_filters(true)
+        .build()?;
 
     'outer: loop {
         let mut network = match network_connect(&config, &config.addr, protocol.clone()).await {

--- a/rumqttd/src/link/console.rs
+++ b/rumqttd/src/link/console.rs
@@ -1,4 +1,4 @@
-use crate::link::local::{LinkRx};
+use crate::link::local::LinkRx;
 use crate::local::LinkBuilder;
 use crate::router::{Event, Print};
 use crate::{ConnectionId, ConsoleSettings};

--- a/rumqttd/src/link/console.rs
+++ b/rumqttd/src/link/console.rs
@@ -1,4 +1,5 @@
-use crate::link::local::{Link, LinkRx};
+use crate::link::local::{LinkRx};
+use crate::local::LinkBuilder;
 use crate::router::{Event, Print};
 use crate::{ConnectionId, ConsoleSettings};
 use axum::extract::{Path, State};
@@ -23,8 +24,10 @@ impl ConsoleLink {
     /// Requires the corresponding Router to be running to complete
     pub fn new(config: ConsoleSettings, router_tx: Sender<(ConnectionId, Event)>) -> ConsoleLink {
         let tx = router_tx.clone();
-        let (link_tx, link_rx, _ack) =
-            Link::new(None, "console", tx, true, None, true, None).unwrap();
+        let (link_tx, link_rx, _ack) = LinkBuilder::new("console", tx)
+            .dynamic_filters(true)
+            .build()
+            .unwrap();
         let connection_id = link_tx.connection_id;
         ConsoleLink {
             config,

--- a/rumqttd/src/link/local.rs
+++ b/rumqttd/src/link/local.rs
@@ -129,6 +129,7 @@ impl<'a> LinkBuilder<'a> {
 
 pub struct Link;
 
+#[deprecated = "Link will be removed soon, please consider using LinkBuilder"]
 impl Link {
     #[allow(clippy::type_complexity)]
     fn prepare(

--- a/rumqttd/src/link/local.rs
+++ b/rumqttd/src/link/local.rs
@@ -35,6 +35,98 @@ pub enum LinkError {
     Elapsed(#[from] tokio::time::error::Elapsed),
 }
 
+// used to build LinkTx and LinkRx
+pub struct LinkBuilder<'a> {
+    tenant_id: Option<String>,
+    client_id: &'a str,
+    router_tx: Sender<(ConnectionId, Event)>,
+    // true by default
+    clean_session: bool,
+    last_will: Option<LastWill>,
+    // false by default
+    dynamic_filters: bool,
+    // default to 0, indicating to not use topic alias
+    topic_alias_max: u16,
+}
+
+impl<'a> LinkBuilder<'a> {
+    pub fn new(client_id: &'a str, router_tx: Sender<(ConnectionId, Event)>) -> Self {
+        LinkBuilder {
+            client_id,
+            router_tx,
+            tenant_id: None,
+            clean_session: true,
+            last_will: None,
+            dynamic_filters: false,
+            topic_alias_max: 0,
+        }
+    }
+
+    pub fn tenant_id(mut self, tenant_id: Option<String>) -> Self {
+        self.tenant_id = tenant_id;
+        self
+    }
+
+    pub fn last_will(mut self, last_will: Option<LastWill>) -> Self {
+        self.last_will = last_will;
+        self
+    }
+
+    pub fn topic_alias_max(mut self, max: u16) -> Self {
+        self.topic_alias_max = max;
+        self
+    }
+
+    pub fn clean_session(mut self, clean: bool) -> Self {
+        self.clean_session = clean;
+        self
+    }
+
+    pub fn dynamic_filters(mut self, dynamic_filters: bool) -> Self {
+        self.dynamic_filters = dynamic_filters;
+        self
+    }
+
+    pub fn build(self) -> Result<(LinkTx, LinkRx, Notification), LinkError> {
+        // Connect to router
+        // Local connections to the router shall have access to all subscriptions
+        let connection = Connection::new(
+            self.tenant_id,
+            self.client_id.to_owned(),
+            self.clean_session,
+            self.last_will,
+            self.dynamic_filters,
+            self.topic_alias_max,
+        );
+        let incoming = Incoming::new(connection.client_id.to_owned());
+        let (outgoing, link_rx) = Outgoing::new(connection.client_id.to_owned());
+        let outgoing_data_buffer = outgoing.buffer();
+        let incoming_data_buffer = incoming.buffer();
+
+        let event = Event::Connect {
+            connection,
+            incoming,
+            outgoing,
+        };
+
+        self.router_tx.send((0, event))?;
+
+        link_rx.recv()?;
+        let notification = outgoing_data_buffer.lock().pop_front().unwrap();
+
+        // Right now link identifies failure with dropped rx in router,
+        // which is probably ok. We need this here to get id assigned by router
+        let id = match notification {
+            Notification::DeviceAck(Ack::ConnAck(id, ..)) => id,
+            _message => return Err(LinkError::NotConnectionAck),
+        };
+
+        let tx = LinkTx::new(id, self.router_tx.clone(), incoming_data_buffer);
+        let rx = LinkRx::new(id, self.router_tx, link_rx, outgoing_data_buffer);
+        Ok((tx, rx, notification))
+    }
+}
+
 pub struct Link;
 
 impl Link {

--- a/rumqttd/src/link/remote.rs
+++ b/rumqttd/src/link/remote.rs
@@ -1,6 +1,7 @@
-use crate::link::local::{Link, LinkError, LinkRx, LinkTx};
+use crate::link::local::{LinkError, LinkRx, LinkTx};
 use crate::link::network;
 use crate::link::network::Network;
+use crate::local::LinkBuilder;
 use crate::protocol::{Connect, Packet, Protocol};
 use crate::router::{Event, Notification};
 use crate::{ConnectionId, ConnectionSettings};
@@ -121,15 +122,13 @@ impl<P: Protocol> RemoteLink<P> {
 
         let topic_alias_max = props.and_then(|p| p.topic_alias_max);
 
-        let (link_tx, link_rx, notification) = Link::new(
-            tenant_id,
-            &client_id,
-            router_tx,
-            clean_session,
-            lastwill,
-            dynamic_filters,
-            topic_alias_max,
-        )?;
+        let (link_tx, link_rx, notification) = LinkBuilder::new(&client_id, router_tx)
+            .tenant_id(tenant_id)
+            .clean_session(clean_session)
+            .last_will(lastwill)
+            .dynamic_filters(dynamic_filters)
+            .topic_alias_max(topic_alias_max.unwrap_or(0))
+            .build()?;
 
         let id = link_rx.id();
         Span::current().record("connection_id", id);

--- a/rumqttd/src/server/broker.rs
+++ b/rumqttd/src/server/broker.rs
@@ -3,6 +3,7 @@ use crate::link::console::ConsoleLink;
 use crate::link::network::{Network, N};
 use crate::link::remote::{self, RemoteLink};
 use crate::link::{bridge, timer};
+use crate::local::LinkBuilder;
 use crate::protocol::v4::V4;
 use crate::protocol::v5::V5;
 use crate::protocol::Protocol;
@@ -31,7 +32,7 @@ use std::time::Duration;
 use std::{io, thread};
 
 use crate::link::console;
-use crate::link::local::{self, Link, LinkRx, LinkTx};
+use crate::link::local::{self, LinkRx, LinkTx};
 use crate::router::{Disconnection, Event, Router};
 use crate::{Config, ConnectionId, ServerSettings};
 use tokio::net::{TcpListener, TcpStream};
@@ -144,15 +145,8 @@ impl Broker {
     pub fn link(&self, client_id: &str) -> Result<(LinkTx, LinkRx), local::LinkError> {
         // Register this connection with the router. Router replies with ack which if ok will
         // start the link. Router can sometimes reject the connection (ex. max connection limit).
-        let (link_tx, link_rx, _ack) = Link::new(
-            None,
-            client_id,
-            self.router_tx.clone(),
-            true,
-            None,
-            false,
-            None,
-        )?;
+        let (link_tx, link_rx, _ack) =
+            LinkBuilder::new(client_id, self.router_tx.clone()).build()?;
         Ok((link_tx, link_rx))
     }
 


### PR DESCRIPTION
Support for constructing `LinkRx`/`LinkTx` using `LinkBuidler`.

```rust
let (link_tx, link_rx, notification) = LinkBuilder::new(&client_id, router_tx)
    .tenant_id(tenant_id) // None by default
    .clean_session(clean_session) // true by default
    .last_will(lastwill) // None by default
    .dynamic_filters(dynamic_filters) // false by default
    .topic_alias_max(topic_alias_max) // 0 by default
    .build()?;
```
## Type of change

Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if its relevant of user of the library. If its not relevant mention why.
