### PR TITLE
Add websocket request modifier for v4 client

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for all variants of TLS key formats currently supported by Rustls: `PKCS#1`, `PKCS#8`, `RFC5915`. In practice we should now support all RSA keys and ECC keys in `DER` and `SEC1` encoding. Previously only `PKCS#1` and `PKCS#8` where supported.
 - TLS Error variants: `NoValidClientCertInChain`, `NoValidKeyInChain`.
 - Drain `Request`s, which weren't received by eventloop, from channel and put them in pending while doing cleanup to prevent data loss.
+- websocket request modifier for v4 client
 
 ### Changed
 - Synchronous client methods take `&self` instead of `&mut self` (#646)

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -407,6 +407,10 @@ async fn network_connect(
                 .headers_mut()
                 .insert("Sec-WebSocket-Protocol", "mqtt".parse().unwrap());
 
+            if let Some(request_modifier) = options.request_modifier() {
+                request = request_modifier(request).await;
+            }
+
             let (socket, response) =
                 async_tungstenite::tokio::client_async(request, tcp_stream).await?;
             validate_response_headers(response)?;
@@ -419,6 +423,10 @@ async fn network_connect(
             request
                 .headers_mut()
                 .insert("Sec-WebSocket-Protocol", "mqtt".parse().unwrap());
+
+            if let Some(request_modifier) = options.request_modifier() {
+                request = request_modifier(request).await;
+            }
 
             let connector = tls::rustls_connector(&tls_config).await?;
 

--- a/rumqttc/src/v5/mqttbytes/v5/mod.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/mod.rs
@@ -11,7 +11,7 @@ pub use self::{
     pubrec::{PubRec, PubRecProperties, PubRecReason},
     pubrel::{PubRel, PubRelProperties, PubRelReason},
     suback::{SubAck, SubAckProperties, SubscribeReasonCode},
-    subscribe::{Filter, Subscribe, SubscribeProperties, RetainForwardRule},
+    subscribe::{Filter, RetainForwardRule, Subscribe, SubscribeProperties},
     unsuback::{UnsubAck, UnsubAckProperties, UnsubAckReason},
     unsubscribe::{Unsubscribe, UnsubscribeProperties},
 };


### PR DESCRIPTION
currently websocket request modifier is only present in v5 client, this PR aims to bring it to v4 client as well.

## Type of change

 - New feature (non-breaking change which adds functionality) 
## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
