### PR TITLE
rumqttd: Changes peer initiated disconnect logs to info.

### DIFF
--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Public re-export `Strategy` for shared subscriptions
-- Log level of link disconnect by peer.
+- Client id added to disconnect logs.
+- Peer initiated disconnects logged as info rather than error.
 
 ### Deprecated
 

--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Public re-export `Strategy` for shared subscriptions
-- Client id added to disconnect logs.
 - Peer initiated disconnects logged as info rather than error.
 
 ### Deprecated

--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Public re-export `Strategy` for shared subscriptions
+_ Log level of link disconnect by peer.
 
 ### Deprecated
 

--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Public re-export `Strategy` for shared subscriptions
-_ Log level of link disconnect by peer.
+- Log level of link disconnect by peer.
 
 ### Deprecated
 

--- a/rumqttd/src/server/broker.rs
+++ b/rumqttd/src/server/broker.rs
@@ -1,6 +1,6 @@
 use crate::link::alerts::{self};
 use crate::link::console::ConsoleLink;
-use crate::link::network::{Network, N};
+use crate::link::network::{self, Network, N};
 use crate::link::remote::{self, mqtt_connect, RemoteLink};
 use crate::link::{bridge, timer};
 use crate::local::LinkBuilder;
@@ -580,6 +580,16 @@ async fn remote<P: Protocol>(
                     error!(error=?e, "Disconnected!!");
                 }
             }
+            remote::Error::Network(e) => match e {
+                network::Error::Io(e) => {
+                    if e.kind() == io::ErrorKind::ConnectionAborted {
+                        info!("Link disconnected");
+                    } else {
+                        error!(error=?e, "Disconnected!!");
+                    }
+                }
+                _ => error!(error=?e, "Disconnected!!"),
+            },
             _ => error!(error=?e, "Disconnected!!"),
         },
     };

--- a/rumqttd/src/server/broker.rs
+++ b/rumqttd/src/server/broker.rs
@@ -579,7 +579,7 @@ async fn remote<P: Protocol>(
         }
         // Any other error
         Err(e) => {
-            error!(error=?e, "disconencted");
+            error!(error=?e, "disconnected");
         }
     };
 

--- a/rumqttd/src/server/broker.rs
+++ b/rumqttd/src/server/broker.rs
@@ -572,9 +572,16 @@ async fn remote<P: Protocol>(
             send_disconnect = false;
         }
         // Any other error
-        Err(e) => {
-            error!(error=?e, "Disconnected!!");
-        }
+        Err(e) => match e {
+            remote::Error::Io(e) => {
+                if e.kind() == io::ErrorKind::ConnectionAborted {
+                    info!("Link disconnected");
+                } else {
+                    error!(error=?e, "Disconnected!!");
+                }
+            }
+            _ => error!(error=?e, "Disconnected!!"),
+        },
     };
 
     if send_disconnect {

--- a/rumqttd/src/server/broker.rs
+++ b/rumqttd/src/server/broker.rs
@@ -568,18 +568,18 @@ async fn remote<P: Protocol>(
         // No need to send a disconnect message when disconnection
         // originated internally in the router.
         Err(remote::Error::Link(e)) => {
-            error!(error=?e, client_id=client_id, "router-drop");
+            error!(error=?e, "router-drop");
             send_disconnect = false;
         }
         // Connection was closed by peer
         Err(remote::Error::Network(network::Error::Io(err)) | remote::Error::Io(err))
             if err.kind() == io::ErrorKind::ConnectionAborted =>
         {
-            info!(error=?err, client_id=client_id, "disconnected");
+            info!(error=?err, "disconnected");
         }
         // Any other error
         Err(e) => {
-            error!(error=?e, client_id=client_id, "disconencted");
+            error!(error=?e, "disconencted");
         }
     };
 


### PR DESCRIPTION
* Disconnect by peer shouldn't be an error. Peer initiated disconnects should be logged as good faith operations.

## Type of change

Miscellaneous (related to maintenance)

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
