### PR TITLE
Will messages and will delay interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ for more information look at rumqttc's [README](https://github.com/bytebeamio/ru
 - [x] QoS 0 and 1
 - [x] Connection via TLS
 - [x] Retransmission after reconnect
-- [ ] Last will
+- [x] Last will
 - [x] Retained messages
 - [x] QoS 2
 - [ ] MQTT 5

--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Will delay interval for MQTTv5 (#686)
 
 ### Changed
 
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Link and its implementation which were deprecated.
 
 ### Fixed
+- Will Messages
 - Retained Messages
 
 ### Security

--- a/rumqttd/src/link/local.rs
+++ b/rumqttd/src/link/local.rs
@@ -1,4 +1,6 @@
-use crate::protocol::{Filter, LastWill, Packet, Publish, QoS, RetainForwardRule, Subscribe};
+use crate::protocol::{
+    Filter, LastWill, LastWillProperties, Packet, Publish, QoS, RetainForwardRule, Subscribe,
+};
 use crate::router::Ack;
 use crate::router::{
     iobufs::{Incoming, Outgoing},
@@ -41,6 +43,7 @@ pub struct LinkBuilder<'a> {
     // true by default
     clean_session: bool,
     last_will: Option<LastWill>,
+    last_will_properties: Option<LastWillProperties>,
     // false by default
     dynamic_filters: bool,
     // default to 0, indicating to not use topic alias
@@ -55,6 +58,7 @@ impl<'a> LinkBuilder<'a> {
             tenant_id: None,
             clean_session: true,
             last_will: None,
+            last_will_properties: None,
             dynamic_filters: false,
             topic_alias_max: 0,
         }
@@ -67,6 +71,14 @@ impl<'a> LinkBuilder<'a> {
 
     pub fn last_will(mut self, last_will: Option<LastWill>) -> Self {
         self.last_will = last_will;
+        self
+    }
+
+    pub fn last_will_properties(
+        mut self,
+        last_will_properties: Option<LastWillProperties>,
+    ) -> Self {
+        self.last_will_properties = last_will_properties;
         self
     }
 
@@ -93,6 +105,7 @@ impl<'a> LinkBuilder<'a> {
             self.client_id.to_owned(),
             self.clean_session,
             self.last_will,
+            self.last_will_properties,
             self.dynamic_filters,
             self.topic_alias_max,
         );

--- a/rumqttd/src/link/remote.rs
+++ b/rumqttd/src/link/remote.rs
@@ -74,12 +74,12 @@ impl<P: Protocol> RemoteLink<P> {
         })
         .await??;
 
-        let (connect, props, lastwill, login) = match packet {
-            Packet::Connect(connect, props, lastwill, _, login) => {
+        let (connect, props, lastwill, lastwill_props, login) = match packet {
+            Packet::Connect(connect, props, lastwill, lastwill_props, login) => {
                 Span::current().record("client_id", &connect.client_id);
 
                 // Ignore last will
-                (connect, props, lastwill, login)
+                (connect, props, lastwill, lastwill_props, login)
             }
             packet => return Err(Error::NotConnectPacket(packet)),
         };
@@ -126,6 +126,7 @@ impl<P: Protocol> RemoteLink<P> {
             .tenant_id(tenant_id)
             .clean_session(clean_session)
             .last_will(lastwill)
+            .last_will_properties(lastwill_props)
             .dynamic_filters(dynamic_filters)
             .topic_alias_max(topic_alias_max.unwrap_or(0))
             .build()?;

--- a/rumqttd/src/link/remote.rs
+++ b/rumqttd/src/link/remote.rs
@@ -75,11 +75,11 @@ impl<P: Protocol> RemoteLink<P> {
         .await??;
 
         let (connect, props, lastwill, login) = match packet {
-            Packet::Connect(connect, props, _lastwill, _, login) => {
+            Packet::Connect(connect, props, lastwill, _, login) => {
                 Span::current().record("client_id", &connect.client_id);
 
                 // Ignore last will
-                (connect, props, None, login)
+                (connect, props, lastwill, login)
             }
             packet => return Err(Error::NotConnectPacket(packet)),
         };

--- a/rumqttd/src/router/connection.rs
+++ b/rumqttd/src/router/connection.rs
@@ -1,5 +1,6 @@
 use slab::Slab;
 
+use crate::protocol::LastWillProperties;
 use crate::Filter;
 use crate::{protocol::LastWill, Topic};
 use std::collections::{HashMap, HashSet};
@@ -22,6 +23,8 @@ pub struct Connection {
     pub subscriptions: HashSet<Filter>,
     /// Last will of this connection
     pub last_will: Option<LastWill>,
+    /// Properties of Last will
+    pub last_will_properties: Option<LastWillProperties>,
     /// Connection events
     pub events: ConnectionEvents,
     /// Topic aliases set by clients
@@ -39,6 +42,7 @@ impl Connection {
         client_id: String,
         clean: bool,
         last_will: Option<LastWill>,
+        last_will_properties: Option<LastWillProperties>,
         dynamic_filters: bool,
         topic_alias_max: u16,
     ) -> Connection {
@@ -67,6 +71,7 @@ impl Connection {
             clean,
             subscriptions: HashSet::default(),
             last_will,
+            last_will_properties,
             events: ConnectionEvents::default(),
             topic_aliases: HashMap::new(),
             broker_topic_aliases,

--- a/rumqttd/src/router/mod.rs
+++ b/rumqttd/src/router/mod.rs
@@ -54,7 +54,7 @@ pub enum Event {
     /// Data for native commitlog
     DeviceData,
     /// Disconnection request
-    Disconnect(Disconnection),
+    Disconnect,
     /// Shadow
     Shadow(ShadowRequest),
     /// Collect and send alerts to all alerts links
@@ -63,6 +63,8 @@ pub enum Event {
     SendMeters,
     /// Get metrics of a connection or all connections
     PrintStatus(Print),
+    /// Publish Will message
+    PublishWill(String),
 }
 
 /// Notification from router to connection

--- a/rumqttd/src/router/mod.rs
+++ b/rumqttd/src/router/mod.rs
@@ -64,7 +64,7 @@ pub enum Event {
     /// Get metrics of a connection or all connections
     PrintStatus(Print),
     /// Publish Will message
-    PublishWill(String),
+    PublishWill((String, Option<String>)),
 }
 
 /// Notification from router to connection

--- a/rumqttd/src/router/routing.rs
+++ b/rumqttd/src/router/routing.rs
@@ -1082,7 +1082,6 @@ impl Router {
             None => return,
         };
 
-        error!("Unexpected: last will not unset");
         let publish = Publish {
             dup: false,
             qos: will.qos,


### PR DESCRIPTION
Bring back support for will messages and also support will delays.

We separate disconnection and publishing will messages. Will messages are published _after_ disconnection ( and cleanup ). 

## Type of change

<!-- - Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)

NOTE: This can be considered breaking as signature of some fns in rumqttd are changed. In reality, this shouldn't affect any of the user, but still.
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintanance) -->

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if its relevant of user of the library. If its not relevant mention why.
