### PR TITLE
fix(rumqttc/examples): Fix rumqttc async_manual_acks.rs

### DIFF
--- a/rumqttc/examples/async_manual_acks.rs
+++ b/rumqttc/examples/async_manual_acks.rs
@@ -1,6 +1,6 @@
 use tokio::{task, time};
 
-use rumqttc::{self, AsyncClient, Event, EventLoop, Incoming, MqttOptions, Outgoing, QoS};
+use rumqttc::{self, AsyncClient, Event, EventLoop, Incoming, MqttOptions, QoS};
 use std::error::Error;
 use std::time::Duration;
 
@@ -59,11 +59,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
             }
             Err(error) => {
                 println!("Error = {error:?}");
-                return Ok(());
-            }
-        }
-        if let Ok(Event::Outgoing(Outgoing::PubAck(puback))) = event {
-            if puback == 10 {
                 return Ok(());
             }
         }


### PR DESCRIPTION
- Allow code to continue after first loop finishes

<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

- Miscellaneous (related to maintenance)

## Checklist:

- [x] Formatted with `cargo fmt`
- [ ] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
