### PR TITLE
Validate "mqtt" exists in comma delimited subprotocol header 

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Allow keep alive values <= 5 seconds (#643)
+- Verify "mqtt" is present in websocket subprotocol header.
 
 ### Security
 - Remove dependency on webpki. [CVE](https://rustsec.org/advisories/RUSTSEC-2023-0052)

--- a/rumqttc/src/websockets.rs
+++ b/rumqttc/src/websockets.rs
@@ -28,11 +28,17 @@ pub(crate) fn validate_response_headers(
         .get("Sec-WebSocket-Protocol")
         .ok_or(ValidationError::SubprotocolHeaderMissing)?;
 
-    let sub_protocol = val.to_str()?;
+    let subprotocols = val.to_str()?;
 
-    if !sub_protocol.contains("mqtt") {
+    // In Sec-WebSocket-Protocol header
+    // multiple subprotocols can be listed in a comma-delimited format
+    // e.g. Sec-WebSocket-Protocol: mqtt, chat
+    if !subprotocols
+        .split(',')
+        .any(|protocol| protocol.trim() == "mqtt")
+    {
         return Err(ValidationError::SubprotocolMqttMissing(
-            sub_protocol.to_owned(),
+            subprotocols.to_owned(),
         ));
     }
 


### PR DESCRIPTION
This PR adds up on #724 and fixes behavior incase the header contains multiple subprotocols listed in a comma-delimited format.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
