### PR TITLE
console endpoint /config prints router config

### DIFF
--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Console endpoint /config prints Router Config instead of returning console settings
 
 ### Deprecated
 

--- a/rumqttd/src/link/console.rs
+++ b/rumqttd/src/link/console.rs
@@ -3,7 +3,7 @@ use crate::local::LinkBuilder;
 use crate::router::{Event, Print};
 use crate::{ConnectionId, ConsoleSettings};
 use axum::extract::{Path, State};
-use axum::response::{IntoResponse, Redirect, Response};
+use axum::response::{IntoResponse, Response};
 use axum::routing::post;
 use axum::Json;
 use axum::{routing::get, Router};
@@ -61,12 +61,18 @@ pub async fn start(console: Arc<ConsoleLink>) {
         .unwrap();
 }
 
-async fn root() -> impl IntoResponse {
-    Redirect::to("/config")
+async fn root(State(console): State<Arc<ConsoleLink>>) -> impl IntoResponse {
+    Json(console.config.clone())
 }
 
 async fn config(State(console): State<Arc<ConsoleLink>>) -> impl IntoResponse {
-    Json(console.config.clone())
+    let event = Event::PrintStatus(Print::Config);
+    let message = (console.connection_id, event);
+    if console.router_tx.send(message).is_err() {
+        return Response::builder().status(404).body("".to_owned()).unwrap();
+    }
+
+    Response::new("OK".to_owned())
 }
 
 async fn router(State(console): State<Arc<ConsoleLink>>) -> impl IntoResponse {


### PR DESCRIPTION
This PR changes functionality of console's /config. previously it was returning console settings, now it prints router config!

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected) 

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
