### PR TITLE
Allow ECC Key Configuration with rustls

### DIFF
--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Log warning if websocket config is getting ignored
-- Add `ecc_certpath` and `ecc_keypath` options to config file to support EC keys with `rustls`
+- Add support for ECC keys when configuring TLS in rumqttd 
 
 ### Changed
 - Console endpoint /config prints Router Config instead of returning console settings

--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Log warning if websocket config is getting ignored
+- Add `ecc_certpath` and `ecc_keypath` options to config file to support EC keys with `rustls`
 
 ### Changed
 - Console endpoint /config prints Router Config instead of returning console settings

--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 use std::{collections::HashMap, path::Path};
 
 use serde::{Deserialize, Serialize};
-use tracing::{debug, trace};
 use tracing_subscriber::{
     filter::EnvFilter,
     fmt::{

--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -82,7 +82,7 @@ impl TlsConfig {
     // Returns true only if all of the file paths inside `TlsConfig` actually exists on file system.
     // NOTE: This doesn't verify if certificate files are in required format or not.
     pub fn validate_paths(&self) -> bool {
-        let result = match self {
+        match self {
             TlsConfig::Rustls {
                 capath,
                 certpath,
@@ -91,9 +91,7 @@ impl TlsConfig {
                 .iter()
                 .all(|v| Path::new(v).exists()),
             TlsConfig::NativeTls { pkcs12path, .. } => Path::new(pkcs12path).exists(),
-        };
-        trace!("Validating TLS config paths with result: {:?}", result);
-        result
+        }
     }
 }
 

--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -1,6 +1,6 @@
-use std::{collections::HashMap, path::Path};
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::{collections::HashMap, path::Path};
 
 use serde::{Deserialize, Serialize};
 use tracing::{debug, trace};
@@ -11,8 +11,8 @@ use tracing_subscriber::{
         Layer,
     },
     layer::Layered,
-    Registry,
     reload::Handle,
+    Registry,
 };
 
 pub use link::alerts;

--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -72,11 +72,6 @@ pub enum TlsConfig {
         certpath: String,
         keypath: String,
     },
-    RustlsWithECC {
-        capath: String,
-        ecc_certpath: String,
-        ecc_keypath: String,
-    },
     NativeTls {
         pkcs12path: String,
         pkcs12pass: String,
@@ -93,13 +88,6 @@ impl TlsConfig {
                 certpath,
                 keypath,
             } => [capath, certpath, keypath]
-                .iter()
-                .all(|v| Path::new(v).exists()),
-            TlsConfig::RustlsWithECC {
-                capath,
-                ecc_certpath,
-                ecc_keypath,
-            } => [capath, ecc_certpath, ecc_keypath]
                 .iter()
                 .all(|v| Path::new(v).exists()),
             TlsConfig::NativeTls { pkcs12path, .. } => Path::new(pkcs12path).exists(),

--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -3,6 +3,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
+use tracing::{debug, trace};
 use tracing_subscriber::{
     filter::EnvFilter,
     fmt::{
@@ -86,7 +87,7 @@ impl TlsConfig {
     // Returns true only if all of the file paths inside `TlsConfig` actually exists on file system.
     // NOTE: This doesn't verify if certificate files are in required format or not.
     pub fn validate_paths(&self) -> bool {
-        match self {
+        let result = match self {
             TlsConfig::Rustls {
                 capath,
                 certpath,
@@ -102,7 +103,9 @@ impl TlsConfig {
                 .iter()
                 .all(|v| Path::new(v).exists()),
             TlsConfig::NativeTls { pkcs12path, .. } => Path::new(pkcs12path).exists(),
-        }
+        };
+        trace!("Validating TLS config paths with result: {:?}", result);
+        result
     }
 }
 

--- a/rumqttd/src/main.rs
+++ b/rumqttd/src/main.rs
@@ -2,6 +2,7 @@ use config::FileFormat;
 use rumqttd::Broker;
 
 use clap::Parser;
+use tracing::trace;
 
 static RUMQTTD_DEFAULT_CONFIG: &str = include_str!("../rumqttd.toml");
 
@@ -97,6 +98,7 @@ fn validate_config(configs: &rumqttd::Config) {
                 if !tls_config.validate_paths() {
                     panic!("Certificate path not valid for server v4.{name}.")
                 }
+                trace!("Validated certificate paths for server v4.{name}.");
             }
         }
     }
@@ -107,6 +109,7 @@ fn validate_config(configs: &rumqttd::Config) {
                 if !tls_config.validate_paths() {
                     panic!("Certificate path not valid for server v5.{name}.")
                 }
+                trace!("Validated certificate paths for server v5.{name}.");
             }
         }
     }
@@ -117,6 +120,7 @@ fn validate_config(configs: &rumqttd::Config) {
                 if !tls_config.validate_paths() {
                     panic!("Certificate path not valid for server ws.{name}.")
                 }
+                trace!("Validated certificate paths for server ws.{name}.");
             }
         }
     }

--- a/rumqttd/src/server/tls.rs
+++ b/rumqttd/src/server/tls.rs
@@ -4,6 +4,7 @@ use std::fs::File;
 #[cfg(feature = "use-native-tls")]
 use std::io::Read;
 
+#[cfg(feature = "use-rustls")]
 use rustls_pemfile::Item;
 use tokio::net::TcpStream;
 #[cfg(feature = "use-native-tls")]

--- a/rumqttd/src/server/tls.rs
+++ b/rumqttd/src/server/tls.rs
@@ -1,8 +1,8 @@
-#[cfg(feature = "use-rustls")]
-use std::{io::BufReader, sync::Arc};
 use std::fs::File;
 #[cfg(feature = "use-native-tls")]
 use std::io::Read;
+#[cfg(feature = "use-rustls")]
+use std::{io::BufReader, sync::Arc};
 
 #[cfg(feature = "use-rustls")]
 use rustls_pemfile::Item;
@@ -13,8 +13,8 @@ use tokio_native_tls::native_tls;
 use tokio_native_tls::native_tls::Error as NativeTlsError;
 #[cfg(feature = "use-rustls")]
 use tokio_rustls::rustls::{
-    Certificate, Error as RustlsError, PrivateKey, RootCertStore,
-    server::AllowAnyAuthenticatedClient, ServerConfig,
+    server::AllowAnyAuthenticatedClient, Certificate, Error as RustlsError, PrivateKey,
+    RootCertStore, ServerConfig,
 };
 use tracing::error;
 

--- a/rumqttd/src/server/tls.rs
+++ b/rumqttd/src/server/tls.rs
@@ -102,13 +102,7 @@ impl TLSAcceptor {
                 capath,
                 certpath,
                 keypath,
-            } => Self::rustls(capath, certpath, keypath, false),
-            #[cfg(feature = "use-rustls")]
-            TlsConfig::RustlsWithECC {
-                capath,
-                ecc_certpath,
-                ecc_keypath,
-            } => Self::rustls(capath, ecc_certpath, ecc_keypath, true),
+            } => Self::rustls(capath, certpath, keypath),
             #[cfg(feature = "use-native-tls")]
             TlsConfig::NativeTls {
                 pkcs12path,
@@ -180,7 +174,6 @@ impl TLSAcceptor {
         ca_path: &String,
         cert_path: &String,
         key_path: &String,
-        is_ecc: bool,
     ) -> Result<TLSAcceptor, Error> {
         let (certs, key) = {
             // Get certificates

--- a/rumqttd/src/server/tls.rs
+++ b/rumqttd/src/server/tls.rs
@@ -1,9 +1,11 @@
 use std::fs::File;
-use std::io::Read;
 use tokio::net::TcpStream;
 
 #[cfg(feature = "use-native-tls")]
-use {tokio_native_tls::native_tls, tokio_native_tls::native_tls::Error as NativeTlsError};
+use {
+    std::io::Read, tokio_native_tls::native_tls,
+    tokio_native_tls::native_tls::Error as NativeTlsError,
+};
 
 #[cfg(feature = "use-rustls")]
 use {

--- a/rumqttd/src/server/tls.rs
+++ b/rumqttd/src/server/tls.rs
@@ -1,22 +1,21 @@
+#[cfg(feature = "use-rustls")]
+use std::{io::BufReader, sync::Arc};
 use std::fs::File;
-
 #[cfg(feature = "use-native-tls")]
 use std::io::Read;
+
+use rustls_pemfile::Item;
 use tokio::net::TcpStream;
 #[cfg(feature = "use-native-tls")]
 use tokio_native_tls::native_tls;
 #[cfg(feature = "use-native-tls")]
 use tokio_native_tls::native_tls::Error as NativeTlsError;
-
 #[cfg(feature = "use-rustls")]
 use tokio_rustls::rustls::{
-    server::AllowAnyAuthenticatedClient, Certificate, Error as RustlsError, PrivateKey,
-    RootCertStore, ServerConfig,
+    Certificate, Error as RustlsError, PrivateKey, RootCertStore,
+    server::AllowAnyAuthenticatedClient, ServerConfig,
 };
-
-use std::iter;
-#[cfg(feature = "use-rustls")]
-use std::{io::BufReader, sync::Arc};
+use tracing::error;
 
 use crate::link::network::N;
 use crate::TlsConfig;
@@ -195,23 +194,10 @@ impl TLSAcceptor {
                 .collect();
 
             // Get private key
-            let key_file = File::open(key_path);
-            let key_file = key_file.map_err(|_| Error::ServerKeyNotFound(key_path.clone()))?;
+            let key = first_private_key_in_pemfile(key_path)
+                .map_err(|_| Error::InvalidServerKey(key_path.clone()))?;
 
-            let keys = match is_ecc {
-                false => rustls_pemfile::rsa_private_keys(&mut BufReader::new(key_file)),
-                true => rustls_pemfile::ec_private_keys(&mut BufReader::new(key_file)),
-            };
-
-            let keys = keys.map_err(|_| Error::InvalidServerKey(key_path.clone()))?;
-
-            // Get the first key
-            let key = match keys.first() {
-                Some(k) => k.clone(),
-                None => return Err(Error::InvalidServerKey(key_path.clone())),
-            };
-
-            (certs, PrivateKey(key))
+            (certs, key)
         };
 
         // client authentication with a CA. CA isn't required otherwise
@@ -238,5 +224,35 @@ impl TLSAcceptor {
 
         let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(server_config));
         Ok(TLSAcceptor::Rustls { acceptor })
+    }
+}
+
+#[cfg(feature = "use-rustls")]
+/// Get the first private key in a PEM file
+fn first_private_key_in_pemfile(key_path: &String) -> Result<PrivateKey, Error> {
+    // Get private key
+    let key_file = File::open(key_path);
+    let key_file = key_file.map_err(|_| Error::ServerKeyNotFound(key_path.clone()))?;
+
+    // Let's iterate over the keys with read_one/read_all
+    let rd = &mut BufReader::new(key_file);
+
+    loop {
+        match rustls_pemfile::read_one(rd) {
+            Ok(maybe_inner) => match maybe_inner {
+                None => {
+                    error!("No private key found in {:?}", key_path);
+                    return Err(Error::InvalidServerKey(key_path.clone()));
+                }
+                Some(Item::ECKey(key)) => return Ok(PrivateKey(key)),
+                Some(Item::RSAKey(key)) => return Ok(PrivateKey(key)),
+                Some(Item::PKCS8Key(key)) => return Ok(PrivateKey(key)),
+                Some(_) => {}
+            },
+            Err(err) => {
+                error!("Error reading key file: {:?}", err);
+                return Err(Error::InvalidServerKey(key_path.clone()));
+            }
+        }
     }
 }

--- a/rumqttd/src/server/tls.rs
+++ b/rumqttd/src/server/tls.rs
@@ -14,9 +14,9 @@ use tokio_rustls::rustls::{
     RootCertStore, ServerConfig,
 };
 
+use std::iter;
 #[cfg(feature = "use-rustls")]
 use std::{io::BufReader, sync::Arc};
-use std::iter;
 
 use crate::link::network::N;
 use crate::TlsConfig;
@@ -108,7 +108,7 @@ impl TLSAcceptor {
             TlsConfig::RustlsWithECC {
                 capath,
                 ecc_certpath,
-                ecc_keypath
+                ecc_keypath,
             } => Self::rustls(capath, ecc_certpath, ecc_keypath, true),
             #[cfg(feature = "use-native-tls")]
             TlsConfig::NativeTls {
@@ -176,8 +176,6 @@ impl TLSAcceptor {
         Ok(TLSAcceptor::NativeTLS { acceptor })
     }
 
-
-
     #[cfg(feature = "use-rustls")]
     fn rustls(
         ca_path: &String,
@@ -200,12 +198,10 @@ impl TLSAcceptor {
             let key_file = File::open(key_path);
             let key_file = key_file.map_err(|_| Error::ServerKeyNotFound(key_path.clone()))?;
 
-            let keys =
-                match is_ecc {
-                    false => rustls_pemfile::rsa_private_keys(&mut BufReader::new(key_file)),
-                    true => rustls_pemfile::ec_private_keys(&mut BufReader::new(key_file))
-                };
-
+            let keys = match is_ecc {
+                false => rustls_pemfile::rsa_private_keys(&mut BufReader::new(key_file)),
+                true => rustls_pemfile::ec_private_keys(&mut BufReader::new(key_file)),
+            };
 
             let keys = keys.map_err(|_| Error::InvalidServerKey(key_path.clone()))?;
 

--- a/rumqttd/src/server/tls.rs
+++ b/rumqttd/src/server/tls.rs
@@ -1,22 +1,20 @@
 use std::fs::File;
-#[cfg(feature = "use-native-tls")]
 use std::io::Read;
-#[cfg(feature = "use-rustls")]
-use std::{io::BufReader, sync::Arc};
+use tokio::net::TcpStream;
+
+#[cfg(feature = "use-native-tls")]
+use {tokio_native_tls::native_tls, tokio_native_tls::native_tls::Error as NativeTlsError};
 
 #[cfg(feature = "use-rustls")]
-use rustls_pemfile::Item;
-use tokio::net::TcpStream;
-#[cfg(feature = "use-native-tls")]
-use tokio_native_tls::native_tls;
-#[cfg(feature = "use-native-tls")]
-use tokio_native_tls::native_tls::Error as NativeTlsError;
-#[cfg(feature = "use-rustls")]
-use tokio_rustls::rustls::{
-    server::AllowAnyAuthenticatedClient, Certificate, Error as RustlsError, PrivateKey,
-    RootCertStore, ServerConfig,
+use {
+    rustls_pemfile::Item,
+    std::{io::BufReader, sync::Arc},
+    tokio_rustls::rustls::{
+        server::AllowAnyAuthenticatedClient, Certificate, Error as RustlsError, PrivateKey,
+        RootCertStore, ServerConfig,
+    },
+    tracing::error,
 };
-use tracing::error;
 
 use crate::link::network::N;
 use crate::TlsConfig;


### PR DESCRIPTION
## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)

<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.

#### Possible remaining actions 
- [ ] I have not included any tests yet. If you think this PR may be accepted I will look at that Monday
- [ ] I think that we should add a mention in the documentation for this feature
- [ ] I have made the choice of adding the `ecc_` prefix. Perhaps it makes more sense to detect the header or algorithm values found in the certificate (` ----- BEGIN EC PRIVATE KEY ----- `). Also, I didn't want to add a breaking change, but this assumes the RSA certs are the defaults.
- [ ] Consider implementing the above breaking change (maybe in future PR), with the following approach:
-   `rsa_` prefix allows current certs (such as the ones generated by provision, which I think are PKCS#1), i.e `BEGIN RSA PRIVATE KEY`
-  `ec_` or `ecc_` prefix with the `BEGIN EC PRIVATE KEY`
- no prefix for universal private key files, of the form `BEGIN PRIVATE KEY`

Anyway, someone more senior in this project can help make those decisions. I don't fully understand if there was a reason for hardcoding RSA in the code, but my use case requires ECC (embedded environments)