### PR TITLE
Adds handler to set socket option in rumqttd.

### DIFF
--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* `set_socket_opts` in `ConnectionSettings`.
+
 ### Changed
 
 ### Deprecated

--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::{collections::HashMap, path::Path};
 
 use serde::{Deserialize, Serialize};
+use tokio::net::TcpStream;
 use tracing_subscriber::{
     filter::EnvFilter,
     fmt::{
@@ -44,6 +45,7 @@ pub type ClientId = String;
 pub type AuthUser = String;
 pub type AuthPass = String;
 pub type AuthHandler = Arc<dyn Fn(ClientId, AuthUser, AuthPass) -> bool + Send + Sync + 'static>;
+pub type SocketOptHandler = Arc<dyn Fn(&mut TcpStream) + Send + Sync + 'static>;
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct Config {
@@ -135,6 +137,8 @@ pub struct ConnectionSettings {
     pub external_auth: Option<AuthHandler>,
     #[serde(default)]
     pub dynamic_filters: bool,
+    #[serde(skip)]
+    pub set_socket_opts: Option<SocketOptHandler>,
 }
 
 impl fmt::Debug for ConnectionSettings {
@@ -146,6 +150,7 @@ impl fmt::Debug for ConnectionSettings {
             .field("auth", &self.auth)
             .field("external_auth", &self.external_auth.is_some())
             .field("dynamic_filters", &self.dynamic_filters)
+            .field("set_socket_opts", &self.set_socket_opts.is_some())
             .finish()
     }
 }

--- a/rumqttd/src/server/broker.rs
+++ b/rumqttd/src/server/broker.rs
@@ -391,7 +391,13 @@ impl<P: Protocol + Clone + Send + 'static> Server<P> {
         loop {
             // Await new network connection.
             let (stream, addr) = match listener.accept().await {
-                Ok((s, r)) => (s, r),
+                Ok((mut s, r)) => {
+                    if let Some(ref set_sockopt) = config.set_socket_opts {
+                        set_sockopt(&mut s);
+                    }
+
+                    (s, r)
+                }
                 Err(e) => {
                     error!(error=?e, "Unable to accept socket.");
                     continue;


### PR DESCRIPTION
This is useful for setting lower level settings on the socket, such as `SO_KEEPALIVE`, `TCP_KEEPCNT`, and various socket level flags. 

A use case we have is currently when a client is connect, the network drops on the client end, rumqttd will not show as disconnected until the TCP keep alive settings from the OS kick in, this defaults to 2 hours on Linux. This allows a spot so the connections that need specific TCP conditions can have that.

This adds extra configs, which reduce zombie connections that can exist. 

ref #775 

## Type of change

 New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
