### PR TITLE
Make v4 config optional

### DIFF
--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Console endpoint /config prints Router Config instead of returning console settings
+- v4 config is optional, user can specify v4 and/or v5 config
 
 ### Deprecated
 

--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -44,7 +44,7 @@ use self::router::shared_subs::Strategy;
 pub struct Config {
     pub id: usize,
     pub router: RouterConfig,
-    pub v4: HashMap<String, ServerSettings>,
+    pub v4: Option<HashMap<String, ServerSettings>>,
     pub v5: Option<HashMap<String, ServerSettings>>,
     pub ws: Option<HashMap<String, ServerSettings>>,
     pub cluster: Option<ClusterSettings>,

--- a/rumqttd/src/main.rs
+++ b/rumqttd/src/main.rs
@@ -88,10 +88,12 @@ fn main() {
 
 // Do any extra validation that needs to be done before starting the broker here.
 fn validate_config(configs: &rumqttd::Config) {
-    for (name, server_setting) in &configs.v4 {
-        if let Some(tls_config) = &server_setting.tls {
-            if !tls_config.validate_paths() {
-                panic!("Certificate path not valid for server v4.{name}.")
+    if let Some(v4) = &configs.v4 {
+        for (name, server_setting) in v4 {
+            if let Some(tls_config) = &server_setting.tls {
+                if !tls_config.validate_paths() {
+                    panic!("Certificate path not valid for server v4.{name}.")
+                }
             }
         }
     }


### PR DESCRIPTION
This PR makes v4 config optional so that users can specify v4 and/or v5 config ( or ws ) as per their use case.

This will allow user to use only v5 if they wish.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
