### PR TITLE
fix(rumqttd): handle subscription qos as max qos

### DIFF
--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Will Messages
 - Retained Messages
 - Publish properties in QoS2 publish
+- Handle subscription qos as per standards.
 
 ### Security
 - Remove dependency on webpki. [CVE](https://rustsec.org/advisories/RUSTSEC-2023-0052)

--- a/rumqttd/src/protocol/mod.rs
+++ b/rumqttd/src/protocol/mod.rs
@@ -577,7 +577,7 @@ pub struct DisconnectProperties {
 
 /// Quality of service
 #[repr(u8)]
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[allow(clippy::enum_variant_names)]
 pub enum QoS {
     #[default]

--- a/rumqttd/src/router/routing.rs
+++ b/rumqttd/src/router/routing.rs
@@ -1582,7 +1582,7 @@ fn forward_device_data(
             }
         });
 
-    let (len, inflight) = outgoing.push_forwards(forwards, qos, filter_idx);
+    let (len, inflight) = outgoing.push_forwards(forwards, filter_idx);
 
     debug!(
         inflight_count = inflight,

--- a/rumqttd/src/router/routing.rs
+++ b/rumqttd/src/router/routing.rs
@@ -12,6 +12,7 @@ use crate::segments::Position;
 use crate::*;
 use flume::{bounded, Receiver, RecvError, Sender, TryRecvError};
 use slab::Slab;
+use std::cmp::min;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::str::Utf8Error;
 use std::thread;
@@ -1092,7 +1093,7 @@ impl Router {
         let tenant_prefix = tenant_id.map(|id| format!("/tenants/{id}/"));
 
         let Some((will, will_props)) = self.last_wills.remove(&client_id) else {
-            return
+            return;
         };
 
         let publish = Publish {
@@ -1552,7 +1553,7 @@ fn forward_device_data(
     let forwards = publishes
         .into_iter()
         .map(|((mut publish, mut properties), offset)| {
-            publish.qos = protocol::qos(qos).unwrap();
+            publish.qos = min(publish.qos, protocol::qos(qos).unwrap());
 
             // if there is some topic alias to use, set it in publish properties
             if topic_alias.is_some() {


### PR DESCRIPTION
when we subscribe to a filter ( in v3.11 / v5 ), we specify the qos, which is maximum qos , but we treat is as the qos for all publishes. to clarify, [standards](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901170) mention:

> If a subscribing Client has been granted maximum QoS 1 for a particular Topic Filter, then a QoS 0 Application Message matching the filter is delivered to the Client at QoS 0.
>

i.e. if we have A subscribing to a topic with qos2, and them B publish 3 messages ( with qos 0, 1 & 2 ) to that topic. A should recv 3 messages, but with qos of 0, 1 and 2 respectively. Currently it recv all 3 with qos 2!

## Type of change

- Bug fix (non-breaking change which fixes an issue) 

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
