### PR TITLE
Allow rustls configuration in rumqttd

### DIFF
--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -69,7 +69,7 @@ pub struct PrometheusSetting {
 #[serde(untagged)]
 pub enum TlsConfig {
     Rustls {
-        capath: String,
+        capath: Option<String>,
         certpath: String,
         keypath: String,
     },
@@ -88,9 +88,15 @@ impl TlsConfig {
                 capath,
                 certpath,
                 keypath,
-            } => [capath, certpath, keypath]
-                .iter()
-                .all(|v| Path::new(v).exists()),
+            } => {
+                let cert_key_exist = Path::new(certpath).exists() && Path::new(keypath).exists();
+                let ca_exists = match capath {
+                    Some(p) => Path::new(p).exists(),
+                    None => true,
+                };
+
+                cert_key_exist && ca_exists
+            }
             TlsConfig::NativeTls { pkcs12path, .. } => Path::new(pkcs12path).exists(),
         }
     }

--- a/rumqttd/src/server/tls.rs
+++ b/rumqttd/src/server/tls.rs
@@ -120,13 +120,13 @@ impl TLSAcceptor {
             #[cfg(feature = "use-rustls")]
             TLSAcceptor::Rustls { acceptor } => {
                 let stream = acceptor.accept(stream).await?;
-                let (_, session) = stream.get_ref();
-                let peer_certificates = session
-                    .peer_certificates()
-                    .ok_or(Error::NoPeerCertificate)?;
-                let tenant_id = extract_tenant_id(&peer_certificates[0].0)?;
+                // let (_, session) = stream.get_ref();
+                // let peer_certificates = session
+                //     .peer_certificates()
+                //     .ok_or(Error::NoPeerCertificate)?;
+                // let tenant_id = extract_tenant_id(&peer_certificates[0].0)?;
                 let network = Box::new(stream);
-                Ok((tenant_id, network))
+                Ok((None, network))
             }
             #[cfg(feature = "use-native-tls")]
             TLSAcceptor::NativeTLS { acceptor } => {
@@ -171,7 +171,7 @@ impl TLSAcceptor {
 
     #[cfg(feature = "use-rustls")]
     fn rustls(
-        ca_path: &String,
+        ca_path: &Option<String>,
         cert_path: &String,
         key_path: &String,
     ) -> Result<TLSAcceptor, Error> {
@@ -211,26 +211,28 @@ impl TLSAcceptor {
             (certs, PrivateKey(key))
         };
 
-        // client authentication with a CA. CA isn't required otherwise
-        let server_config = {
-            let ca_file = File::open(ca_path);
-            let ca_file = ca_file.map_err(|_| Error::CaFileNotFound(ca_path.clone()))?;
-            let ca_file = &mut BufReader::new(ca_file);
-            let ca_certs = rustls_pemfile::certs(ca_file)?;
-            let ca_cert = ca_certs
-                .first()
-                .map(|c| Certificate(c.to_owned()))
-                .ok_or_else(|| Error::InvalidCACert(ca_path.to_string()))?;
+        let mut builder = ServerConfig::builder().with_safe_defaults();
+        let server_config = match ca_path {
+            Some(ca_path) => {
+                let ca_file = File::open(ca_path);
+                let ca_file = ca_file.map_err(|_| Error::CaFileNotFound(ca_path.clone()))?;
+                let ca_file = &mut BufReader::new(ca_file);
+                let ca_certs = rustls_pemfile::certs(ca_file)?;
+                let ca_cert = ca_certs
+                    .first()
+                    .map(|c| Certificate(c.to_owned()))
+                    .ok_or_else(|| Error::InvalidCACert(ca_path.to_string()))?;
 
-            let mut store = RootCertStore::empty();
-            store
-                .add(&ca_cert)
-                .map_err(|_| Error::InvalidCACert(ca_path.to_string()))?;
+                let mut store = RootCertStore::empty();
+                store
+                    .add(&ca_cert)
+                    .map_err(|_| Error::InvalidCACert(ca_path.to_string()))?;
 
-            ServerConfig::builder()
-                .with_safe_defaults()
-                .with_client_cert_verifier(Arc::new(AllowAnyAuthenticatedClient::new(store)))
-                .with_single_cert(certs, key)?
+                builder
+                    .with_client_cert_verifier(Arc::new(AllowAnyAuthenticatedClient::new(store)))
+                    .with_single_cert(certs, key)?
+            }
+            None => builder.with_no_client_auth().with_single_cert(certs, key)?,
         };
 
         let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(server_config));


### PR DESCRIPTION
* Allows private key to be any flavor supported by [`rustls_pemfile`](https://docs.rs/rustls-pemfile/latest/rustls_pemfile/).
* Allows TLS connections without client certs.

Removes setting the tenant id by client cert (keeps native and rustls impls the same).

closes #746 #747 

## Type of change

New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
