### PR TITLE
rumqttc: TLS Key encoding fix

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Expose `EventLoop::clean` to allow triggering shutdown and subsequent storage of pending requests
-- Add support for `SEC1` encoded TLS keys (specifically focusing on elliptic curve cryptography (ECC)).
+- Support for all variants of TLS key formats currently supported by Rustls: `PKCS#1`, `PKCS#8`, `RFC5915`. In practice we should now support all RSA keys and ECC keys in `DER` and `SEC1` encoding. Previously only `PKCS#1` and `PKCS#8` where supported.
+- TLS Error variants: `NoValidCACert`, `NoValidKeyInChain`.
 
 ### Changed
 - Synchronous client methods take `&self` instead of `&mut self` (#646)

--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Expose `EventLoop::clean` to allow triggering shutdown and subsequent storage of pending requests
 - Support for all variants of TLS key formats currently supported by Rustls: `PKCS#1`, `PKCS#8`, `RFC5915`. In practice we should now support all RSA keys and ECC keys in `DER` and `SEC1` encoding. Previously only `PKCS#1` and `PKCS#8` where supported.
-- TLS Error variants: `NoValidCACert`, `NoValidKeyInChain`.
+- TLS Error variants: `NoValidClientCertInChain`, `NoValidKeyInChain`.
 
 ### Changed
 - Synchronous client methods take `&self` instead of `&mut self` (#646)

--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Expose `EventLoop::clean` to allow triggering shutdown and subsequent storage of pending requests
+- Add support for `SEC1` encoded TLS keys (specifically focusing on elliptic curve cryptography (ECC)). The `EC` and `PKCS` variants are added to the `Key` enum the `ECC` variant is deprecated because it was ambiguous.
 
 ### Changed
 - Synchronous client methods take `&self` instead of `&mut self` (#646)

--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Expose `EventLoop::clean` to allow triggering shutdown and subsequent storage of pending requests
-- Add support for `SEC1` encoded TLS keys (specifically focusing on elliptic curve cryptography (ECC)). The `EC` and `PKCS` variants are added to the `Key` enum the `ECC` variant is deprecated because it was ambiguous.
+- Add support for `SEC1` encoded TLS keys (specifically focusing on elliptic curve cryptography (ECC)).
 
 ### Changed
 - Synchronous client methods take `&self` instead of `&mut self` (#646)
+- Removed the `Key` enum: users do not need to specify the TLS key variant in the `TlsConfiguration` anymore, this is inferred automatically.
+To update your code simply remove `Key::ECC()` or `Key::RSA()` from the initialization.
 
 ### Deprecated
 

--- a/rumqttc/examples/tls2.rs
+++ b/rumqttc/examples/tls2.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 #[cfg(feature = "use-rustls")]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    use rumqttc::{self, AsyncClient, Key, MqttOptions, TlsConfiguration, Transport};
+    use rumqttc::{self, AsyncClient, MqttOptions, TlsConfiguration, Transport};
 
     pretty_env_logger::init();
     color_backtrace::install();
@@ -23,7 +23,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let transport = Transport::Tls(TlsConfiguration::Simple {
         ca,
         alpn: None,
-        client_auth: Some((client_cert, Key::RSA(client_key))),
+        client_auth: Some((client_cert, client_key)),
     });
 
     mqttoptions.set_transport(transport);

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -208,7 +208,10 @@ impl Request {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Key {
     RSA(Vec<u8>),
+    #[deprecated]
     ECC(Vec<u8>),
+    EC(Vec<u8>),
+    PKCS(Vec<u8>),
 }
 
 impl From<Publish> for Request {

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -208,10 +208,7 @@ impl Request {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Key {
     RSA(Vec<u8>),
-    #[deprecated]
     ECC(Vec<u8>),
-    EC(Vec<u8>),
-    PKCS(Vec<u8>),
 }
 
 impl From<Publish> for Request {

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -207,8 +207,25 @@ impl Request {
 /// Key type for TLS authentication
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Key {
+    /// RSA key in PKCS#1 encoding
     RSA(Vec<u8>),
+    /// Eliptic curve key in SEC1 encoding
+    EC(Vec<u8>),
+    /// Key in PKCS#8 encoding
+    PKCS(Vec<u8>),
+    #[deprecated = "use PKCS or EC instead"]
+    /// Eliptic curve key in PKCS#8 encoding.
+    /// Deprecated: use PKCS or EC instead.
     ECC(Vec<u8>),
+}
+
+impl Key {
+    pub fn to_inner(self) -> Vec<u8> {
+        #[allow(deprecated)]
+        match self {
+            Key::RSA(k) | Key::ECC(k) | Key::EC(k) | Key::PKCS(k) => k,
+        }
+    }
 }
 
 impl From<Publish> for Request {

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -293,7 +293,7 @@ impl Transport {
     #[cfg_attr(docsrs, doc(cfg(all(feature = "use-rustls", feature = "websocket"))))]
     pub fn wss(
         ca: Vec<u8>,
-        client_auth: Option<(Vec<u8>, Key)>,
+        client_auth: Option<(Vec<u8>, Vec<u8>)>,
         alpn: Option<Vec<Vec<u8>>>,
     ) -> Self {
         let config = TlsConfiguration::Simple {

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -204,30 +204,6 @@ impl Request {
     }
 }
 
-/// Key type for TLS authentication
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum Key {
-    /// RSA key in PKCS#1 encoding
-    RSA(Vec<u8>),
-    /// Eliptic curve key in SEC1 encoding
-    EC(Vec<u8>),
-    /// Key in PKCS#8 encoding
-    PKCS(Vec<u8>),
-    #[deprecated = "use PKCS or EC instead"]
-    /// Eliptic curve key in PKCS#8 encoding.
-    /// Deprecated: use PKCS or EC instead.
-    ECC(Vec<u8>),
-}
-
-impl Key {
-    pub fn to_inner(self) -> Vec<u8> {
-        #[allow(deprecated)]
-        match self {
-            Key::RSA(k) | Key::ECC(k) | Key::EC(k) | Key::PKCS(k) => k,
-        }
-    }
-}
-
 impl From<Publish> for Request {
     fn from(publish: Publish) -> Request {
         Request::Publish(publish)
@@ -283,7 +259,7 @@ impl Transport {
     #[cfg(feature = "use-rustls")]
     pub fn tls(
         ca: Vec<u8>,
-        client_auth: Option<(Vec<u8>, Key)>,
+        client_auth: Option<(Vec<u8>, Vec<u8>)>,
         alpn: Option<Vec<Vec<u8>>>,
     ) -> Self {
         let config = TlsConfiguration::Simple {
@@ -353,7 +329,7 @@ pub enum TlsConfiguration {
         /// alpn settings
         alpn: Option<Vec<Vec<u8>>>,
         /// tls client_authentication
-        client_auth: Option<(Vec<u8>, Key)>,
+        client_auth: Option<(Vec<u8>, Vec<u8>)>,
     },
     #[cfg(feature = "use-native-tls")]
     SimpleNative {

--- a/rumqttc/src/tls.rs
+++ b/rumqttc/src/tls.rs
@@ -110,9 +110,13 @@ pub async fn rustls_connector(tls_config: &TlsConfiguration) -> Result<RustlsCon
                     Key::RSA(k) => rustls_pemfile::rsa_private_keys(&mut BufReader::new(
                         Cursor::new(k.clone()),
                     )),
-                    Key::ECC(k) => rustls_pemfile::pkcs8_private_keys(&mut BufReader::new(
-                        Cursor::new(k.clone()),
-                    )),
+                    Key::EC(k) => {
+                        rustls_pemfile::ec_private_keys(&mut BufReader::new(Cursor::new(k.clone())))
+                    }
+                    #[allow(deprecated)]
+                    Key::ECC(k) | Key::PKCS(k) => rustls_pemfile::pkcs8_private_keys(
+                        &mut BufReader::new(Cursor::new(k.clone())),
+                    ),
                 };
                 let keys = match read_keys {
                     Ok(v) => v,

--- a/rumqttc/src/tls.rs
+++ b/rumqttc/src/tls.rs
@@ -1,4 +1,6 @@
 #[cfg(feature = "use-rustls")]
+use rustls_pemfile::Item;
+#[cfg(feature = "use-rustls")]
 use tokio_rustls::rustls;
 #[cfg(feature = "use-rustls")]
 use tokio_rustls::rustls::client::InvalidDnsNameError;
@@ -67,8 +69,6 @@ pub enum Error {
 
 #[cfg(feature = "use-rustls")]
 pub async fn rustls_connector(tls_config: &TlsConfiguration) -> Result<RustlsConnector, Error> {
-    use rustls_pemfile::Item;
-
     let config = match tls_config {
         TlsConfiguration::Simple {
             ca,

--- a/rumqttc/src/tls.rs
+++ b/rumqttc/src/tls.rs
@@ -109,7 +109,7 @@ pub async fn rustls_connector(tls_config: &TlsConfiguration) -> Result<RustlsCon
                 // of key generation determines the Signature Algorithm during the TLS Handskahe.
 
                 // Create buffer for key file
-                let mut key_buffer = BufReader::new(Cursor::new(client.1.clone().to_inner()));
+                let mut key_buffer = BufReader::new(Cursor::new(client.1.clone()));
                 // We only read the first key in the key file
                 let key = match rustls_pemfile::read_one(&mut key_buffer) {
                     Ok(Some(rustls_pemfile::Item::RSAKey(key)))


### PR DESCRIPTION
<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

Breaking Change


## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.

## Description

This PR lets users of rumqttc use any of the Rustls supported key encodings [RSA (PKCS#1), PKCS#8, SEC1].  

This issue addresses #751 

I left the `Key` enum as is to prevent a breaking change, however it does no longer matter if the user choses `RSA` or `ECC`. For a cleaner API I think the `Key` enum could be removed. 

