### PR TITLE
feat(rumqttc): Replace multi line debug log with single line

### DIFF
--- a/rumqttc/src/v5/state.rs
+++ b/rumqttc/src/v5/state.rs
@@ -587,11 +587,8 @@ impl MqttState {
         self.await_pingresp = true;
 
         debug!(
-            "Pingreq,
-            last incoming packet before {} millisecs,
-            last outgoing request before {} millisecs",
-            elapsed_in.as_millis(),
-            elapsed_out.as_millis()
+            "Pingreq, last incoming packet before {:?}, last outgoing request before {:?}",
+            elapsed_in, elapsed_out,
         );
 
         Packet::PingReq(PingReq).write(&mut self.write)?;


### PR DESCRIPTION
## Type of change

Miscellaneous (related to maintenance)

## Checklist:

- [X] Formatted with `cargo fmt`
- [X] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.

Change the ping timing debug log from a multi line string to a single line with the use of the `Debug` impl of `Duration`. Multi line logs screw a log stream in regards of readability. This PR doesn't contain any API change and just affect debug logs - no need to add a noisy changelog entry.
