### PR TITLE
Publish properties in qos2 publishes

### DIFF
--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Retained Messages
+- Publish properties in QoS2 publish
 
 ### Security
 

--- a/rumqttd/src/router/logs.rs
+++ b/rumqttd/src/router/logs.rs
@@ -373,7 +373,7 @@ pub struct AckLog {
     // Committed acks per connection. First pkid, last pkid, data
     committed: VecDeque<Ack>,
     // Recorded qos 2 publishes
-    recorded: VecDeque<Publish>,
+    recorded: VecDeque<(Publish, Option<PublishProperties>)>,
 }
 
 impl AckLog {
@@ -400,9 +400,9 @@ impl AckLog {
         self.committed.push_back(ack);
     }
 
-    pub fn pubrec(&mut self, publish: Publish, ack: PubRec) {
+    pub fn pubrec(&mut self, publish: Publish, props: Option<PublishProperties>, ack: PubRec) {
         let ack = Ack::PubRec(ack);
-        self.recorded.push_back(publish);
+        self.recorded.push_back((publish, props));
         self.committed.push_back(ack);
     }
 
@@ -411,7 +411,7 @@ impl AckLog {
         self.committed.push_back(ack);
     }
 
-    pub fn pubcomp(&mut self, ack: PubComp) -> Option<Publish> {
+    pub fn pubcomp(&mut self, ack: PubComp) -> Option<(Publish, Option<PublishProperties>)> {
         let ack = Ack::PubComp(ack);
         self.committed.push_back(ack);
         self.recorded.pop_front()

--- a/rumqttd/src/router/routing.rs
+++ b/rumqttd/src/router/routing.rs
@@ -580,7 +580,7 @@ impl Router {
                             };
 
                             let ackslog = self.ackslog.get_mut(id).unwrap();
-                            ackslog.pubrec(publish, pubrec);
+                            ackslog.pubrec(publish, properties, pubrec);
                             force_ack = true;
                             continue;
                         }
@@ -794,7 +794,7 @@ impl Router {
                     // on reconnection ( with clean session false )
                     // we try to retrive publish assuming broker saved the previous state
                     // successfully in graveyard.
-                    let publish = match ackslog.pubcomp(pubcomp) {
+                    let (publish, props) = match ackslog.pubcomp(pubcomp) {
                         Some(v) => v,
                         None => {
                             disconnect = true;
@@ -806,7 +806,7 @@ impl Router {
                     match append_to_commitlog(
                         id,
                         publish,
-                        None,
+                        props,
                         &mut self.datalog,
                         &mut self.notifications,
                         &mut self.connections,


### PR DESCRIPTION
Publish properties were not being recorded for qos2. This PR aims to fix that behaviour.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
