### PR TITLE
Adds external auth capabilities.

### DIFF
--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - websocket feature is enabled by default
 - console configuration is optional
 - rustls client auth is featured gated behind "verify-client-cert" ( disabled by default ). 
-- auth in cofig is now `static_auth`
+- `auth` in cofig is now `static_auth`
 
 ### Deprecated
 - "websockets" feature is removed in favour of "websocket"

--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - websocket feature is enabled by default
 - console configuration is optional
 - rustls client auth is featured gated behind "verify-client-cert" ( disabled by default ). 
-- `auth` in cofig is now `static_auth`
+- `auth` property in config is now `static_auth`
 
 ### Deprecated
 - "websockets" feature is removed in favour of "websocket"

--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Log warning if websocket config is getting ignored
 - Add support for ECC keys when configuring TLS in rumqttd
-- External authorization
+- Support for external authentication with custom function
 
 ### Changed
 - Console endpoint /config prints Router Config instead of returning console settings

--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -17,8 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - v4 config is optional, user can specify v4 and/or v5 config
 - websocket feature is enabled by default
 - console configuration is optional
-- rustls client auth is featured gated behind "verify-client-cert" ( disabled by default ). 
-- `auth` property in config is now `static_auth`
+- rustls client auth is featured gated behind "verify-client-cert" ( disabled by default ).
 
 ### Deprecated
 - "websockets" feature is removed in favour of "websocket"

--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Log warning if websocket config is getting ignored
-- Add support for ECC keys when configuring TLS in rumqttd 
+- Add support for ECC keys when configuring TLS in rumqttd
+- External authorization
 
 ### Changed
 - Console endpoint /config prints Router Config instead of returning console settings
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - websocket feature is enabled by default
 - console configuration is optional
 - rustls client auth is featured gated behind "verify-client-cert" ( disabled by default ). 
+- auth in cofig is now `static_auth`
 
 ### Deprecated
 - "websockets" feature is removed in favour of "websocket"

--- a/rumqttd/rumqttd.toml
+++ b/rumqttd/rumqttd.toml
@@ -45,7 +45,7 @@ next_connection_delay_ms = 1
     max_payload_size = 20480
     max_inflight_count = 100
     dynamic_filters = true
- #   auth = { user1 = "p@ssw0rd", user2 = "password" }
+ #   static_auth = { user1 = "p@ssw0rd", user2 = "password" }
  #      [v4.1.connections.auth]
  #      user1 = "p@ssw0rd"
  #      user2 = "password"

--- a/rumqttd/rumqttd.toml
+++ b/rumqttd/rumqttd.toml
@@ -45,7 +45,7 @@ next_connection_delay_ms = 1
     max_payload_size = 20480
     max_inflight_count = 100
     dynamic_filters = true
- #   static_auth = { user1 = "p@ssw0rd", user2 = "password" }
+ #   auth = { user1 = "p@ssw0rd", user2 = "password" }
  #      [v4.1.connections.auth]
  #      user1 = "p@ssw0rd"
  #      user2 = "password"

--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -144,7 +144,7 @@ impl fmt::Debug for ConnectionSettings {
             .field("max_payload_size", &self.max_payload_size)
             .field("max_inflight_count", &self.max_inflight_count)
             .field("static_auth", &self.static_auth)
-            .field("dynamic_auth.is_some()", &self.dynamic_auth.is_some())
+            .field("dynamic_auth", &self.dynamic_auth.is_some())
             .field("dynamic_filters", &self.dynamic_filters)
             .finish()
     }

--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -1,5 +1,7 @@
+use std::fmt;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::{collections::HashMap, path::Path};
 
 use serde::{Deserialize, Serialize};
@@ -37,6 +39,11 @@ pub type Filter = String;
 pub type TopicId = usize;
 pub type Offset = (u64, u64);
 pub type Cursor = (u64, u64);
