### PR TITLE
chore: enhance cargo workspace and release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,22 @@
 [workspace]
-
 members = [
   "rumqttc",
   "rumqttd",
   "benchmarks",
   "benchmarks/simplerouter",
 ]
+
+[workspace.package]
+rust-version = "1.70.0"
+edition = "2021"
+repository = "https://github.com/bytebeamio/rumqtt"
+license = "Apache-2.0"
+authors = ["tekjar <raviteja@bytebeam.io>"]
+
+[profile.dev.build-override]
+debug = true
+
+[profile.release]
+codegen-units = 1
+lto = true
+strip = true

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "benchmarks"
 version = "0.4.0"
-authors = ["tekjar <raviteja@bytebeam.io>"]
-edition = "2018"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
+rust-version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+authors.workspace = true
 
 [dependencies]
 bytes = "1"

--- a/benchmarks/simplerouter/Cargo.toml
+++ b/benchmarks/simplerouter/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "simplerouter"
 version = "0.1.0"
-edition = "2021"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
+rust-version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+authors.workspace = true
 
 [dependencies]
 bytes = "1"

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
 name = "rumqttc"
 version = "0.22.0"
+publish = true
 description = "An efficient and robust mqtt client for your connected devices"
-license = "Apache-2.0"
-repository = "https://github.com/bytebeamio/rumqtt"
-authors = ["tekjar"]
-edition = "2018"
 keywords = ["mqtt", "iot", "coap", "http"]
 categories = ["network-programming"]
+rust-version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+authors.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -528,8 +528,6 @@ impl MqttOptions {
     /// options.set_transport(Transport::tls_with_config(client_config.into()));
     /// ```
     pub fn parse_url<S: Into<String>>(url: S) -> Result<MqttOptions, OptionError> {
-        use std::convert::TryFrom;
-
         let url = url::Url::parse(&url.into())?;
         let options = MqttOptions::try_from(url)?;
 

--- a/rumqttc/src/v5/mod.rs
+++ b/rumqttc/src/v5/mod.rs
@@ -178,8 +178,6 @@ impl MqttOptions {
     /// options.set_transport(Transport::tls_with_config(client_config.into()));
     /// ```
     pub fn parse_url<S: Into<String>>(url: S) -> Result<MqttOptions, OptionError> {
-        use std::convert::TryFrom;
-
         let url = url::Url::parse(&url.into())?;
         let options = MqttOptions::try_from(url)?;
 

--- a/rumqttd/Cargo.toml
+++ b/rumqttd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rumqttd"
 version = "0.17.0"
-publish = false
+publish = true
 description = "rumqttd is a high performance MQTT broker written in Rust which is light weight and embeddable"
 keywords = ["mqtt", "broker", "iot", "kafka", "nats"]
 categories = ["network-programming"]

--- a/rumqttd/Cargo.toml
+++ b/rumqttd/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
 name = "rumqttd"
 version = "0.16.0"
-license = "Apache-2.0"
+publish = false
 description = "rumqttd is a high performance MQTT broker written in Rust which is light weight and embeddable"
-authors = ["tekjar <raviteja@bytebeam.io>"]
-edition = "2021"
 keywords = ["mqtt", "broker", "iot", "kafka", "nats"]
 categories = ["network-programming"]
-repository = "https://github.com/bytebeamio/rumqtt/"
+rust-version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+authors.workspace = true
 
 [dependencies]
 tokio = { version = "1.0", features = ["rt", "time", "net", "io-util", "macros"]}


### PR DESCRIPTION
Related to PR #671

What has been changed:

- Enhance `cargo workspace` utilization while avoiding repetitions
- Updated release profile
    ```toml
    [profile.release]
    codegen-units = 1 # Better optimization
    lto = true # Link time optimization
    strip = true # Stripping
    ```