### PR TITLE
Add support for `native-tls` when using websocket transport

### DIFF
--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -360,7 +360,10 @@ async fn network_connect(
     let (domain, port) = match options.transport() {
         #[cfg(feature = "websocket")]
         Transport::Ws => split_url(&options.broker_addr)?,
-        #[cfg(all(feature = "use-rustls", feature = "websocket"))]
+        #[cfg(all(
+            any(feature = "use-rustls", feature = "use-native-tls"),
+            feature = "websocket"
+        ))]
         Transport::Wss(_) => split_url(&options.broker_addr)?,
         _ => options.broker_address(),
     };
@@ -407,14 +410,20 @@ async fn network_connect(
 
             Network::new(WsStream::new(socket), options.max_incoming_packet_size)
         }
-        #[cfg(all(feature = "use-rustls", feature = "websocket"))]
+        #[cfg(all(
+            any(feature = "use-rustls", feature = "use-native-tls"),
+            feature = "websocket"
+        ))]
         Transport::Wss(tls_config) => {
             let mut request = options.broker_addr.as_str().into_client_request()?;
             request
                 .headers_mut()
                 .insert("Sec-WebSocket-Protocol", "mqtt".parse().unwrap());
 
+            #[cfg(feature = "use-rustls")]
             let connector = tls::rustls_connector(&tls_config).await?;
+            #[cfg(feature = "use-native-tls")]
+            let connector = tls::native_tls_connector(&tls_config).await?;
 
             let (socket, response) = async_tungstenite::tokio::client_async_tls_with_connector(
                 request,
@@ -422,6 +431,7 @@ async fn network_connect(
                 Some(connector),
             )
             .await?;
+
             validate_response_headers(response)?;
 
             Network::new(WsStream::new(socket), options.max_incoming_packet_size)

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -240,7 +240,10 @@ pub enum Transport {
     #[cfg(feature = "websocket")]
     #[cfg_attr(docsrs, doc(cfg(feature = "websocket")))]
     Ws,
-    #[cfg(all(feature = "use-rustls", feature = "websocket"))]
+    #[cfg(all(
+        any(feature = "use-rustls", feature = "use-native-tls"),
+        feature = "websocket"
+    ))]
     #[cfg_attr(docsrs, doc(cfg(all(feature = "use-rustls", feature = "websocket"))))]
     Wss(TlsConfiguration),
 }
@@ -312,14 +315,32 @@ impl Transport {
         Self::wss_with_config(config)
     }
 
-    #[cfg(all(feature = "use-rustls", feature = "websocket"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "use-rustls", feature = "websocket"))))]
+    #[cfg(all(
+        any(feature = "use-rustls", feature = "use-native-tls"),
+        feature = "websocket"
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            any(feature = "use-rustls", feature = "use-native-tls"),
+            feature = "websocket"
+        )))
+    )]
     pub fn wss_with_config(tls_config: TlsConfiguration) -> Self {
         Self::Wss(tls_config)
     }
 
-    #[cfg(all(feature = "use-rustls", feature = "websocket"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "use-rustls", feature = "websocket"))))]
+    #[cfg(all(
+        any(feature = "use-rustls", feature = "use-native-tls"),
+        feature = "websocket"
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            any(feature = "use-rustls", feature = "use-native-tls"),
+            feature = "websocket"
+        )))
+    )]
     pub fn wss_with_default_config() -> Self {
         Self::Wss(Default::default())
     }
@@ -367,6 +388,13 @@ impl Default for TlsConfiguration {
             .with_no_client_auth();
 
         Self::Rustls(Arc::new(tls_config))
+    }
+}
+
+#[cfg(feature = "use-native-tls")]
+impl Default for TlsConfiguration {
+    fn default() -> Self {
+        Self::Native
     }
 }
 

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -290,7 +290,10 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
     let (domain, port) = match options.transport() {
         #[cfg(feature = "websocket")]
         Transport::Ws => split_url(&options.broker_addr)?,
-        #[cfg(all(feature = "use-rustls", feature = "websocket"))]
+        #[cfg(all(
+            any(feature = "use-rustls", feature = "use-native-tls"),
+            feature = "websocket"
+        ))]
         Transport::Wss(_) => split_url(&options.broker_addr)?,
         _ => options.broker_address(),
     };
@@ -345,7 +348,10 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
 
             Network::new(WsStream::new(socket), max_incoming_pkt_size)
         }
-        #[cfg(all(feature = "use-rustls", feature = "websocket"))]
+        #[cfg(all(
+            any(feature = "use-rustls", feature = "use-native-tls"),
+            feature = "websocket"
+        ))]
         Transport::Wss(tls_config) => {
             let mut request = options.broker_addr.as_str().into_client_request()?;
             request
@@ -356,7 +362,10 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
                 request = request_modifier(request).await;
             }
 
+            #[cfg(feature = "use-rustls")]
             let connector = tls::rustls_connector(&tls_config).await?;
+            #[cfg(feature = "use-native-tls")]
+            let connector = tls::native_tls_connector(&tls_config).await?;
 
             let (socket, response) = async_tungstenite::tokio::client_async_tls_with_connector(
                 request,


### PR DESCRIPTION
This PR adds support for `native-tls` when using `Transport::Wss`.

This is still a WIP since the feature `tokio-native-tls` needs to be set in `async-tungstenite` when using `use-native-tls` feature in this crate. At the same time, if `use-rustls` is set in this crate, `async-tungstenite` needs to set feature `tokio-rustls-native-certs`. I have no idea how to edit `Cargo.toml` to support both of these cases.

At the moment `async-tungstenite` always uses - even if using insecure WS connection - `tokio-rustls-native-certs` feature, which I don't think is correct either.

## Type of change

New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Formatted with `cargo fmt`
- [ ] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
