### PR TITLE
Shared subscriptions with configurable strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,6 +1968,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "pretty_assertions",
  "pretty_env_logger",
+ "rand",
  "rustls-pemfile",
  "rustls-webpki",
  "serde",

--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Subscription IDs in v5 publish packets (#632)
+- Shared Subscriptions with configurable strategies (#668)
 
 ### Changed
 

--- a/rumqttd/Cargo.toml
+++ b/rumqttd/Cargo.toml
@@ -34,6 +34,7 @@ metrics = "0.20.1"
 metrics-exporter-prometheus = "0.11.0"
 clap = { version = "4.2", features = ["derive"] }
 axum = "0.6.4"
+rand = "0.8.5"
 
 [features]
 default = ["use-rustls"]

--- a/rumqttd/rumqttd.toml
+++ b/rumqttd/rumqttd.toml
@@ -10,7 +10,7 @@ max_segment_size = 104857600
 max_segment_count = 10
 max_read_len = 10240
 max_connections = 10010
-# shared_subscriptions_strategy = "sticky" # "sticky" | "roundrobin" ( default ) | "random"
+# shared_subscriptions_strategy = "random" # "sticky" | "roundrobin" ( default ) | "random"
 
 # [bridge]
 # name = "bridge-1"

--- a/rumqttd/rumqttd.toml
+++ b/rumqttd/rumqttd.toml
@@ -10,6 +10,7 @@ max_segment_size = 104857600
 max_segment_count = 10
 max_read_len = 10240
 max_connections = 10010
+# shared_subscriptions_strategy = "sticky" # "sticky" | "roundrobin" ( default ) | "random"
 
 # [bridge]
 # name = "bridge-1"

--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -38,6 +38,8 @@ pub use link::meters;
 pub use router::{Alert, IncomingMeter, Meter, Notification, OutgoingMeter};
 pub use server::Broker;
 
+use self::router::shared_subs::Strategy;
+
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct Config {
     pub id: usize,
@@ -146,6 +148,9 @@ pub struct RouterConfig {
     pub max_read_len: u64,
     pub max_connections: usize,
     pub initialized_filters: Option<Vec<Filter>>,
+    // defaults to Round Robin
+    #[serde(default)]
+    pub shared_subscriptions_strategy: Strategy,
 }
 
 type ReloadHandle = Handle<EnvFilter, Layered<Layer<Registry, Pretty, Format<Pretty>>, Registry>>;

--- a/rumqttd/src/router/logs.rs
+++ b/rumqttd/src/router/logs.rs
@@ -415,6 +415,7 @@ impl AckLog {
 #[cfg(test)]
 mod test {
     use super::DataLog;
+    use crate::router::shared_subs::Strategy;
     use crate::RouterConfig;
 
     #[test]
@@ -426,6 +427,7 @@ mod test {
             max_outgoing_packet_count: 1024,
             custom_segment: None,
             initialized_filters: None,
+            shared_subscriptions_strategy: Strategy::RoundRobin,
         };
         let mut data = DataLog::new(config).unwrap();
         data.next_native_offset("topic/a");
@@ -445,6 +447,7 @@ mod test {
             max_outgoing_packet_count: 1024,
             custom_segment: None,
             initialized_filters: None,
+            shared_subscriptions_strategy: Strategy::RoundRobin,
         };
         let mut data = DataLog::new(config).unwrap();
         data.next_native_offset("+/+");

--- a/rumqttd/src/router/logs.rs
+++ b/rumqttd/src/router/logs.rs
@@ -7,7 +7,7 @@ use crate::protocol::{
     PublishProperties, SubAck, UnsubAck,
 };
 use crate::router::{DataRequest, FilterIdx, SubscriptionMeter, Waiters};
-use crate::{ConnectionId, Filter, Offset, RouterConfig, Topic};
+use crate::{ConnectionId, Cursor, Filter, Offset, RouterConfig, Topic};
 
 use crate::segments::{CommitLog, Position};
 use crate::Storage;
@@ -297,6 +297,7 @@ pub struct Data<T> {
     pub log: CommitLog<T>,
     pub waiters: Waiters<DataRequest>,
     meter: SubscriptionMeter,
+    pub(crate) shared_cursors: HashMap<String, Cursor>,
 }
 
 impl<T> Data<T>
@@ -313,6 +314,7 @@ where
             log,
             waiters,
             meter: metrics,
+            shared_cursors: HashMap::new(),
         }
     }
 

--- a/rumqttd/src/router/logs.rs
+++ b/rumqttd/src/router/logs.rs
@@ -297,7 +297,6 @@ pub struct Data<T> {
     pub log: CommitLog<T>,
     pub waiters: Waiters<DataRequest>,
     meter: SubscriptionMeter,
-    pub(crate) shared_cursors: HashMap<String, Cursor>,
 }
 
 impl<T> Data<T>
@@ -314,7 +313,6 @@ where
             log,
             waiters,
             meter: metrics,
-            shared_cursors: HashMap::new(),
         }
     }
 

--- a/rumqttd/src/router/logs.rs
+++ b/rumqttd/src/router/logs.rs
@@ -7,7 +7,7 @@ use crate::protocol::{
     PublishProperties, SubAck, UnsubAck,
 };
 use crate::router::{DataRequest, FilterIdx, SubscriptionMeter, Waiters};
-use crate::{ConnectionId, Cursor, Filter, Offset, RouterConfig, Topic};
+use crate::{ConnectionId, Filter, Offset, RouterConfig, Topic};
 
 use crate::segments::{CommitLog, Position};
 use crate::Storage;

--- a/rumqttd/src/router/mod.rs
+++ b/rumqttd/src/router/mod.rs
@@ -22,6 +22,7 @@ pub mod iobufs;
 mod logs;
 mod routing;
 mod scheduler;
+mod shared_subs;
 mod waiters;
 
 pub use alertlog::Alert;
@@ -191,6 +192,7 @@ pub struct DataRequest {
     pub read_count: usize,
     /// Maximum count of payload buffer per replica
     max_count: usize,
+    pub(crate) group: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/rumqttd/src/router/mod.rs
+++ b/rumqttd/src/router/mod.rs
@@ -22,7 +22,7 @@ pub mod iobufs;
 mod logs;
 mod routing;
 mod scheduler;
-mod shared_subs;
+pub(crate) mod shared_subs;
 mod waiters;
 
 pub use alertlog::Alert;

--- a/rumqttd/src/router/routing.rs
+++ b/rumqttd/src/router/routing.rs
@@ -447,8 +447,7 @@ impl Router {
         // Remove connections from all groups
         // TODO: find a better way to do this
         self.shared_subscriptions
-            .iter_mut()
-            .for_each(|(_, group)| group.remove_client(id));
+            .retain(|_, group| group.remove_client(id));
 
         // Add disconnection event to metrics
         let time = match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
@@ -714,8 +713,7 @@ impl Router {
                             }
 
                             self.shared_subscriptions
-                                .iter_mut()
-                                .for_each(|(_, group)| group.remove_client(id));
+                                .retain(|_, group| group.remove_client(id));
 
                             if let Some(broker_aliases) = connection.broker_topic_aliases.as_mut() {
                                 broker_aliases.remove_alias(filter);

--- a/rumqttd/src/router/routing.rs
+++ b/rumqttd/src/router/routing.rs
@@ -1004,6 +1004,7 @@ impl Router {
         }
 
         // Add requests back to the tracker if there are any
+        requests.extend(skipped_requests);
         self.scheduler.trackv(id, requests);
         Some(())
     }

--- a/rumqttd/src/router/routing.rs
+++ b/rumqttd/src/router/routing.rs
@@ -447,12 +447,11 @@ impl Router {
         let inflight_data_requests = self.datalog.clean(id);
         let retransmissions = outgoing.retransmission_map();
 
-        // Remove connections from all groups
-        // TODO: find a way to clear the self.groups_per_filter map of empty groups.
-        // TODO: find a better way to do this
+        // Remove connections from all groups and
+        // discard empty group ( group with no client )
+        // note: can we do this in better way?
         self.shared_subscriptions.retain(|_, group| {
             group.remove_client(&client_id);
-            //Only keep subscriptions where there are clients present
             !group.is_empty()
         });
 
@@ -491,7 +490,7 @@ impl Router {
                         // TODO: Test this more
                         self.shared_subscriptions
                             .get_mut(group_name)
-                            .unwrap()
+                            .expect("group must exists")
                             .cursor = *cursor;
                     }
                 }
@@ -720,11 +719,10 @@ impl Router {
                             }
 
                             // Remove connections from all groups
-                            // TODO: find a way to clear the self.groups_per_filter map of empty groups.
-                            // TODO: find a better way to do this
+                            // discard empty group ( group with no client )
+                            // note: can we do this in better way?
                             self.shared_subscriptions.retain(|_, group| {
                                 group.remove_client(&client_id);
-                                //Only keep subscriptions where there are clients present
                                 !group.is_empty()
                             });
 

--- a/rumqttd/src/router/routing.rs
+++ b/rumqttd/src/router/routing.rs
@@ -656,6 +656,7 @@ impl Router {
                         }
 
                         let mut group = None;
+                        let original_filter = f.path.clone();
 
                         if let Some((grp, filter_path)) = extract_group(&f.path) {
                             self.groups_per_filter
@@ -671,7 +672,7 @@ impl Router {
                         let qos = f.qos;
 
                         let (idx, cursor) = self.datalog.next_native_offset(filter);
-                        self.prepare_filter(id, cursor, idx, filter.clone(), qos as u8, group);
+                        self.prepare_filter(id, cursor, idx, original_filter, qos as u8, group);
                         self.datalog
                             .handle_retained_messages(filter, &mut self.notifications);
 

--- a/rumqttd/src/router/shared_subs.rs
+++ b/rumqttd/src/router/shared_subs.rs
@@ -67,26 +67,25 @@ pub enum Strategy {
 
 #[cfg(test)]
 mod tests {
+    use crate::router::shared_subs::Strategy;
+
     use super::SharedGroup;
 
     #[test]
     fn performs_round_robin() {
         let mut group = SharedGroup {
-            clients: vec![1, 2, 3],
+            clients: vec!["A".into(), "B".into(), "C".into()],
             current_client_index: 0,
-            next_client: 1,
+            cursor: (0, 0),
+            strategy: Strategy::RoundRobin,
         };
         group.update_next_client();
-        assert_eq!(group.next_client, 2);
         assert_eq!(group.current_client_index, 1);
         group.update_next_client();
-        assert_eq!(group.next_client, 3);
         assert_eq!(group.current_client_index, 2);
         group.update_next_client();
-        assert_eq!(group.next_client, 1);
         assert_eq!(group.current_client_index, 0);
-        group.add_client(4);
-        assert_eq!(group.next_client, 1);
+        group.add_client("D".into());
         assert_eq!(group.current_client_index, 0);
     }
 
@@ -96,18 +95,16 @@ mod tests {
         // we remove A
         // [ B, C ] => Should be the next client (B)
         let mut group = SharedGroup {
-            clients: vec![1, 2, 3],
+            clients: vec!["A".into(), "B".into(), "C".into()],
             current_client_index: 0,
-            next_client: 1,
+            cursor: (0, 0),
+            strategy: Strategy::RoundRobin,
         };
-        group.remove_client(1);
-        assert_eq!(group.next_client, 2);
+        group.remove_client(&"A".into());
         assert_eq!(group.current_client_index, 0);
         group.update_next_client();
-        assert_eq!(group.next_client, 3);
         assert_eq!(group.current_client_index, 1);
         group.update_next_client();
-        assert_eq!(group.next_client, 2);
         assert_eq!(group.current_client_index, 0);
     }
 
@@ -117,18 +114,16 @@ mod tests {
         // we remove C
         // [ A, B ] => Should be the next client (A)
         let mut group = SharedGroup {
-            clients: vec![1, 2, 3],
+            clients: vec!["A".into(), "B".into(), "C".into()],
             current_client_index: 0,
-            next_client: 1,
+            cursor: (0, 0),
+            strategy: Strategy::RoundRobin,
         };
         group.update_next_client();
-        assert_eq!(group.next_client, 2);
         assert_eq!(group.current_client_index, 1);
         group.update_next_client();
-        assert_eq!(group.next_client, 3);
         assert_eq!(group.current_client_index, 2);
-        group.remove_client(3);
-        assert_eq!(group.next_client, 1);
+        group.remove_client(&"C".into());
         assert_eq!(group.current_client_index, 0);
     }
 }

--- a/rumqttd/src/router/shared_subs.rs
+++ b/rumqttd/src/router/shared_subs.rs
@@ -1,58 +1,46 @@
-type ClientType = usize;
-
 pub struct SharedGroup {
     // using Vec over HashSet for maintaining order of iter
-    clients: Vec<ClientType>,
+    clients: Vec<String>,
     // Index into clients, allows us to skip doing iter everytime
     client_cursor: usize,
-    // clients: Cycle<IntoIter<String>>,
-    pub next_client: ClientType,
+    // TODO; random, sticky strategy
+    // we can either have that logic in update_next_client or current_client
     // strategy: Strategy,
 }
 
 impl SharedGroup {
-    pub fn new(client: ClientType) -> Self {
+    pub fn new() -> Self {
         SharedGroup {
-            clients: vec![client],
+            clients: vec![],
             client_cursor: 0,
-            next_client: client,
         }
     }
+
     pub fn is_empty(&self) -> bool {
         self.clients.is_empty()
     }
 
-    pub fn add_client(&mut self, client: ClientType) {
-        // let mut updated_clients: Vec<String> = self.clients.collect();
-        // updated_clients.push(client);
-        // self.clients = updated_clients.into_iter().cycle();
+    pub fn current_client(&self) -> Option<&String> {
+        self.clients.get(self.client_cursor)
+    }
+
+    pub fn add_client(&mut self, client: String) {
         self.clients.push(client)
     }
 
-    pub fn remove_client(&mut self, client: ClientType) {
+    pub fn remove_client(&mut self, client: &String) {
         // remove client from vec
-        // let updated_clients: Vec<String> = self.clients.filter(|&c| c != client).collect();
-        // self.clients = updated_clients.into_iter().cycle();
+        self.clients.retain(|c| c != client);
 
-        self.clients.retain(|c| c != &client);
-        // Exit when there are no remaining clients.
-        if self.clients.is_empty() {
-            return;
+        // if there are no clients left, we have to avoid % by 0
+        if !self.clients.is_empty() {
+            // Make sure that we are within bounds and that next client is the correct client.
+            self.client_cursor %= self.clients.len();
         }
-        //Make sure that we are within bounds and that next client is the correct client.
-        self.client_cursor %= self.clients.len();
-        self.next_client = self.clients[self.client_cursor];
     }
 
     pub fn update_next_client(&mut self) {
-        // let mut clients = self.clients.iter().cycle();
-        // assert_eq!(
-        //     clients.find(|c| *c == &self.next_client),
-        //     Some(&self.next_client)
-        // );
-        // self.next_client = dbg!(*clients.next().unwrap());
         self.client_cursor = (self.client_cursor + 1) % self.clients.len();
-        self.next_client = self.clients[self.client_cursor];
     }
 }
 

--- a/rumqttd/src/router/shared_subs.rs
+++ b/rumqttd/src/router/shared_subs.rs
@@ -18,6 +18,10 @@ impl SharedGroup {
             next_client: client,
         }
     }
+    pub fn is_empty(&self) -> bool {
+        self.clients.is_empty()
+    }
+
     pub fn add_client(&mut self, client: ClientType) {
         // let mut updated_clients: Vec<String> = self.clients.collect();
         // updated_clients.push(client);
@@ -25,21 +29,19 @@ impl SharedGroup {
         self.clients.push(client)
     }
 
-    pub fn remove_client(&mut self, client: ClientType) -> bool {
+    pub fn remove_client(&mut self, client: ClientType) {
         // remove client from vec
         // let updated_clients: Vec<String> = self.clients.filter(|&c| c != client).collect();
         // self.clients = updated_clients.into_iter().cycle();
 
         self.clients.retain(|c| c != &client);
-        // Exit with false if there are no remaining clients.
+        // Exit when there are no remaining clients.
         if self.clients.is_empty() {
-            return false;
+            return;
         }
         //Make sure that we are within bounds and that next client is the correct client.
-        self.client_cursor = self.client_cursor % self.clients.len();
+        self.client_cursor %= self.clients.len();
         self.next_client = self.clients[self.client_cursor];
-
-        true
     }
 
     pub fn update_next_client(&mut self) {

--- a/rumqttd/src/router/shared_subs.rs
+++ b/rumqttd/src/router/shared_subs.rs
@@ -25,15 +25,21 @@ impl SharedGroup {
         self.clients.push(client)
     }
 
-    pub fn remove_client(&mut self, client: ClientType) {
+    pub fn remove_client(&mut self, client: ClientType) -> bool {
         // remove client from vec
         // let updated_clients: Vec<String> = self.clients.filter(|&c| c != client).collect();
         // self.clients = updated_clients.into_iter().cycle();
 
         self.clients.retain(|c| c != &client);
+        // Exit with false if there are no remaining clients.
+        if self.clients.is_empty() {
+            return false;
+        }
         //Make sure that we are within bounds and that next client is the correct client.
         self.client_cursor = self.client_cursor % self.clients.len();
         self.next_client = self.clients[self.client_cursor];
+
+        true
     }
 
     pub fn update_next_client(&mut self) {

--- a/rumqttd/src/router/shared_subs.rs
+++ b/rumqttd/src/router/shared_subs.rs
@@ -29,8 +29,11 @@ impl SharedGroup {
         // remove client from vec
         // let updated_clients: Vec<String> = self.clients.filter(|&c| c != client).collect();
         // self.clients = updated_clients.into_iter().cycle();
+
         self.clients.retain(|c| c != &client);
-        self.update_next_client()
+        //Make sure that we are within bounds and that next client is the correct client.
+        self.client_cursor = self.client_cursor % self.clients.len();
+        self.next_client = self.clients[self.client_cursor];
     }
 
     pub fn update_next_client(&mut self) {
@@ -42,5 +45,73 @@ impl SharedGroup {
         // self.next_client = dbg!(*clients.next().unwrap());
         self.client_cursor = (self.client_cursor + 1) % self.clients.len();
         self.next_client = self.clients[self.client_cursor];
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SharedGroup;
+
+    #[test]
+    fn performs_round_robin() {
+        let mut group = SharedGroup {
+            clients: vec![1, 2, 3],
+            client_cursor: 0,
+            next_client: 1,
+        };
+        group.update_next_client();
+        assert_eq!(group.next_client, 2);
+        assert_eq!(group.client_cursor, 1);
+        group.update_next_client();
+        assert_eq!(group.next_client, 3);
+        assert_eq!(group.client_cursor, 2);
+        group.update_next_client();
+        assert_eq!(group.next_client, 1);
+        assert_eq!(group.client_cursor, 0);
+        group.add_client(4);
+        assert_eq!(group.next_client, 1);
+        assert_eq!(group.client_cursor, 0);
+    }
+
+    #[test]
+    fn handles_round_robin_when_start_removed() {
+        // [ A, B, C ] => 0
+        // we remove A
+        // [ B, C ] => Should be the next client (B)
+        let mut group = SharedGroup {
+            clients: vec![1, 2, 3],
+            client_cursor: 0,
+            next_client: 1,
+        };
+        group.remove_client(1);
+        assert_eq!(group.next_client, 2);
+        assert_eq!(group.client_cursor, 0);
+        group.update_next_client();
+        assert_eq!(group.next_client, 3);
+        assert_eq!(group.client_cursor, 1);
+        group.update_next_client();
+        assert_eq!(group.next_client, 2);
+        assert_eq!(group.client_cursor, 0);
+    }
+
+    #[test]
+    fn handles_round_robin_when_last_removed() {
+        // [ A, B, C ] => 2 (C)
+        // we remove C
+        // [ A, B ] => Should be the next client (A)
+        let mut group = SharedGroup {
+            clients: vec![1, 2, 3],
+            client_cursor: 0,
+            next_client: 1,
+        };
+        group.update_next_client();
+        assert_eq!(group.next_client, 2);
+        assert_eq!(group.client_cursor, 1);
+        group.update_next_client();
+        assert_eq!(group.next_client, 3);
+        assert_eq!(group.client_cursor, 2);
+        group.remove_client(3);
+        assert_eq!(group.next_client, 1);
+        assert_eq!(group.client_cursor, 0);
     }
 }

--- a/rumqttd/src/router/shared_subs.rs
+++ b/rumqttd/src/router/shared_subs.rs
@@ -3,6 +3,8 @@ type ClientType = usize;
 pub struct SharedGroup {
     // using Vec over HashSet for maintaining order of iter
     clients: Vec<ClientType>,
+    // Index into clients, allows us to skip doing iter everytime
+    client_cursor: usize,
     // clients: Cycle<IntoIter<String>>,
     pub next_client: ClientType,
     // strategy: Strategy,
@@ -12,6 +14,7 @@ impl SharedGroup {
     pub fn new(client: ClientType) -> Self {
         SharedGroup {
             clients: vec![client],
+            client_cursor: 0,
             next_client: client,
         }
     }
@@ -26,15 +29,18 @@ impl SharedGroup {
         // remove client from vec
         // let updated_clients: Vec<String> = self.clients.filter(|&c| c != client).collect();
         // self.clients = updated_clients.into_iter().cycle();
-        self.clients.retain(|c| c != &client)
+        self.clients.retain(|c| c != &client);
+        self.update_next_client()
     }
 
     pub fn update_next_client(&mut self) {
-        let mut clients = self.clients.iter().cycle();
-        assert_eq!(
-            clients.find(|c| *c == &self.next_client),
-            Some(&self.next_client)
-        );
-        self.next_client = dbg!(*clients.next().unwrap());
+        // let mut clients = self.clients.iter().cycle();
+        // assert_eq!(
+        //     clients.find(|c| *c == &self.next_client),
+        //     Some(&self.next_client)
+        // );
+        // self.next_client = dbg!(*clients.next().unwrap());
+        self.client_cursor = (self.client_cursor + 1) % self.clients.len();
+        self.next_client = self.clients[self.client_cursor];
     }
 }

--- a/rumqttd/src/router/shared_subs.rs
+++ b/rumqttd/src/router/shared_subs.rs
@@ -1,0 +1,40 @@
+type ClientType = usize;
+
+pub struct SharedGroup {
+    // using Vec over HashSet for maintaining order of iter
+    clients: Vec<ClientType>,
+    // clients: Cycle<IntoIter<String>>,
+    pub next_client: ClientType,
+    // strategy: Strategy,
+}
+
+impl SharedGroup {
+    pub fn new(client: ClientType) -> Self {
+        SharedGroup {
+            clients: vec![client],
+            next_client: client,
+        }
+    }
+    pub fn add_client(&mut self, client: ClientType) {
+        // let mut updated_clients: Vec<String> = self.clients.collect();
+        // updated_clients.push(client);
+        // self.clients = updated_clients.into_iter().cycle();
+        self.clients.push(client)
+    }
+
+    pub fn remove_client(&mut self, client: ClientType) {
+        // remove client from vec
+        // let updated_clients: Vec<String> = self.clients.filter(|&c| c != client).collect();
+        // self.clients = updated_clients.into_iter().cycle();
+        self.clients.retain(|c| c != &client)
+    }
+
+    pub fn update_next_client(&mut self) {
+        let mut clients = self.clients.iter().cycle();
+        assert_eq!(
+            clients.find(|c| *c == &self.next_client),
+            Some(&self.next_client)
+        );
+        self.next_client = dbg!(*clients.next().unwrap());
+    }
+}

--- a/rumqttd/src/router/shared_subs.rs
+++ b/rumqttd/src/router/shared_subs.rs
@@ -1,20 +1,21 @@
+use serde::{Deserialize, Serialize};
+
 pub struct SharedGroup {
     // using Vec over HashSet for maintaining order of iter
     clients: Vec<String>,
     // Index into clients, allows us to skip doing iter everytime
     current_client_index: usize,
     pub cursor: (u64, u64),
-    // TODO; random, sticky strategy
-    // we can either have that logic in update_next_client or current_client
-    // strategy: Strategy,
+    pub strategy: Strategy,
 }
 
 impl SharedGroup {
-    pub fn new(cursor: (u64, u64)) -> Self {
+    pub fn new(cursor: (u64, u64), strategy: Strategy) -> Self {
         SharedGroup {
             clients: vec![],
             current_client_index: 0,
             cursor,
+            strategy,
         }
     }
 
@@ -42,8 +43,27 @@ impl SharedGroup {
     }
 
     pub fn update_next_client(&mut self) {
-        self.current_client_index = (self.current_client_index + 1) % self.clients.len();
+        match self.strategy {
+            Strategy::RoundRobin => {
+                self.current_client_index = (self.current_client_index + 1) % self.clients.len();
+            }
+            Strategy::Random => {
+                // how shall we randomly choose client
+                // we might need to add extra dependency
+                todo!()
+            }
+            Strategy::Sticky => {}
+        }
     }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum Strategy {
+    #[default]
+    RoundRobin,
+    Random,
+    Sticky,
 }
 
 #[cfg(test)]

--- a/rumqttd/src/router/shared_subs.rs
+++ b/rumqttd/src/router/shared_subs.rs
@@ -1,3 +1,4 @@
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 pub struct SharedGroup {
@@ -48,9 +49,7 @@ impl SharedGroup {
                 self.current_client_index = (self.current_client_index + 1) % self.clients.len();
             }
             Strategy::Random => {
-                // how shall we randomly choose client
-                // we might need to add extra dependency
-                todo!()
+                self.current_client_index = rand::thread_rng().gen_range(0..self.clients.len());
             }
             Strategy::Sticky => {}
         }


### PR DESCRIPTION
This PR adds support for shared subscriptions. This PR adds support for shared subscriptions in broker with the ability to use multiple strategies for it. The available strategies are as follows:

- round_robin (Default): 	In order of subscription, moving from first to last to first etc.
- random: 	Random selection among all subscribers, using `rand` crate to select a random client.
- sticky: 	Always send to the last selected subscriber, only moving when a client is no longer available.

Strategies are specified in the router config and by default commented but easily changeable.

This PR supersedes #628 and was made by me and @swanandx. 👍🏼 

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintanance) -->

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if its relevant of user of the library. If its not relevant mention why.
