### PR TITLE
Add `from_senders` for the Sync Client

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TLS Error variants: `NoValidClientCertInChain`, `NoValidKeyInChain`.
 - Drain `Request`s, which weren't received by eventloop, from channel and put them in pending while doing cleanup to prevent data loss.
 - websocket request modifier for v4 client
+- Surfaced `AsyncClient`'s `from_senders` method to the `Client` as `from_sender`
 
 ### Changed
 - Synchronous client methods take `&self` instead of `&mut self` (#646)

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -257,6 +257,16 @@ impl Client {
         (client, connection)
     }
 
+    /// Create a new `Client` from a channel `Sender`.
+    ///
+    /// This is mostly useful for creating a test instance where you can
+    /// listen on the corresponding receiver.
+    pub fn from_sender(request_tx: Sender<Request>) -> Client {
+        Client {
+            client: AsyncClient::from_senders(request_tx),
+        }
+    }
+
     /// Sends a MQTT Publish to the `EventLoop`
     pub fn publish<S, V>(
         &self,
@@ -499,5 +509,15 @@ mod test {
         let (_, mut connection) = Client::new(mqttoptions, 10);
         let _ = connection.iter();
         let _ = connection.iter();
+    }
+
+    #[test]
+    fn should_be_able_to_build_test_client_from_channel() {
+        let (tx, rx) = flume::bounded(1);
+        let client = Client::from_sender(tx);
+        client
+            .publish("hello/world", QoS::ExactlyOnce, false, "good bye")
+            .expect("Should be able to publish");
+        let _ = rx.try_recv().expect("Should have message");
     }
 }

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -57,8 +57,10 @@ impl AsyncClient {
         (client, eventloop)
     }
 
-    /// Create a new `AsyncClient` from a pair of async channel `Sender`s. This is mostly useful for
-    /// creating a test instance.
+    /// Create a new `AsyncClient` from a channel `Sender`.
+    ///
+    /// This is mostly useful for creating a test instance where you can
+    /// listen on the corresponding receiver.
     pub fn from_senders(request_tx: Sender<Request>) -> AsyncClient {
         AsyncClient { request_tx }
     }

--- a/rumqttc/src/v5/client.rs
+++ b/rumqttc/src/v5/client.rs
@@ -62,8 +62,10 @@ impl AsyncClient {
         (client, eventloop)
     }
 
-    /// Create a new `AsyncClient` from a pair of async channel `Sender`s. This is mostly useful for
-    /// creating a test instance.
+    /// Create a new `AsyncClient` from a channel `Sender`.
+    ///
+    /// This is mostly useful for creating a test instance where you can
+    /// listen on the corresponding receiver.
     pub fn from_senders(request_tx: Sender<Request>) -> AsyncClient {
         AsyncClient { request_tx }
     }

--- a/rumqttc/src/v5/client.rs
+++ b/rumqttc/src/v5/client.rs
@@ -472,6 +472,16 @@ impl Client {
         (client, connection)
     }
 
+    /// Create a new `Client` from a channel `Sender`.
+    ///
+    /// This is mostly useful for creating a test instance where you can
+    /// listen on the corresponding receiver.
+    pub fn from_sender(request_tx: Sender<Request>) -> Client {
+        Client {
+            client: AsyncClient::from_senders(request_tx),
+        }
+    }
+
     /// Sends a MQTT Publish to the `EventLoop`
     fn handle_publish<S, P>(
         &self,
@@ -847,5 +857,15 @@ mod test {
         let (_, mut connection) = Client::new(mqttoptions, 10);
         let _ = connection.iter();
         let _ = connection.iter();
+    }
+
+    #[test]
+    fn should_be_able_to_build_test_client_from_channel() {
+        let (tx, rx) = flume::bounded(1);
+        let client = Client::from_sender(tx);
+        client
+            .publish("hello/world", QoS::ExactlyOnce, false, "good bye")
+            .expect("Should be able to publish");
+        let _ = rx.try_recv().expect("Should have message");
     }
 }


### PR DESCRIPTION
A lot of my team's code uses the synchronous client. I'd like to be able to easily write tests using a Fake Mqtt client. One easy way to do this for unit tests is by using something like the `from_senders` method that's available on the `AsyncClient`. This PR adds a `from_sender` method for the sync client which can be used to write tests like the one I wrote in this PR. 

It also updates a stale comment on the async client.

<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [X] Formatted with `cargo fmt`
- [X] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
