### PR TITLE
fix(rumqttd): record client_id in span

### DIFF
--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - MQTT keep alive interval
+- record client id for remote link's span
 
 ### Security
 

--- a/rumqttd/src/link/remote.rs
+++ b/rumqttd/src/link/remote.rs
@@ -186,6 +186,8 @@ where
         packet => return Err(Error::NotConnectPacket(packet)),
     };
 
+    Span::current().record("client_id", &connect.client_id);
+
     handle_auth(config.clone(), login.as_ref(), &connect.client_id)?;
 
     // When keep_alive feature is disabled client can live forever, which is not good in


### PR DESCRIPTION
we used to record `client_id` as a field in remote link's span, but somehow we lost it ( most likely I, @swanandx , am to be blamed :stuck_out_tongue_closed_eyes: ).

This PR fixes it, we record the client_id :partying_face: 

## Type of change
 - Bug fix (non-breaking change which fixes an issue)
## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
