### PR TITLE
drain pending Request from channel while cleanup

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expose `EventLoop::clean` to allow triggering shutdown and subsequent storage of pending requests
 - Support for all variants of TLS key formats currently supported by Rustls: `PKCS#1`, `PKCS#8`, `RFC5915`. In practice we should now support all RSA keys and ECC keys in `DER` and `SEC1` encoding. Previously only `PKCS#1` and `PKCS#8` where supported.
 - TLS Error variants: `NoValidClientCertInChain`, `NoValidKeyInChain`.
+- Drain `Request`s, which weren't received by eventloop, from channel and put them in pending while doing cleanup to prevent data loss.
 
 ### Changed
 - Synchronous client methods take `&self` instead of `&mut self` (#646)

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -127,7 +127,14 @@ impl EventLoop {
     pub fn clean(&mut self) {
         self.network = None;
         self.keepalive_timeout = None;
-        self.pending = self.state.clean().into_iter();
+        let mut pending = self.state.clean();
+
+        // drain requests from channel which weren't yet received
+        // this helps in preventing data loss
+        let requests_in_channel = self.requests_rx.drain();
+        pending.extend(requests_in_channel);
+
+        self.pending = pending.into_iter();
     }
 
     /// Yields Next notification or outgoing request and periodically pings


### PR DESCRIPTION
calling drain on receiver while doing cleanup would help us in preventing data loss to some extend!

## Type of change

- New feature (non-breaking change which adds functionality) 

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
