### PR TITLE
chore(mqttverifier): fix typo and better structure with jsdoc type

### DIFF
--- a/utils/mqttverifier/README.md
+++ b/utils/mqttverifier/README.md
@@ -1,0 +1,5 @@
+# MQTT Verifier
+
+```sh
+node path/to/file.js
+```

--- a/utils/mqttverifier/package-lock.json
+++ b/utils/mqttverifier/package-lock.json
@@ -1,12 +1,24 @@
 {
   "name": "mqttverifier",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
-        "mqtt-packet": "^6.6.0"
+        "mqtt-packet": "^8.2.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.4.8"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
       }
+    },
+    "node_modules/@types/node": {
+      "version": "20.4.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.8.tgz",
+      "integrity": "sha512-0mHckf6D2DiIAzh8fM8f3HQCvMKDpK94YQ0DSVkfWTG9BZleYIWudw9cJxX8oCk9bM+vAkDyujDV6dmKHbvQpg==",
+      "dev": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -28,19 +40,19 @@
       ]
     },
     "node_modules/bl": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
       "dependencies": {
-        "buffer": "^5.5.0",
+        "buffer": "^6.0.3",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
     },
     "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
           "type": "github",
@@ -57,13 +69,13 @@
       ],
       "dependencies": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -101,11 +113,11 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/mqtt-packet": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.6.0.tgz",
-      "integrity": "sha512-LvghnKMFC70hKWMVykmhJarlO5e7lT3t9s9A2qPCUx+lazL3Mq55U+eCV0eLi7/nRRQYvEUWo/2tTo89EjnCJQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-8.2.0.tgz",
+      "integrity": "sha512-21Vo7XdRXUw2qhdTfk8GeOl2jtb8Dkwd4dKxn/epvf37mxTxHodvBJoozTPZGVwh57JXlsh2ChsaxMsAfqxp+A==",
       "dependencies": {
-        "bl": "^4.0.2",
+        "bl": "^5.0.0",
         "debug": "^4.1.1",
         "process-nextick-args": "^2.0.1"
       }
@@ -121,9 +133,9 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -163,99 +175,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    }
-  },
-  "dependencies": {
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
-    "bl": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
-      "requires": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
-    "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "requires": {
-        "ms": "2.1.2"
-      }
-    },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "mqtt-packet": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.6.0.tgz",
-      "integrity": "sha512-LvghnKMFC70hKWMVykmhJarlO5e7lT3t9s9A2qPCUx+lazL3Mq55U+eCV0eLi7/nRRQYvEUWo/2tTo89EjnCJQ==",
-      "requires": {
-        "bl": "^4.0.2",
-        "debug": "^4.1.1",
-        "process-nextick-args": "^2.0.1"
-      }
-    },
-    "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
-    "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     }
   }
 }

--- a/utils/mqttverifier/package.json
+++ b/utils/mqttverifier/package.json
@@ -1,5 +1,13 @@
 {
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">= 18.12.0"
+  },
   "dependencies": {
-    "mqtt-packet": "^6.6.0"
+    "mqtt-packet": "^8.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.4.8"
   }
 }

--- a/utils/mqttverifier/printer.js
+++ b/utils/mqttverifier/printer.js
@@ -1,0 +1,18 @@
+/**
+ * Print the buffer to console.
+ * 
+ * @param {Buffer} buffer - Buffer
+ * @returns {void}
+ */
+export function printer(buffer) {
+    let output = "[";
+    for (const [i, byte] of buffer.entries()) {
+        output += `0x${byte.toString(16).padStart(2, "0")}`;
+        if (i < buffer.length - 1) {
+            output += ", ";
+        }
+    }
+    output += "]";
+
+    console.log(output);
+}

--- a/utils/mqttverifier/suback/s0.js
+++ b/utils/mqttverifier/suback/s0.js
@@ -1,31 +1,23 @@
-const mqtt = require('mqtt-packet');
+import mqtt from "mqtt-packet";
+import { printer } from "../printer.js";
 
