### PR TITLE
console configuration should be optional

### DIFF
--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Console endpoint /config prints Router Config instead of returning console settings
 - v4 config is optional, user can specify v4 and/or v5 config
 - websocket feature is enabled by default
+- console configuration is optional
 
 ### Deprecated
 - "websockets" feature is removed in favour of "websocket"

--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -48,7 +48,7 @@ pub struct Config {
     pub v5: Option<HashMap<String, ServerSettings>>,
     pub ws: Option<HashMap<String, ServerSettings>>,
     pub cluster: Option<ClusterSettings>,
-    pub console: ConsoleSettings,
+    pub console: Option<ConsoleSettings>,
     pub bridge: Option<BridgeConfig>,
     pub prometheus: Option<PrometheusSetting>,
     pub metrics: Option<HashMap<MetricType, MetricSettings>>,

--- a/rumqttd/src/main.rs
+++ b/rumqttd/src/main.rs
@@ -76,7 +76,10 @@ fn main() {
     };
 
     let mut configs: rumqttd::Config = config_builder.build().unwrap().try_deserialize().unwrap();
-    configs.console.set_filter_reload_handle(reload_handle);
+
+    if let Some(console_config) = configs.console.as_mut() {
+        console_config.set_filter_reload_handle(reload_handle)
+    }
 
     validate_config(&configs);
 


### PR DESCRIPTION
Fixes #672 . 

Changes:
- make console settings optional
- instead of blocking on console in `start()`, we block on joining thread handle of spawned servers.

## Type of change

- New feature (non-breaking change which adds functionality) 

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
