### PR TITLE
Session expiry and clean start in rumqttd

### DIFF
--- a/rumqttd/src/link/local.rs
+++ b/rumqttd/src/link/local.rs
@@ -40,6 +40,7 @@ pub struct LinkBuilder<'a> {
     router_tx: Sender<(ConnectionId, Event)>,
     // true by default
     clean_session: bool,
+    session_expiry_interval: Option<u32>,
     last_will: Option<LastWill>,
     // false by default
     dynamic_filters: bool,
@@ -57,6 +58,7 @@ impl<'a> LinkBuilder<'a> {
             last_will: None,
             dynamic_filters: false,
             topic_alias_max: 0,
+            session_expiry_interval: Some(0),
         }
     }
 
@@ -80,6 +82,11 @@ impl<'a> LinkBuilder<'a> {
         self
     }
 
+    pub fn session_expiry_interval(mut self, interval: Option<u32>) -> Self {
+        self.session_expiry_interval = interval;
+        self
+    }
+
     pub fn dynamic_filters(mut self, dynamic_filters: bool) -> Self {
         self.dynamic_filters = dynamic_filters;
         self
@@ -92,6 +99,7 @@ impl<'a> LinkBuilder<'a> {
             self.tenant_id,
             self.client_id.to_owned(),
             self.clean_session,
+            self.session_expiry_interval,
             self.last_will,
             self.dynamic_filters,
             self.topic_alias_max,

--- a/rumqttd/src/link/local.rs
+++ b/rumqttd/src/link/local.rs
@@ -40,7 +40,7 @@ pub struct LinkBuilder<'a> {
     router_tx: Sender<(ConnectionId, Event)>,
     // true by default
     clean_session: bool,
-    session_expiry_interval: Option<u32>,
+    session_expiry_interval: u32,
     last_will: Option<LastWill>,
     // false by default
     dynamic_filters: bool,
@@ -58,7 +58,7 @@ impl<'a> LinkBuilder<'a> {
             last_will: None,
             dynamic_filters: false,
             topic_alias_max: 0,
-            session_expiry_interval: Some(0),
+            session_expiry_interval: 0,
         }
     }
 
@@ -82,7 +82,7 @@ impl<'a> LinkBuilder<'a> {
         self
     }
 
-    pub fn session_expiry_interval(mut self, interval: Option<u32>) -> Self {
+    pub fn session_expiry_interval(mut self, interval: u32) -> Self {
         self.session_expiry_interval = interval;
         self
     }

--- a/rumqttd/src/link/remote.rs
+++ b/rumqttd/src/link/remote.rs
@@ -120,11 +120,22 @@ impl<P: Protocol> RemoteLink<P> {
             return Err(Error::InvalidClientId);
         }
 
-        let topic_alias_max = props.and_then(|p| p.topic_alias_max);
+        let topic_alias_max = props.as_ref().and_then(|p| p.topic_alias_max);
+        // If session expiry interval is absent, use 0 as default.
+        // If the Session Expiry Interval is 0xFFFFFFFF (UINT_MAX), the Session does not expire.
+        // so we set expiry as None
+        let session_expiry_interval = props.as_ref().and_then(|p| {
+            let interval = p.session_expiry_interval.unwrap_or(0);
+            if interval == u32::MAX {
+                return None;
+            }
+            Some(interval)
+        });
 
         let (link_tx, link_rx, notification) = LinkBuilder::new(&client_id, router_tx)
             .tenant_id(tenant_id)
             .clean_session(clean_session)
+            .session_expiry_interval(session_expiry_interval)
             .last_will(lastwill)
             .dynamic_filters(dynamic_filters)
             .topic_alias_max(topic_alias_max.unwrap_or(0))

--- a/rumqttd/src/link/remote.rs
+++ b/rumqttd/src/link/remote.rs
@@ -124,13 +124,10 @@ impl<P: Protocol> RemoteLink<P> {
         // If session expiry interval is absent, use 0 as default.
         // If the Session Expiry Interval is 0xFFFFFFFF (UINT_MAX), the Session does not expire.
         // so we set expiry as None
-        let session_expiry_interval = props.as_ref().and_then(|p| {
-            let interval = p.session_expiry_interval.unwrap_or(0);
-            if interval == u32::MAX {
-                return None;
-            }
-            Some(interval)
-        });
+        let session_expiry_interval = props
+            .as_ref()
+            .and_then(|p| p.session_expiry_interval)
+            .unwrap_or(0);
 
         let (link_tx, link_rx, notification) = LinkBuilder::new(&client_id, router_tx)
             .tenant_id(tenant_id)

--- a/rumqttd/src/link/remote.rs
+++ b/rumqttd/src/link/remote.rs
@@ -121,9 +121,8 @@ impl<P: Protocol> RemoteLink<P> {
         }
 
         let topic_alias_max = props.as_ref().and_then(|p| p.topic_alias_max);
+
         // If session expiry interval is absent, use 0 as default.
-        // If the Session Expiry Interval is 0xFFFFFFFF (UINT_MAX), the Session does not expire.
-        // so we set expiry as None
         let session_expiry_interval = props
             .as_ref()
             .and_then(|p| p.session_expiry_interval)

--- a/rumqttd/src/router/connection.rs
+++ b/rumqttd/src/router/connection.rs
@@ -19,7 +19,7 @@ pub struct Connection {
     /// Clean session
     pub clean: bool,
     /// Session Expiry Interval, None indicates session never expires
-    pub expiry_interval: Option<u32>,
+    pub expiry_interval: u32,
     /// Subscriptions
     pub subscriptions: HashSet<Filter>,
     /// Last will of this connection
@@ -40,7 +40,7 @@ impl Connection {
         tenant_id: Option<String>,
         client_id: String,
         clean: bool,
-        expiry_interval: Option<u32>,
+        expiry_interval: u32,
         last_will: Option<LastWill>,
         dynamic_filters: bool,
         topic_alias_max: u16,

--- a/rumqttd/src/router/connection.rs
+++ b/rumqttd/src/router/connection.rs
@@ -18,7 +18,7 @@ pub struct Connection {
     pub dynamic_filters: bool,
     /// Clean session
     pub clean: bool,
-    /// Session Expiry Interval, None indicates session never expires
+    /// Session Expiry Interval
     pub expiry_interval: u32,
     /// Subscriptions
     pub subscriptions: HashSet<Filter>,

--- a/rumqttd/src/router/connection.rs
+++ b/rumqttd/src/router/connection.rs
@@ -18,6 +18,8 @@ pub struct Connection {
     pub dynamic_filters: bool,
     /// Clean session
     pub clean: bool,
+    /// Session Expiry Interval, None indicates session never expires
+    pub expiry_interval: Option<u32>,
     /// Subscriptions
     pub subscriptions: HashSet<Filter>,
     /// Last will of this connection
@@ -38,6 +40,7 @@ impl Connection {
         tenant_id: Option<String>,
         client_id: String,
         clean: bool,
+        expiry_interval: Option<u32>,
         last_will: Option<LastWill>,
         dynamic_filters: bool,
         topic_alias_max: u16,
@@ -65,6 +68,7 @@ impl Connection {
             tenant_prefix,
             dynamic_filters,
             clean,
+            expiry_interval,
             subscriptions: HashSet::default(),
             last_will,
             events: ConnectionEvents::default(),

--- a/rumqttd/src/router/routing.rs
+++ b/rumqttd/src/router/routing.rs
@@ -870,7 +870,8 @@ impl Router {
                         Some(exp) if exp > 0 => {
                             let connection = self.connections.get_mut(id).unwrap();
                             // If the Session Expiry Interval in the CONNECT packet was zero,
-                            // then it is a Protocol Error to set a non-zero Session Expiry Interval in the DISCONNECT packet sent by the Client
+                            // then it is a Protocol Error to set a non-zero Session Expiry Interval
+                            // in the DISCONNECT packet sent by the Client
                             if connection.expiry_interval == 0 {
                                 disconnect_reason = Some(DisconnectReasonCode::ProtocolError);
                             } else {

--- a/rumqttd/src/router/routing.rs
+++ b/rumqttd/src/router/routing.rs
@@ -475,7 +475,9 @@ impl Router {
         }
 
         // Save state for persistent sessions
-        if !connection.clean {
+        // In v5: whether to store session or not is determined
+        // by session expiry interval, not by clean start flag!
+        if !connection.clean || connection.expiry_interval > 0 {
             // Add inflight data requests back to tracker
             inflight_data_requests
                 .into_iter()


### PR DESCRIPTION
This PR aims to add session expiry support in `rumqttd`. It works by adding a expiry interval while storing session in graveyard. 

## Type of change

New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Formatted with `cargo fmt`
- [ ] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
