### PR TITLE
use patched `ws_stream_tungstenite` to remove `webpki`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,20 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.19.0",
+]
+
+[[package]]
+name = "async-tungstenite"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e9efbe14612da0a19fb983059a0b621e9cf6225d7018ecab4f9988215540dc"
+dependencies = [
+ "futures-io",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+ "tungstenite 0.20.0",
 ]
 
 [[package]]
@@ -1840,7 +1853,7 @@ name = "rumqttc"
 version = "0.22.0"
 dependencies = [
  "async-http-proxy",
- "async-tungstenite",
+ "async-tungstenite 0.22.2",
  "bincode",
  "bytes",
  "color-backtrace",
@@ -1869,7 +1882,7 @@ dependencies = [
 name = "rumqttd"
 version = "0.17.0"
 dependencies = [
- "async-tungstenite",
+ "async-tungstenite 0.22.2",
  "axum",
  "bytes",
  "clap",
@@ -2611,6 +2624,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e862a1c4128df0112ab625f55cd5c934bcb4312ba80b39ae4b4835a3fd58e649"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "log",
+ "rand",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3027,10 +3054,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 [[package]]
 name = "ws_stream_tungstenite"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b6e7a5ba9436eb3868b052be83377dc685fad6d2f4cddaa2a2251b673472071"
+source = "git+https://github.com/swanandx/ws_stream_tungstenite#1dc6b3f52672922c1fc9a3473ceb980e3cab89af"
 dependencies = [
- "async-tungstenite",
+ "async-tungstenite 0.23.0",
  "async_io_stream",
  "bitflags 2.2.1",
  "futures-core",
@@ -3041,7 +3067,7 @@ dependencies = [
  "pharos",
  "rustc_version",
  "tokio",
- "tungstenite",
+ "tungstenite 0.20.0",
 ]
 
 [[package]]

--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow keep alive values <= 5 seconds (#643)
 
 ### Security
+- Remove dependency on webpki. [CVE](https://rustsec.org/advisories/RUSTSEC-2023-0052)
 
 ---
 

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -38,7 +38,8 @@ rustls-pemfile = { version = "1", optional = true }
 rustls-native-certs = { version = "0.6", optional = true }
 # websockets
 async-tungstenite = { version = "0.22", default-features = false, features = ["tokio-rustls-native-certs"], optional = true }
-ws_stream_tungstenite = { version = "0.10", default-features = false, features = ["tokio_io"], optional = true }
+# NOTE: change this to use crates.io once https://github.com/najamelan/ws_stream_tungstenite/pull/11 is merged.
+ws_stream_tungstenite = { git= "https://github.com/swanandx/ws_stream_tungstenite", default-features = false, features = ["tokio_io"], optional = true }
 http = { version = "0.2", optional = true }
 # native-tls
 tokio-native-tls = { version = "0.3.1", optional = true }

--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Publish properties in QoS2 publish
 
 ### Security
+- Remove dependency on webpki. [CVE](https://rustsec.org/advisories/RUSTSEC-2023-0052)
 
 ---
 

--- a/rumqttd/Cargo.toml
+++ b/rumqttd/Cargo.toml
@@ -25,7 +25,8 @@ rustls-webpki = { version = "0.101.4", optional = true }
 tokio-native-tls = { version = "0.3", optional = true }
 rustls-pemfile = { version = "1", optional = true }
 async-tungstenite = { version = "0.22.0", default-features = false, features = ["tokio-runtime"], optional = true }
-ws_stream_tungstenite = { version = "0.10.0", default-features = false, features = ["tokio_io"], optional = true }
+# NOTE: change this to use crates.io once https://github.com/najamelan/ws_stream_tungstenite/pull/11 is merged.
+ws_stream_tungstenite = { git= "https://github.com/swanandx/ws_stream_tungstenite", default-features = false, features = ["tokio_io"], optional = true }
 x509-parser = {version= "0.15.1", optional = true}
 futures-util = { version = "0.3.28", optional = true}
 parking_lot = "0.12.1"


### PR DESCRIPTION
Fixes #689 .

Once https://github.com/najamelan/ws_stream_tungstenite/pull/11 is merged, and `ws_strem_tungstenite` is released with the patch, we will switch back to using it from crates.io ( most likely in `ws_stream_tungstenite` version `0.11.0` )

Until then, as this is security issue, we should not block on it and use the patched version.
## Type of change

- Miscellaneous (related to maintenance)

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
