### PR TITLE
update tungstenite dependencies for security purpose

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `MqttOptions::set_request_modifier` for setting a handler for modifying a websocket request before sending it.
 
 ### Changed
+- Removed dependency vulnerability, see [rustsec](https://rustsec.org/advisories/RUSTSEC-2023-0065). Update of `tungstenite` dependency.
 
 ### Deprecated
 

--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `MqttOptions::set_request_modifier` for setting a handler for modifying a websocket request before sending it.
 
 ### Changed
-- Removed dependency vulnerability, see [rustsec](https://rustsec.org/advisories/RUSTSEC-2023-0065). Update of `tungstenite` dependency.
 
 ### Deprecated
 
@@ -25,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 - Remove dependency on webpki. [CVE](https://rustsec.org/advisories/RUSTSEC-2023-0052)
+- Removed dependency vulnerability, see [rustsec](https://rustsec.org/advisories/RUSTSEC-2023-0065). Update of `tungstenite` dependency.
 
 ---
 

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -37,8 +37,8 @@ rustls-webpki = { version = "0.101.4", optional = true }
 rustls-pemfile = { version = "1", optional = true }
 rustls-native-certs = { version = "0.6", optional = true }
 # websockets
-async-tungstenite = { version = "0.22", default-features = false, features = ["tokio-rustls-native-certs"], optional = true }
-ws_stream_tungstenite = { version= "0.10", default-features = false, features = ["tokio_io"], optional = true }
+async-tungstenite = { version = "0.23", default-features = false, features = ["tokio-rustls-native-certs"], optional = true }
+ws_stream_tungstenite = { version= "0.11", default-features = false, features = ["tokio_io"], optional = true }
 http = { version = "0.2", optional = true }
 # native-tls
 tokio-native-tls = { version = "0.3.1", optional = true }


### PR DESCRIPTION
As described in [rustsec](https://rustsec.org/advisories/RUSTSEC-2023-0065), there is a vulnerability in older versions of tungstenite. This library is used in the chain of dependencies of rumqtt. This change up-steps those dependencies.

## Type of change

 Bug fix (non-breaking change which fixes an issue) 

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
