### PR TITLE
fix(rumqttd): use keepalive duration when reading from network

### DIFF
--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- MQTT keep alive interval
 
 ### Security
 

--- a/rumqttd/src/link/network.rs
+++ b/rumqttd/src/link/network.rs
@@ -55,7 +55,7 @@ impl<P: Protocol> Network<P> {
             write: BytesMut::with_capacity(10 * 1024),
             max_incoming_size,
             max_connection_buffer_len,
-            keepalive: Duration::MAX,
+            keepalive: Duration::ZERO,
             protocol,
         }
     }

--- a/rumqttd/src/link/network.rs
+++ b/rumqttd/src/link/network.rs
@@ -1,5 +1,8 @@
 use bytes::BytesMut;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::{
+    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
+    time::timeout,
+};
 
 use std::{
     collections::VecDeque,
@@ -52,7 +55,7 @@ impl<P: Protocol> Network<P> {
             write: BytesMut::with_capacity(10 * 1024),
             max_incoming_size,
             max_connection_buffer_len,
-            keepalive: Duration::from_secs(0),
+            keepalive: Duration::MAX,
             protocol,
         }
     }
@@ -100,7 +103,7 @@ impl<P: Protocol> Network<P> {
 
             // read more packets until a frame can be created. This function
             // blocks until a frame can be created. Use this in a select! branch
-            self.read_bytes(required).await?;
+            timeout(self.keepalive, self.read_bytes(required)).await??;
         }
     }
 


### PR DESCRIPTION
MQTT keepalive duration set by the client wasn't being used. This PR aims to fix this issue :)

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

- Bug fix (non-breaking change which fixes an issue)
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
