### PR TITLE
rumqttc | Unbounded client support

### DIFF
--- a/benchmarks/clients/rumqttasync.rs
+++ b/benchmarks/clients/rumqttasync.rs
@@ -21,7 +21,7 @@ pub async fn start(id: &str, payload_size: usize, count: usize) -> Result<(), Bo
     mqttoptions.set_keep_alive(Duration::from_secs(20));
     mqttoptions.set_inflight(100);
 
-    let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    let (client, mut eventloop) = AsyncClient::new(mqttoptions, Some(10));
     task::spawn(async move {
         for _i in 0..count {
             let payload = vec![0; payload_size];

--- a/benchmarks/clients/rumqttasyncqos0.rs
+++ b/benchmarks/clients/rumqttasyncqos0.rs
@@ -21,7 +21,7 @@ pub async fn start(id: &str, payload_size: usize, count: usize) -> Result<(), Bo
     mqttoptions.set_keep_alive(Duration::from_secs(20));
     mqttoptions.set_inflight(100);
 
-    let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    let (client, mut eventloop) = AsyncClient::new(mqttoptions, Some(10));
     task::spawn(async move {
         for _i in 0..count {
             let payload = vec![0; payload_size];

--- a/benchmarks/clients/rumqttsync.rs
+++ b/benchmarks/clients/rumqttsync.rs
@@ -17,7 +17,7 @@ pub fn start(id: &str, payload_size: usize, count: usize) -> Result<(), Box<dyn 
     mqttoptions.set_keep_alive(Duration::from_secs(20));
     mqttoptions.set_inflight(100);
 
-    let (mut client, mut connection) = Client::new(mqttoptions, 10);
+    let (mut client, mut connection) = Client::new(mqttoptions, Some(10));
     thread::spawn(move || {
         for _i in 0..count {
             let payload = vec![0; payload_size];

--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changed `cap` parameter's type from `usize` to `Option<usize>` in `Client::new` and `AsyncClient::new` to decide whether the channel is bounded or unbounded.
+
 ### Deprecated
 
 ### Removed

--- a/rumqttc/README.md
+++ b/rumqttc/README.md
@@ -18,7 +18,7 @@ use std::thread;
 let mut mqttoptions = MqttOptions::new("rumqtt-sync", "test.mosquitto.org", 1883);
 mqttoptions.set_keep_alive(Duration::from_secs(5));
 
-let (mut client, mut connection) = Client::new(mqttoptions, 10);
+let (mut client, mut connection) = Client::new(mqttoptions, Some(10));
 client.subscribe("hello/rumqtt", QoS::AtMostOnce).unwrap();
 thread::spawn(move || for i in 0..10 {
    client.publish("hello/rumqtt", QoS::AtLeastOnce, false, vec![i; i as usize]).unwrap();
@@ -43,7 +43,7 @@ use std::error::Error;
 let mut mqttoptions = MqttOptions::new("rumqtt-async", "test.mosquitto.org", 1883);
 mqttoptions.set_keep_alive(Duration::from_secs(5));
 
-let (mut client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+let (mut client, mut eventloop) = AsyncClient::new(mqttoptions, Some(10));
 client.subscribe("hello/rumqtt", QoS::AtMostOnce).await.unwrap();
 
 task::spawn(async move {

--- a/rumqttc/examples/async_manual_acks.rs
+++ b/rumqttc/examples/async_manual_acks.rs
@@ -11,7 +11,7 @@ fn create_conn() -> (AsyncClient, EventLoop) {
         .set_manual_acks(true)
         .set_clean_session(false);
 
-    AsyncClient::new(mqttoptions, 10)
+    AsyncClient::new(mqttoptions, Some(10))
 }
 
 #[tokio::main(worker_threads = 1)]

--- a/rumqttc/examples/async_manual_acks_v5.rs
+++ b/rumqttc/examples/async_manual_acks_v5.rs
@@ -14,7 +14,7 @@ fn create_conn() -> (AsyncClient, EventLoop) {
         .set_manual_acks(true)
         .set_clean_start(false);
 
-    AsyncClient::new(mqttoptions, 10)
+    AsyncClient::new(mqttoptions, Some(10))
 }
 
 #[tokio::main(worker_threads = 1)]

--- a/rumqttc/examples/asyncpubsub.rs
+++ b/rumqttc/examples/asyncpubsub.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut mqttoptions = MqttOptions::new("test-1", "localhost", 1883);
     mqttoptions.set_keep_alive(Duration::from_secs(5));
 
-    let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    let (client, mut eventloop) = AsyncClient::new(mqttoptions, Some(10));
     task::spawn(async move {
         requests(client).await;
         time::sleep(Duration::from_secs(3)).await;

--- a/rumqttc/examples/asyncpubsub_v5.rs
+++ b/rumqttc/examples/asyncpubsub_v5.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut mqttoptions = MqttOptions::new("test-1", "localhost", 1884);
     mqttoptions.set_keep_alive(Duration::from_secs(5));
 
-    let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    let (client, mut eventloop) = AsyncClient::new(mqttoptions, Some(10));
     task::spawn(async move {
         requests(client).await;
         time::sleep(Duration::from_secs(3)).await;

--- a/rumqttc/examples/serde.rs
+++ b/rumqttc/examples/serde.rs
@@ -34,7 +34,7 @@ impl TryFrom<&[u8]> for Message {
 fn main() {
     let mqqt_opts = MqttOptions::new("test-1", "localhost", 1883);
 
-    let (mut client, mut connection) = Client::new(mqqt_opts, 10);
+    let (mut client, mut connection) = Client::new(mqqt_opts, Some(10));
     client.subscribe("hello/rumqtt", QoS::AtMostOnce).unwrap();
     thread::spawn(move || {
         for i in 0..10 {

--- a/rumqttc/examples/syncpubsub.rs
+++ b/rumqttc/examples/syncpubsub.rs
@@ -11,7 +11,7 @@ fn main() {
         .set_keep_alive(Duration::from_secs(5))
         .set_last_will(will);
 
-    let (client, mut connection) = Client::new(mqttoptions, 10);
+    let (client, mut connection) = Client::new(mqttoptions, Some(10));
     thread::spawn(move || publish(client));
 
     for (i, notification) in connection.iter().enumerate() {

--- a/rumqttc/examples/syncpubsub_v5.rs
+++ b/rumqttc/examples/syncpubsub_v5.rs
@@ -12,7 +12,7 @@ fn main() {
         .set_keep_alive(Duration::from_secs(5))
         .set_last_will(will);
 
-    let (client, mut connection) = Client::new(mqttoptions, 10);
+    let (client, mut connection) = Client::new(mqttoptions, Some(10));
     thread::spawn(move || publish(client));
 
     for (i, notification) in connection.iter().enumerate() {

--- a/rumqttc/examples/syncrecv.rs
+++ b/rumqttc/examples/syncrecv.rs
@@ -11,7 +11,7 @@ fn main() {
         .set_keep_alive(Duration::from_secs(5))
         .set_last_will(will);
 
-    let (client, mut connection) = Client::new(mqttoptions, 10);
+    let (client, mut connection) = Client::new(mqttoptions, Some(10));
     thread::spawn(move || publish(client));
 
     if let Ok(notification) = connection.recv() {

--- a/rumqttc/examples/syncrecv_v5.rs
+++ b/rumqttc/examples/syncrecv_v5.rs
@@ -12,7 +12,7 @@ fn main() {
         .set_keep_alive(Duration::from_secs(5))
         .set_last_will(will);
 
-    let (client, mut connection) = Client::new(mqttoptions, 10);
+    let (client, mut connection) = Client::new(mqttoptions, Some(10));
     thread::spawn(move || publish(client));
 
     if let Ok(notification) = connection.recv() {

--- a/rumqttc/examples/tls.rs
+++ b/rumqttc/examples/tls.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     mqttoptions.set_transport(Transport::tls_with_config(client_config.into()));
 
-    let (_client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    let (_client, mut eventloop) = AsyncClient::new(mqttoptions, Some(10));
 
     loop {
         match eventloop.poll().await {

--- a/rumqttc/examples/tls2.rs
+++ b/rumqttc/examples/tls2.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     mqttoptions.set_transport(transport);
 
-    let (_client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    let (_client, mut eventloop) = AsyncClient::new(mqttoptions, Some(10));
 
     loop {
         match eventloop.poll().await {

--- a/rumqttc/examples/topic_alias.rs
+++ b/rumqttc/examples/topic_alias.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     mqttoptions.set_keep_alive(Duration::from_secs(5));
     mqttoptions.set_topic_alias_max(10.into());
 
-    let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    let (client, mut eventloop) = AsyncClient::new(mqttoptions, Some(10));
     task::spawn(async move {
         requests(client).await;
         time::sleep(Duration::from_secs(3)).await;

--- a/rumqttc/examples/unbounded.rs
+++ b/rumqttc/examples/unbounded.rs
@@ -1,0 +1,23 @@
+use rumqttc::{Client, MqttOptions, QoS};
+use std::thread;
+use std::time::Duration;
+
+fn main() {
+    let mqqt_opts = MqttOptions::new("test-1", "localhost", 1883);
+
+    let (mut client, mut connection) = Client::new(mqqt_opts, None);
+    client.subscribe("hello/rumqtt", QoS::AtMostOnce).unwrap();
+    thread::spawn(move || {
+        for i in 0..10 {
+            client
+                .publish("hello/rumqtt", QoS::AtLeastOnce, false, vec![1; i])
+                .unwrap();
+            thread::sleep(Duration::from_millis(100));
+        }
+    });
+
+    // Iterate to poll the eventloop for connection progress
+    for notification in connection.iter() {
+        println!("Notification = {:?}", notification);
+    }
+}

--- a/rumqttc/examples/websocket.rs
+++ b/rumqttc/examples/websocket.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     mqttoptions.set_transport(Transport::Ws);
     mqttoptions.set_keep_alive(Duration::from_secs(60));
 
-    let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    let (client, mut eventloop) = AsyncClient::new(mqttoptions, Some(10));
     task::spawn(async move {
         requests(client).await;
         time::sleep(Duration::from_secs(3)).await;

--- a/rumqttc/examples/websocket_proxy.rs
+++ b/rumqttc/examples/websocket_proxy.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         port: 8100,
     });
 
-    let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    let (client, mut eventloop) = AsyncClient::new(mqttoptions, Some(10));
     task::spawn(async move {
         requests(client).await;
         time::sleep(Duration::from_secs(3)).await;

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -47,8 +47,8 @@ pub struct AsyncClient {
 impl AsyncClient {
     /// Create a new `AsyncClient`.
     ///
-    /// `cap` specifies the capacity of the bounded async channel.
-    pub fn new(options: MqttOptions, cap: usize) -> (AsyncClient, EventLoop) {
+    /// `cap` specifies the capacity of the bounded async channel. If is `None`, the channel is unbounded.
+    pub fn new(options: MqttOptions, cap: Option<usize>) -> (AsyncClient, EventLoop) {
         let eventloop = EventLoop::new(options, cap);
         let request_tx = eventloop.requests_tx.clone();
 
@@ -242,8 +242,8 @@ pub struct Client {
 impl Client {
     /// Create a new `Client`
     ///
-    /// `cap` specifies the capacity of the bounded async channel.
-    pub fn new(options: MqttOptions, cap: usize) -> (Client, Connection) {
+    /// `cap` specifies the capacity of the bounded async channel. If is `None`, the channel is unbounded.
+    pub fn new(options: MqttOptions, cap: Option<usize>) -> (Client, Connection) {
         let (client, eventloop) = AsyncClient::new(options, cap);
         let client = Client { client };
         let runtime = runtime::Builder::new_current_thread()
@@ -498,7 +498,7 @@ mod test {
             .set_keep_alive(Duration::from_secs(5))
             .set_last_will(will);
 
-        let (_, mut connection) = Client::new(mqttoptions, 10);
+        let (_, mut connection) = Client::new(mqttoptions, Some(10));
         let _ = connection.iter();
         let _ = connection.iter();
     }

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -4,7 +4,7 @@ use crate::{MqttOptions, Outgoing};
 
 use crate::framed::N;
 use crate::mqttbytes::v4::*;
-use flume::{bounded, Receiver, Sender};
+use flume::{bounded, unbounded, Receiver, Sender};
 use tokio::net::{lookup_host, TcpSocket, TcpStream};
 use tokio::select;
 use tokio::time::{self, Instant, Sleep};
@@ -96,8 +96,11 @@ impl EventLoop {
     ///
     /// When connection encounters critical errors (like auth failure), user has a choice to
     /// access and update `options`, `state` and `requests`.
-    pub fn new(mqtt_options: MqttOptions, cap: usize) -> EventLoop {
-        let (requests_tx, requests_rx) = bounded(cap);
+    pub fn new(mqtt_options: MqttOptions, cap: Option<usize>) -> EventLoop {
+        let (requests_tx, requests_rx) = match cap {
+            Some(cap) => bounded(cap),
+            None => unbounded(),
+        };
         let pending = Vec::new();
         let pending = pending.into_iter();
         let max_inflight = mqtt_options.inflight;

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -16,7 +16,7 @@
 //! let mut mqttoptions = MqttOptions::new("rumqtt-sync", "test.mosquitto.org", 1883);
 //! mqttoptions.set_keep_alive(Duration::from_secs(5));
 //!
-//! let (mut client, mut connection) = Client::new(mqttoptions, 10);
+//! let (mut client, mut connection) = Client::new(mqttoptions, Some(10));
 //! client.subscribe("hello/rumqtt", QoS::AtMostOnce).unwrap();
 //! thread::spawn(move || for i in 0..10 {
 //!    client.publish("hello/rumqtt", QoS::AtLeastOnce, false, vec![i; i as usize]).unwrap();
@@ -43,7 +43,7 @@
 //! let mut mqttoptions = MqttOptions::new("rumqtt-async", "test.mosquitto.org", 1883);
 //! mqttoptions.set_keep_alive(Duration::from_secs(5));
 //!
-//! let (mut client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+//! let (mut client, mut eventloop) = AsyncClient::new(mqttoptions, Some(10));
 //! client.subscribe("hello/rumqtt", QoS::AtMostOnce).await.unwrap();
 //!
 //! task::spawn(async move {

--- a/rumqttc/src/v5/client.rs
+++ b/rumqttc/src/v5/client.rs
@@ -52,8 +52,8 @@ pub struct AsyncClient {
 impl AsyncClient {
     /// Create a new `AsyncClient`.
     ///
-    /// `cap` specifies the capacity of the bounded async channel.
-    pub fn new(options: MqttOptions, cap: usize) -> (AsyncClient, EventLoop) {
+    /// `cap` specifies the capacity of the bounded async channel. If is `None`, the channel is unbounded.
+    pub fn new(options: MqttOptions, cap: Option<usize>) -> (AsyncClient, EventLoop) {
         let eventloop = EventLoop::new(options, cap);
         let request_tx = eventloop.requests_tx.clone();
 
@@ -456,8 +456,8 @@ pub struct Client {
 impl Client {
     /// Create a new `Client`
     ///
-    /// `cap` specifies the capacity of the bounded async channel.
-    pub fn new(options: MqttOptions, cap: usize) -> (Client, Connection) {
+    /// `cap` specifies the capacity of the bounded async channel. If is `None`, the channel is unbounded.
+    pub fn new(options: MqttOptions, cap: Option<usize>) -> (Client, Connection) {
         let (client, eventloop) = AsyncClient::new(options, cap);
         let client = Client { client };
 
@@ -842,7 +842,7 @@ mod test {
             .set_keep_alive(Duration::from_secs(5))
             .set_last_will(will);
 
-        let (_, mut connection) = Client::new(mqttoptions, 10);
+        let (_, mut connection) = Client::new(mqttoptions, Some(10));
         let _ = connection.iter();
         let _ = connection.iter();
     }

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -4,7 +4,7 @@ use super::{Incoming, MqttOptions, MqttState, Outgoing, Request, StateError, Tra
 use crate::eventloop::socket_connect;
 use crate::framed::N;
 
-use flume::{bounded, Receiver, Sender};
+use flume::{bounded, unbounded, Receiver, Sender};
 use tokio::select;
 use tokio::time::{self, error::Elapsed, Instant, Sleep};
 
@@ -94,8 +94,11 @@ impl EventLoop {
     ///
     /// When connection encounters critical errors (like auth failure), user has a choice to
     /// access and update `options`, `state` and `requests`.
-    pub fn new(options: MqttOptions, cap: usize) -> EventLoop {
-        let (requests_tx, requests_rx) = bounded(cap);
+    pub fn new(options: MqttOptions, cap: Option<usize>) -> EventLoop {
+        let (requests_tx, requests_rx) = match cap {
+            Some(cap) => bounded(cap),
+            None => unbounded(),
+        };
         let pending = Vec::new();
         let pending = pending.into_iter();
         let inflight_limit = options.outgoing_inflight_upper_limit.unwrap_or(u16::MAX);

--- a/rumqttc/tests/reliability.rs
+++ b/rumqttc/tests/reliability.rs
@@ -78,7 +78,7 @@ async fn connection_should_timeout_on_time() {
 
     time::sleep(Duration::from_secs(1)).await;
     let options = MqttOptions::new("dummy", "127.0.0.1", 1880);
-    let mut eventloop = EventLoop::new(options, 5);
+    let mut eventloop = EventLoop::new(options, Some(5));
 
     let start = Instant::now();
     let o = eventloop.poll().await;
@@ -102,7 +102,7 @@ async fn idle_connection_triggers_pings_on_time() {
 
     // Create client eventloop and poll
     task::spawn(async move {
-        let mut eventloop = EventLoop::new(options, 5);
+        let mut eventloop = EventLoop::new(options, Some(5));
         run(&mut eventloop, false).await.unwrap();
     });
 
@@ -138,7 +138,7 @@ async fn some_outgoing_and_no_incoming_should_trigger_pings_on_time() {
 
     // start sending qos0 publishes. this makes sure that there is
     // outgoing activity but no incoming activity
-    let (client, mut eventloop) = AsyncClient::new(options, 5);
+    let (client, mut eventloop) = AsyncClient::new(options, Some(5));
 
     // Start sending publishes
     task::spawn(async move {
@@ -181,7 +181,7 @@ async fn some_incoming_and_no_outgoing_should_trigger_pings_on_time() {
     options.set_keep_alive(Duration::from_secs(keep_alive));
 
     task::spawn(async move {
-        let mut eventloop = EventLoop::new(options, 5);
+        let mut eventloop = EventLoop::new(options, Some(5));
         run(&mut eventloop, false).await.unwrap();
     });
 
@@ -225,7 +225,7 @@ async fn detects_halfopen_connections_in_the_second_ping_request() {
 
     time::sleep(Duration::from_secs(1)).await;
     let start = Instant::now();
-    let mut eventloop = EventLoop::new(options, 5);
+    let mut eventloop = EventLoop::new(options, Some(5));
     loop {
         if let Err(e) = eventloop.poll().await {
             match e {
@@ -250,7 +250,7 @@ async fn requests_are_blocked_after_max_inflight_queue_size() {
 
     // start sending qos0 publishes. this makes sure that there is
     // outgoing activity but no incoming activity
-    let (client, mut eventloop) = AsyncClient::new(options, 5);
+    let (client, mut eventloop) = AsyncClient::new(options, Some(5));
     task::spawn(async move {
         start_requests(10, QoS::AtLeastOnce, 1, client).await;
     });
@@ -275,7 +275,7 @@ async fn requests_are_recovered_after_inflight_queue_size_falls_below_max() {
     let mut options = MqttOptions::new("dummy", "127.0.0.1", 1888);
     options.set_inflight(3);
 
-    let (client, mut eventloop) = AsyncClient::new(options, 5);
+    let (client, mut eventloop) = AsyncClient::new(options, Some(5));
 
     task::spawn(async move {
         start_requests(5, QoS::AtLeastOnce, 1, client).await;
@@ -314,7 +314,7 @@ async fn packet_id_collisions_are_detected_and_flow_control_is_applied() {
     let mut options = MqttOptions::new("dummy", "127.0.0.1", 1891);
     options.set_inflight(10);
 
-    let (client, mut eventloop) = AsyncClient::new(options, 5);
+    let (client, mut eventloop) = AsyncClient::new(options, Some(5));
 
     task::spawn(async move {
         start_requests(15, QoS::AtLeastOnce, 0, client).await;
@@ -436,7 +436,7 @@ async fn next_poll_after_connect_failure_reconnects() {
     });
 
     time::sleep(Duration::from_secs(1)).await;
-    let mut eventloop = EventLoop::new(options, 5);
+    let mut eventloop = EventLoop::new(options, Some(5));
 
     match eventloop.poll().await {
         Err(ConnectionError::ConnectionRefused(ConnectReturnCode::BadUserNamePassword)) => (),
@@ -458,7 +458,7 @@ async fn reconnection_resumes_from_the_previous_state() {
     options.set_keep_alive(Duration::from_secs(5));
 
     // start sending qos0 publishes. Makes sure that there is out activity but no in activity
-    let (client, mut eventloop) = AsyncClient::new(options, 5);
+    let (client, mut eventloop) = AsyncClient::new(options, Some(5));
     task::spawn(async move {
         start_requests(10, QoS::AtLeastOnce, 1, client).await;
         time::sleep(Duration::from_secs(10)).await;
@@ -499,7 +499,7 @@ async fn reconnection_resends_unacked_packets_from_the_previous_connection_first
 
     // start sending qos0 publishes. this makes sure that there is
     // outgoing activity but no incoming activity
-    let (client, mut eventloop) = AsyncClient::new(options, 5);
+    let (client, mut eventloop) = AsyncClient::new(options, Some(5));
     task::spawn(async move {
         start_requests(10, QoS::AtLeastOnce, 1, client).await;
         time::sleep(Duration::from_secs(10)).await;
@@ -532,7 +532,7 @@ async fn state_is_being_cleaned_properly_and_pending_request_calculated_properly
     let mut network_options = NetworkOptions::new();
     network_options.set_tcp_send_buffer_size(1024);
 
-    let (client, mut eventloop) = AsyncClient::new(options, 5);
+    let (client, mut eventloop) = AsyncClient::new(options, Some(5));
     eventloop.set_network_options(network_options);
     task::spawn(async move {
         start_requests_with_payload(100, QoS::AtLeastOnce, 0, client, 5000).await;


### PR DESCRIPTION
## Type of change

Fix #658 

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
   Add support for unbounded client.
   Changed `cap` parameter's type from `usize` to `Option<usize>` in `Client::new` and `AsyncClient::new` to decide whether the channel is bounded or unbounded.
   _Before:_
   ```rs
   Client::new(mqttoptions, 10);   // Bounded only
   ```
   _Now:_
   ```rs
   Client::new(mqttoptions, Some(10));   // Bounded
   Client::new(mqttoptions, None);         // Unbounded
   ```

## Checklist:

- [X] Formatted with `cargo fmt`
- [X] Make an entry to `CHANGELOG.md` if its relevant of user of the library. If its not relevant mention why.


## 🆘 Help 🆘

I need help with *tests*, thanks!