### PR TITLE
Maximum packet size in MQTTv5

### DIFF
--- a/rumqttd/src/link/remote.rs
+++ b/rumqttd/src/link/remote.rs
@@ -146,6 +146,7 @@ impl<P: Protocol> RemoteLink<P> {
 
                     for notif in self.notifications.drain(..) {
                         if let Some(packet) = notif.into() {
+                // TODO(swanandx): get packet size here and skip based on max size
                             packets.push_back(packet);
                         } else {
                             unscheduled = true;

--- a/rumqttd/src/protocol/mod.rs
+++ b/rumqttd/src/protocol/mod.rs
@@ -13,6 +13,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 
 use crate::Notification;
 
+use self::v5::{connack, disconnect, puback, pubcomp, publish, pubrec, pubrel, suback, unsuback};
+
 // TODO: Handle the cases when there are no properties using Inner struct, so
 // handling of properties can be made simplier internally
 
@@ -40,6 +42,24 @@ pub enum Packet {
     Disconnect(Disconnect, Option<DisconnectProperties>),
 }
 
+impl Packet {
+    pub fn length(&self) -> usize {
+        match self {
+            Packet::ConnAck(ack, props) => connack::len(ack, props),
+            Packet::Publish(publ, props) => publish::len(publ, props),
+            Packet::PubAck(ack, props) => puback::len(ack, props),
+            Packet::PingResp(_) => 2,
+            Packet::SubAck(ack, props) => suback::len(ack, props),
+            Packet::PubRec(rec, props) => pubrec::len(rec, props),
+            Packet::PubRel(rel, props) => pubrel::len(rel, props),
+            Packet::PubComp(comp, props) => pubcomp::len(comp, props),
+            Packet::UnsubAck(ack, props) => unsuback::len(ack, props),
+            Packet::Disconnect(disconn, props) => disconnect::len(disconn, props),
+            // Connect, PingReq, Subscribe, Unsubscribe
+            p => unreachable!("server must never send {p:?} packet"),
+        }
+    }
+}
 //--------------------------- Connect packet -------------------------------
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PingReq;

--- a/rumqttd/src/protocol/v5/connack.rs
+++ b/rumqttd/src/protocol/v5/connack.rs
@@ -1,7 +1,7 @@
 use super::*;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
-fn len(connack: &ConnAck, properties: &Option<ConnAckProperties>) -> usize {
+pub fn len(connack: &ConnAck, properties: &Option<ConnAckProperties>) -> usize {
     let mut len = 1  // session present
                 + 1; // code
 

--- a/rumqttd/src/protocol/v5/disconnect.rs
+++ b/rumqttd/src/protocol/v5/disconnect.rs
@@ -6,7 +6,7 @@ use super::*;
 
 use super::{property, PropertyType};
 
-fn len(disconnect: &Disconnect, properties: &Option<DisconnectProperties>) -> usize {
+pub fn len(disconnect: &Disconnect, properties: &Option<DisconnectProperties>) -> usize {
     if disconnect.reason_code == DisconnectReasonCode::NormalDisconnection && properties.is_none() {
         return 2; // Packet type + 0x00
     }

--- a/rumqttd/src/protocol/v5/mod.rs
+++ b/rumqttd/src/protocol/v5/mod.rs
@@ -5,18 +5,18 @@ use crate::router::Ack;
 use super::*;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
-mod connack;
+pub(super) mod connack;
 mod connect;
-mod disconnect;
+pub(super) mod disconnect;
 mod ping;
-mod puback;
-mod pubcomp;
-mod publish;
-mod pubrec;
-mod pubrel;
-mod suback;
+pub(super) mod puback;
+pub(super) mod pubcomp;
+pub(super) mod publish;
+pub(super) mod pubrec;
+pub(super) mod pubrel;
+pub(super) mod suback;
 mod subscribe;
-mod unsuback;
+pub(super) mod unsuback;
 mod unsubscribe;
 
 /// MQTT packet type

--- a/rumqttd/src/protocol/v5/puback.rs
+++ b/rumqttd/src/protocol/v5/puback.rs
@@ -1,7 +1,7 @@
 use super::*;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
-fn len(puback: &PubAck, properties: &Option<PubAckProperties>) -> usize {
+pub fn len(puback: &PubAck, properties: &Option<PubAckProperties>) -> usize {
     let mut len = 2 + 1; // pkid + reason
 
     // If there are no properties, sending reason code is optional

--- a/rumqttd/src/protocol/v5/pubcomp.rs
+++ b/rumqttd/src/protocol/v5/pubcomp.rs
@@ -1,7 +1,7 @@
 use super::*;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
-fn len(pubcomp: &PubComp, properties: &Option<PubCompProperties>) -> usize {
+pub fn len(pubcomp: &PubComp, properties: &Option<PubCompProperties>) -> usize {
     let mut len = 2 + 1; // pkid + reason
 
     // The Reason Code and Property Length can be omitted if the Reason Code is 0x00 (Success)

--- a/rumqttd/src/protocol/v5/pubrec.rs
+++ b/rumqttd/src/protocol/v5/pubrec.rs
@@ -1,7 +1,7 @@
 use super::*;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
-fn len(pubrec: &PubRec, properties: &Option<PubRecProperties>) -> usize {
+pub fn len(pubrec: &PubRec, properties: &Option<PubRecProperties>) -> usize {
     let mut len = 2 + 1; // pkid + reason
 
     // The Reason Code and Property Length can be omitted if the Reason Code is 0x00 (Success)

--- a/rumqttd/src/protocol/v5/pubrel.rs
+++ b/rumqttd/src/protocol/v5/pubrel.rs
@@ -1,7 +1,7 @@
 use super::*;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
-fn len(pubrel: &PubRel, properties: &Option<PubRelProperties>) -> usize {
+pub fn len(pubrel: &PubRel, properties: &Option<PubRelProperties>) -> usize {
     let mut len = 2 + 1; // pkid + reason
 
     // The Reason Code and Property Length can be omitted if the Reason Code is 0x00 (Success)

--- a/rumqttd/src/server/broker.rs
+++ b/rumqttd/src/server/broker.rs
@@ -461,9 +461,7 @@ async fn remote<P: Protocol>(
         protocol,
     );
 
-    let dynamic_filters = config.dynamic_filters;
-
-    let connect_packet = match mqtt_connect(config, &mut network).await {
+    let connect_packet = match mqtt_connect(config.clone(), &mut network).await {
         Ok(p) => p,
         Err(e) => {
             error!(error=?e, "Error while handling MQTT connect packet");
@@ -506,7 +504,7 @@ async fn remote<P: Protocol>(
         tenant_id.clone(),
         network,
         connect_packet,
-        dynamic_filters,
+        config,
     )
     .await
     {


### PR DESCRIPTION
This PR adds support for max packet size as per defined in MQTTv5 [standards](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901050).

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Formatted with `cargo fmt`
- [ ] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