+
+pub type ClientId = String;
+pub type AuthUser = String;
+pub type AuthPass = String;
+pub type AuthHandler = Arc<dyn Fn(ClientId, AuthUser, AuthPass) -> bool + Send + Sync + 'static>;
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct Config {
@@ -118,14 +125,29 @@ pub struct BridgeConfig {
     pub transport: Transport,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct ConnectionSettings {
     pub connection_timeout_ms: u16,
     pub max_payload_size: usize,
     pub max_inflight_count: usize,
-    pub auth: Option<HashMap<String, String>>,
+    pub static_auth: Option<HashMap<String, String>>,
+    #[serde(skip)]
+    pub dynamic_auth: Option<AuthHandler>,
     #[serde(default)]
     pub dynamic_filters: bool,
+}
+
+impl fmt::Debug for ConnectionSettings {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ConnectionSettings")
+            .field("connection_timeout_ms", &self.connection_timeout_ms)
+            .field("max_payload_size", &self.max_payload_size)
+            .field("max_inflight_count", &self.max_inflight_count)
+            .field("static_auth", &self.static_auth)
+            .field("dynamic_auth.is_some()", &self.dynamic_auth.is_some())
+            .field("dynamic_filters", &self.dynamic_filters)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -130,9 +130,9 @@ pub struct ConnectionSettings {
     pub connection_timeout_ms: u16,
     pub max_payload_size: usize,
     pub max_inflight_count: usize,
-    pub static_auth: Option<HashMap<String, String>>,
+    pub auth: Option<HashMap<String, String>>,
     #[serde(skip)]
-    pub dynamic_auth: Option<AuthHandler>,
+    pub external_auth: Option<AuthHandler>,
     #[serde(default)]
     pub dynamic_filters: bool,
 }
@@ -143,8 +143,8 @@ impl fmt::Debug for ConnectionSettings {
             .field("connection_timeout_ms", &self.connection_timeout_ms)
             .field("max_payload_size", &self.max_payload_size)
             .field("max_inflight_count", &self.max_inflight_count)
-            .field("static_auth", &self.static_auth)
-            .field("dynamic_auth", &self.dynamic_auth.is_some())
+            .field("auth", &self.auth)
+            .field("external_auth", &self.external_auth.is_some())
             .field("dynamic_filters", &self.dynamic_filters)
             .finish()
     }

--- a/rumqttd/src/link/remote.rs
+++ b/rumqttd/src/link/remote.rs
@@ -186,7 +186,7 @@ where
         packet => return Err(Error::NotConnectPacket(packet)),
     };
 
-    handle_auth(config.clone(), login.as_ref())?;
+    handle_auth(connect.client_id.clone(), config.clone(), login.as_ref())?;
 
     // When keep_alive feature is disabled client can live forever, which is not good in
     // distributed broker context so currenlty we don't allow it.
@@ -211,7 +211,11 @@ where
     Ok(packet)
 }
 
-fn handle_auth(config: Arc<ConnectionSettings>, login: Option<&Login>) -> Result<(), Error> {
+fn handle_auth(
+    config: Arc<ConnectionSettings>,
+    login: Option<&Login>,
+    client_id: String,
+) -> Result<(), Error> {
     if config.static_auth.is_none() && config.dynamic_auth.is_none() {
         return Ok(());
     }
@@ -239,7 +243,7 @@ fn handle_auth(config: Arc<ConnectionSettings>, login: Option<&Login>) -> Result
     }
 
     if let Some(ref auth) = config.dynamic_auth {
-        if !auth("".to_owned(), u.to_owned(), p.to_owned()) {
+        if !auth(client_id, u.to_owned(), p.to_owned()) {
             return Err(Error::InvalidAuth);
         }
     }

--- a/rumqttd/src/link/remote.rs
+++ b/rumqttd/src/link/remote.rs
@@ -243,10 +243,10 @@ fn handle_auth(
     }
 
     if let Some(ref auth) = config.dynamic_auth {
-        if !auth(client_id, u.to_owned(), p.to_owned()) {
-            return Err(Error::InvalidAuth);
+        if auth(client_id, u.to_owned(), p.to_owned()) {
+            return Ok(());
         }
     }
 
-    Ok(())
+    return Err(Error::InvalidAuth);
 }

--- a/rumqttd/src/link/remote.rs
+++ b/rumqttd/src/link/remote.rs
@@ -186,7 +186,7 @@ where
         packet => return Err(Error::NotConnectPacket(packet)),
     };
 
-    handle_auth(connect.client_id.clone(), config.clone(), login.as_ref())?;
+    handle_auth(config.clone(), login.as_ref(), connect.client_id.clone())?;
 
     // When keep_alive feature is disabled client can live forever, which is not good in
     // distributed broker context so currenlty we don't allow it.


### PR DESCRIPTION
## Type of change

New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.

## Notes

* Breaks config API by renaming `auth` to `static_auth`.

This solves two problems we currently have with rumqttd:

* The ability to get client id on new connections, when a new connection happens.
* Allow hooks into our external auth service.