### PR TITLE
Enable websocket feature by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           echo "TARGET_DIR=./target/${{ matrix.target }}" >> $GITHUB_ENV
 
       - name: Build release binary
-        run: cross build --verbose --release ${{ env.TARGET_FLAGS }} -p rumqttd --features websockets
+        run: cross build --verbose --release ${{ env.TARGET_FLAGS }} -p rumqttd
 
       - name: rename
         # this assumes git tag is in format rumqttd-x.x.x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           echo "TARGET_DIR=./target/${{ matrix.target }}" >> $GITHUB_ENV
 
       - name: Build release binary
-        run: cross build --verbose --release ${{ env.TARGET_FLAGS }} -p rumqttd
+        run: cross build --verbose --release ${{ env.TARGET_FLAGS }} -p rumqttd --features websockets
 
       - name: rename
         # this assumes git tag is in format rumqttd-x.x.x

--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Log warning if websocket config is getting ignored
 
 ### Changed
 - Console endpoint /config prints Router Config instead of returning console settings
+- GitHub release binaries will have websockets feature enabled
 
 ### Deprecated
 

--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - websocket feature is enabled by default
 
 ### Deprecated
+- "websockets" feature is removed in favour of "websocket"
 
 ### Removed
 

--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Console endpoint /config prints Router Config instead of returning console settings
-- GitHub release binaries will have websockets feature enabled
+- websocket feature is enabled by default
 
 ### Deprecated
 

--- a/rumqttd/Cargo.toml
+++ b/rumqttd/Cargo.toml
@@ -39,7 +39,7 @@ axum = "0.6.20"
 rand = "0.8.5"
 
 [features]
-default = ["use-rustls"]
+default = ["use-rustls", "websocket"]
 use-rustls = ["dep:tokio-rustls", "dep:rustls-webpki", "dep:rustls-pemfile", "dep:x509-parser"]
 use-native-tls = ["dep:tokio-native-tls", "dep:x509-parser"]
 websocket = ["dep:async-tungstenite", "dep:tokio-util", "dep:futures-util", "dep:ws_stream_tungstenite"]

--- a/rumqttd/Cargo.toml
+++ b/rumqttd/Cargo.toml
@@ -43,7 +43,6 @@ default = ["use-rustls"]
 use-rustls = ["dep:tokio-rustls", "dep:rustls-webpki", "dep:rustls-pemfile", "dep:x509-parser"]
 use-native-tls = ["dep:tokio-native-tls", "dep:x509-parser"]
 websocket = ["dep:async-tungstenite", "dep:tokio-util", "dep:futures-util", "dep:ws_stream_tungstenite"]
-websockets = ["websocket"]
 validate-tenant-prefix = []
 allow-duplicate-clientid = []
 

--- a/rumqttd/src/server/broker.rs
+++ b/rumqttd/src/server/broker.rs
@@ -14,7 +14,7 @@ use flume::{RecvError, SendError, Sender};
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::{Arc, Mutex};
-use tracing::{error, field, info, Instrument};
+use tracing::{error, field, info, warn, Instrument};
 
 #[cfg(feature = "websocket")]
 use async_tungstenite::tokio::accept_hdr_async;
@@ -213,6 +213,11 @@ impl Broker {
                     });
                 })?;
             }
+        }
+
+        #[cfg(not(feature = "websocket"))]
+        if self.config.ws.is_some() {
+            warn!("websocket feature is disabled, [ws] config will be ignored.");
         }
 
         #[cfg(feature = "websocket")]


### PR DESCRIPTION
This PR does following:
- enable websocket feature by default
- remove old "websockets" feature
- log warning if ws config is getting ignored

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
