### PR TITLE
feat: configure cross to support x86_64 and aarch64 for linux/musl

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,3 +1,5 @@
+# N.B. The following dependencies are required for all targets to be built: 'qemu' and 'qemu-user-static'
+
 [build]
 pre-build = [
     "dpkg --add-architecture $CROSS_DEB_ARCH",

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,8 +1,15 @@
-[target.x86_64-unknown-linux-musl]
-image = "clux/muslrust:stable"
-
-[target.x86_64-unknown-linux-gnu]
+[build]
 pre-build = [
     "dpkg --add-architecture $CROSS_DEB_ARCH",
     "apt-get update && apt-get install --assume-yes libssl-dev:$CROSS_DEB_ARCH"
 ]
+
+[target.x86_64-unknown-linux-musl]
+image.name = "alpine:edge"
+image.toolchain = ["x86_64-unknown-linux-musl"]
+pre-build = ["apk add --no-cache build-base openssl-dev"]
+
+[target.aarch64-unknown-linux-musl]
+image.name = "alpine:edge"
+image.toolchain = ["aarch64-unknown-linux-musl"]
+pre-build = ["apk add --no-cache build-base openssl-dev"]


### PR DESCRIPTION
Related to PR #671 and PR #673

What has been changed:

- Configure `cross` for enhanced cross compilation supporting `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` and more...