### PR TITLE
optional client certificates while using native-tls

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Synchronous client methods take `&self` instead of `&mut self` (#646)
 - Removed the `Key` enum: users do not need to specify the TLS key variant in the `TlsConfiguration` anymore, this is inferred automatically.
 To update your code simply remove `Key::ECC()` or `Key::RSA()` from the initialization.
+- certificate for client authentication is now optional while using native-tls. `der` & `password` fields are replaced by `client_auth`.
 
 ### Deprecated
 

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -335,10 +335,9 @@ pub enum TlsConfiguration {
     SimpleNative {
         /// ca certificate
         ca: Vec<u8>,
-        /// pkcs12 binary der
-        der: Vec<u8>,
+        /// pkcs12 binary der and
         /// password for use with der
-        password: String,
+        client_auth: Option<(Vec<u8>, String)>,
     },
     #[cfg(feature = "use-rustls")]
     /// Injected rustls ClientConfig for TLS, to allow more customisation.


### PR DESCRIPTION
client certificate is optional while using rumqttc with rustls. But with native-tls, it is required to specify certificates! 

Client authentication certificates should be optional for native-tls as well, this PR makes the required changes for it :rocket: 

## Type of change
 - Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
