### PR TITLE
fix rust-cache with proper key and global RUSTFLAG

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,14 +27,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: actions/cache@v3
+
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - uses: taiki-e/install-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: ${{ runner.os }}-cargo
 
       - uses: taiki-e/install-action@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
 
 name: Build and Test
 
+env:
+  RUSTFLAGS: "-D warnings"
+
 jobs:
   test:
     name: Build and test on ${{ matrix.os }} with ${{ matrix.features }}
@@ -48,8 +51,6 @@ jobs:
 
       - name: Check rumqttc and rumqttd
         run: cargo hack clippy --verbose --each-feature --no-dev-deps --optional-deps url -p rumqttc -p rumqttd
-        env:
-          RUSTFLAGS: "-D warnings"
 
       - name: Check docs
         if: ${{ matrix.os != 'windows-latest' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - uses: taiki-e/install-action@v1
         with:

--- a/rumqttd/src/remove_me.rs
+++ b/rumqttd/src/remove_me.rs
@@ -1,1 +1,0 @@
-panic!("swanandx is for sure a genius, right?");

--- a/rumqttd/src/remove_me.rs
+++ b/rumqttd/src/remove_me.rs
@@ -1,0 +1,1 @@
+panic!("not so genius everytime :(");

--- a/rumqttd/src/remove_me.rs
+++ b/rumqttd/src/remove_me.rs
@@ -1,0 +1,1 @@
+panic!("swanandx is genius :)");

--- a/rumqttd/src/remove_me.rs
+++ b/rumqttd/src/remove_me.rs
@@ -1,1 +1,1 @@
-panic!("swanandx is for sure a genius :-)");
+panic!("swanandx is for sure a genius, right?");

--- a/rumqttd/src/remove_me.rs
+++ b/rumqttd/src/remove_me.rs
@@ -1,1 +1,1 @@
-panic!("not so genius everytime :( !");
+panic!("not so genius everytime :(");

--- a/rumqttd/src/remove_me.rs
+++ b/rumqttd/src/remove_me.rs
@@ -1,1 +1,1 @@
-panic!("not so genius everytime :(");
+panic!("might actually be a genius :)");

--- a/rumqttd/src/remove_me.rs
+++ b/rumqttd/src/remove_me.rs
@@ -1,1 +1,0 @@
-panic!("swanandx is genius :)");

--- a/rumqttd/src/remove_me.rs
+++ b/rumqttd/src/remove_me.rs
@@ -1,1 +1,1 @@
-panic!("not so genius everytime :(");
+panic!("not so genius everytime :( !");

--- a/rumqttd/src/remove_me.rs
+++ b/rumqttd/src/remove_me.rs
@@ -1,1 +1,1 @@
-panic!("might actually be a genius :)");
+panic!("swanandx is for sure a genius :)");

--- a/rumqttd/src/remove_me.rs
+++ b/rumqttd/src/remove_me.rs
@@ -1,1 +1,1 @@
-panic!("swanandx is for sure a genius :)");
+panic!("swanandx is for sure a genius :-)");


### PR DESCRIPTION
CI isn't caching properly. let's say a PR is opened, job runs and saves cache with key "-c4efedb3", now if I push a commit ( editing changelog ), it has restore key of "-fda4c98d.." so it never finds the cache which it should have!

Basically, we are never seeing an cache hit.

This solves two things:
- use keys with `runner.os` ( for cache hits )
- set `RUSTFLAG: -D warnings" globally instead of just clippy ( otherwise the cache is invalidated and project is rebuilt every time! )

## Type of change

- Miscellaneous (related to maintenance)

## Checklist:

- [ ] Formatted with `cargo fmt`
- [ ] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