+/** @type {mqtt.Packet} */
 const packet = {
-	cmd: 'suback',
-	messageId: 42,
-	properties: { // MQTT 5.0 properties
-		reasonString: 'test',
-		userProperties: {
-			'test': 'test'
-		}
-	},
-	granted: [0, 1, 2, 128]
-}
+    cmd: "suback",
+    messageId: 42,
+    properties: {
+        // MQTT 5.0 properties
+        reasonString: "test",
+        userProperties: {
+            test: "test"
+        }
+    },
+    granted: [0, 1, 2, 128]
+};
 
-
+/** @type {unknown} */
 const opts = { protocolVersion: 5 };
-let data = mqtt.generate(packet, opts);
-print(data);
 
+const buffer = mqtt.generate(packet, opts);
 
-function print(data) {
-	let out = "";
-	for (var i = 0; i < data.length; i++) {
-		const hex = Number(data[i]).toString(16).padStart(2, '0');
-		out = out + "0x" + hex + ", ";
-	}
-
-	console.log("[" + out + "]");
-}
-
-
+printer(buffer);

--- a/utils/mqttverifier/subscribe/s0.js
+++ b/utils/mqttverifier/subscribe/s0.js
@@ -1,38 +1,31 @@
-const mqtt = require('mqtt-packet');
+import mqtt from "mqtt-packet";
+import { printer } from "../printer.js";
 
-
+/** @type {mqtt.Packet} */
 const packet = {
-	cmd: 'subscribe',
-	messageId: 42,
-	properties: { // MQTT 5.0 properties
-		subscriptionIdentifier: 100,
-		userProperties: {
-			test: 'test'
-		}
-	},
-	subscriptions: [{
-		topic: 'hello',
-		qos: 1,
-		nl: true, // no Local MQTT 5.0 flag
-		rap: true, // Retain as Published MQTT 5.0 flag
-		rh: 2 // Retain Handling MQTT 5.0
-	}]
+    cmd: "subscribe",
+    messageId: 42,
+    properties: {
+        // MQTT 5.0 properties
+        subscriptionIdentifier: 100,
+        userProperties: {
+            test: "test"
+        }
+    },
+    subscriptions: [
+        {
+            topic: "hello",
+            qos: 1,
+            nl: true, // No Local MQTT 5.0 flag
+            rap: true, // Retain as Published MQTT 5.0 flag
+            rh: 2 // Retain Handling MQTT 5.0
+        }
+    ]
 };
 
-
+/** @type {unknown} */
 const opts = { protocolVersion: 5 };
-let data = mqtt.generate(packet, opts);
-print(data);
 
+const buffer = mqtt.generate(packet, opts);
 
-function print(data) {
-	let out = "";
-	for (var i = 0; i < data.length; i++) {
-		const hex = Number(data[i]).toString(16).padStart(2, '0');
-		out = out + "0x" + hex + ", ";
-	}
-
-	console.log("[" + out + "]");
-}
-
-
+printer(buffer);

--- a/utils/mqttverifier/subscribe/s1.js
+++ b/utils/mqttverifier/subscribe/s1.js
@@ -1,32 +1,24 @@
-const mqtt = require('mqtt-packet');
+import mqtt from "mqtt-packet";
+import { printer } from "../printer.js";
 
-
+/** @type {mqtt.Packet} */
 const packet = {
-	cmd: 'subscribe',
-	messageId: 42,
-	subscriptions: [{
-		topic: 'hello/world',
-		qos: 1,
-		nl: false, // no Local MQTT 5.0 flag
-		rap: false, // Retain as Published MQTT 5.0 flag
-		rh: 0 // Retain Handling MQTT 5.0
-	}]
+    cmd: "subscribe",
+    messageId: 42,
+    subscriptions: [
+        {
+            topic: "hello/world",
+            qos: 1,
+            nl: false, // No Local MQTT 5.0 flag
+            rap: false, // Retain as Published MQTT 5.0 flag
+            rh: 0 // Retain Handling MQTT 5.0
+        }
+    ]
 };
 
-
+/** @type {unknown} */
 const opts = { protocolVersion: 5 };
-let data = mqtt.generate(packet, opts);
-print(data);
 
+const buffer = mqtt.generate(packet, opts);
 
-function print(data) {
-	let out = "";
-	for (var i = 0; i < data.length; i++) {
-		const hex = Number(data[i]).toString(16).padStart(2, '0');
-		out = out + "0x" + hex + ", ";
-	}
-
-	console.log("[" + out + "]");
-}
-
-
+printer(buffer);

--- a/utils/mqttverifier/unsuback/s0.js
+++ b/utils/mqttverifier/unsuback/s0.js
@@ -1,31 +1,22 @@
-const mqtt = require('mqtt-packet');
+import mqtt from "mqtt-packet";
+import { printer } from "../printer.js";
 
+/** @type {mqtt.Packet} */
 const packet = {
-	cmd: 'unsuback',
-	messageId: 10,
-	properties: { // MQTT 5.0 properties
-		reasonString: 'test',
-		userProperties: {
-			'test': 'test'
-		}
-	},
-	granted: [135, 143]
-}
+    cmd: "unsuback",
+    messageId: 10,
+    properties: {
+        // MQTT 5.0 properties
+        reasonString: "test",
+        userProperties: {
+            test: "test"
+        }
+    }
+};
 
-
+/** @type {unknown} */
 const opts = { protocolVersion: 5 };
-let data = mqtt.generate(packet, opts);
-print(data);
 
+const buffer = mqtt.generate(packet, opts);
 
-function print(data) {
-	let out = "";
-	for (var i = 0; i < data.length; i++) {
-		const hex = Number(data[i]).toString(16).padStart(2, '0');
-		out = out + "0x" + hex + ", ";
-	}
-
-	console.log("[" + out + "]");
-}
-
-
+printer(buffer);

--- a/utils/mqttverifier/unsubscribe/s0.js
+++ b/utils/mqttverifier/unsubscribe/s0.js
@@ -1,31 +1,22 @@
-const mqtt = require('mqtt-packet');
+import mqtt from "mqtt-packet";
+import { printer } from "../printer.js";
 
-
+/** @type {mqtt.Packet} */
 const packet = {
-	cmd: 'unsubscribe',
-	messageId: 10,
-	properties: { // MQTT 5.0 properties
-		userProperties: {
-			test: 'test'
-		}
-	},
-	unsubscriptions: ["hello", "world"]
+    cmd: "unsubscribe",
+    messageId: 10,
+    properties: {
+        // MQTT 5.0 properties
+        userProperties: {
+            test: "test"
+        }
+    },
+    unsubscriptions: ["hello", "world"]
 };
 
-
+/** @type {unknown} */
 const opts = { protocolVersion: 5 };
-let data = mqtt.generate(packet, opts);
-print(data);
 
+const buffer = mqtt.generate(packet, opts);
 
-function print(data) {
-	let out = "";
-	for (var i = 0; i < data.length; i++) {
-		const hex = Number(data[i]).toString(16).padStart(2, '0');
-		out = out + "0x" + hex + ", ";
-	}
-
-	console.log("[" + out + "]");
-}
-
-
+printer(buffer);

--- a/utils/mqttverifier/unsubscribe/s1.js
+++ b/utils/mqttverifier/unsubscribe/s1.js
@@ -1,26 +1,16 @@
-const mqtt = require('mqtt-packet');
+import mqtt from "mqtt-packet";
+import { printer } from "../printer.js";
 
-
+/** @type {mqtt.Packet} */
 const packet = {
-	cmd: 'unsubscribe',
-	messageId: 10,
-	unsubscriptions: ["hello"]
+    cmd: "unsubscribe",
+    messageId: 10,
+    unsubscriptions: ["hello"]
 };
 
-
+/** @type {unknown} */
 const opts = { protocolVersion: 5 };
-let data = mqtt.generate(packet, opts);
-print(data);
 
+const buffer = mqtt.generate(packet, opts);
 
-function print(data) {
-	let out = "";
-	for (var i = 0; i < data.length; i++) {
-		const hex = Number(data[i]).toString(16).padStart(2, '0');
-		out = out + "0x" + hex + ", ";
-	}
-
-	console.log("[" + out + "]");
-}
-
-
+printer(buffer);


### PR DESCRIPTION
Related to PR #671 and PR #677

What has been changed:

- `rumqttverifier`
   Better structure (and README) with type info/suggestions via JSDoc
   Note that in `unsuback/s0.js` I've fixed an invalid property for that type of message.