### PR TITLE
feat: oneshot channel returns `Pkid`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1953,6 +1953,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "url",
  "ws_stream_tungstenite",
 ]
@@ -2555,6 +2556,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
+ "slab",
  "tokio",
  "tracing",
 ]

--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -29,6 +29,7 @@ To update your code simply remove `Key::ECC()` or `Key::RSA()` from the initiali
   `rusttls-pemfile` to `2.0.0`, `async-tungstenite` to `0.24.0`, `ws_stream_tungstenite` to `0.12.0`
   and `http` to `1.0.0`. This is a breaking change as types from some of these crates are part of
   the public API.
+- `publish` / `subscribe` / `unsubscribe` methods on `AsyncClient` and `Client` now return a `PkidPromise` which resolves into the identifier value chosen by the `EventLoop` when handling the packet. 
 
 ### Deprecated
 

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -55,6 +55,7 @@ matches = "0.1"
 pretty_assertions = "1"
 pretty_env_logger = "0.5"
 serde = { version = "1", features = ["derive"] }
+tokio-util = { version = "0.7", features = ["time"] }
 
 [[example]]
 name = "tls"

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -24,7 +24,7 @@ proxy = ["dep:async-http-proxy"]
 
 [dependencies]
 futures-util = { version = "0.3", default_features = false, features = ["std"] }
-tokio = { version = "1.36", features = ["rt", "macros", "io-util", "net", "time"] }
+tokio = { version = "1.36", features = ["rt", "macros", "io-util", "net", "time", "sync"] }
 bytes = "1.5"
 log = "0.4"
 flume = { version = "0.11", default-features = false, features = ["async"] }

--- a/rumqttc/examples/pkid_promise.rs
+++ b/rumqttc/examples/pkid_promise.rs
@@ -1,0 +1,61 @@
+use tokio::{
+    task::{self, JoinSet},
+    time,
+};
+
+use rumqttc::{AsyncClient, MqttOptions, QoS};
+use std::error::Error;
+use std::time::Duration;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn Error>> {
+    pretty_env_logger::init();
+    // color_backtrace::install();
+
+    let mut mqttoptions = MqttOptions::new("test-1", "localhost", 1883);
+    mqttoptions.set_keep_alive(Duration::from_secs(5));
+
+    let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    task::spawn(async move {
+        requests(client).await;
+    });
+
+    loop {
+        let event = eventloop.poll().await;
+        match &event {
+            Ok(v) => {
+                println!("Event = {v:?}");
+            }
+            Err(e) => {
+                println!("Error = {e:?}");
+                return Ok(());
+            }
+        }
+    }
+}
+
+async fn requests(client: AsyncClient) {
+    let mut joins = JoinSet::new();
+    joins.spawn(
+        client
+            .subscribe("hello/world", QoS::AtMostOnce)
+            .await
+            .unwrap(),
+    );
+
+    for i in 1..=10 {
+        joins.spawn(
+            client
+                .publish("hello/world", QoS::ExactlyOnce, false, vec![1; i])
+                .await
+                .unwrap(),
+        );
+
+        time::sleep(Duration::from_secs(1)).await;
+    }
+
+    // TODO: maybe rewrite to showcase in-between resolutions?
+    while let Some(Ok(Ok(pkid))) = joins.join_next().await {
+        println!("Pkid: {:?}", pkid);
+    }
+}

--- a/rumqttc/examples/pkid_promise.rs
+++ b/rumqttc/examples/pkid_promise.rs
@@ -61,7 +61,7 @@ async fn requests(client: AsyncClient) {
                         .unwrap().wait_async(),
                 );
             }
-            Some(Ok(Some(pkid))) = joins.join_next() => {
+            Some(Ok(Ok(pkid))) = joins.join_next() => {
                 println!("Pkid: {:?}", pkid);
             }
             else => break,

--- a/rumqttc/examples/pkid_promise.rs
+++ b/rumqttc/examples/pkid_promise.rs
@@ -42,7 +42,8 @@ async fn requests(client: AsyncClient) {
         client
             .subscribe("hello/world", QoS::AtMostOnce)
             .await
-            .unwrap(),
+            .unwrap()
+            .wait_async(),
     );
 
     let mut queue = DelayQueue::new();
@@ -57,10 +58,10 @@ async fn requests(client: AsyncClient) {
                     client
                         .publish("hello/world", QoS::ExactlyOnce, false, vec![1; i.into_inner()])
                         .await
-                        .unwrap(),
+                        .unwrap().wait_async(),
                 );
             }
-            Some(Ok(Ok(pkid))) = joins.join_next() => {
+            Some(Ok(Some(pkid))) = joins.join_next() => {
                 println!("Pkid: {:?}", pkid);
             }
             else => break,

--- a/rumqttc/examples/pkid_promise_v5.rs
+++ b/rumqttc/examples/pkid_promise_v5.rs
@@ -61,7 +61,7 @@ async fn requests(client: AsyncClient) {
                         .unwrap().wait_async(),
                 );
             }
-            Some(Ok(Some(pkid))) = joins.join_next() => {
+            Some(Ok(Ok(pkid))) = joins.join_next() => {
                 println!("Pkid: {:?}", pkid);
             }
             else => break,

--- a/rumqttc/examples/pkid_promise_v5.rs
+++ b/rumqttc/examples/pkid_promise_v5.rs
@@ -5,7 +5,7 @@ use tokio::{
 };
 use tokio_util::time::DelayQueue;
 
-use rumqttc::{AsyncClient, MqttOptions, QoS};
+use rumqttc::v5::{mqttbytes::QoS, AsyncClient, MqttOptions};
 use std::error::Error;
 use std::time::Duration;
 

--- a/rumqttc/examples/pkid_promise_v5.rs
+++ b/rumqttc/examples/pkid_promise_v5.rs
@@ -42,7 +42,8 @@ async fn requests(client: AsyncClient) {
         client
             .subscribe("hello/world", QoS::AtMostOnce)
             .await
-            .unwrap(),
+            .unwrap()
+            .wait_async(),
     );
 
     let mut queue = DelayQueue::new();
@@ -57,7 +58,7 @@ async fn requests(client: AsyncClient) {
                     client
                         .publish("hello/world", QoS::ExactlyOnce, false, vec![1; i.into_inner()])
                         .await
-                        .unwrap(),
+                        .unwrap().wait_async(),
                 );
             }
             Some(Ok(Ok(pkid))) = joins.join_next() => {

--- a/rumqttc/examples/pkid_promise_v5.rs
+++ b/rumqttc/examples/pkid_promise_v5.rs
@@ -61,7 +61,7 @@ async fn requests(client: AsyncClient) {
                         .unwrap().wait_async(),
                 );
             }
-            Some(Ok(Ok(pkid))) = joins.join_next() => {
+            Some(Ok(Some(pkid))) = joins.join_next() => {
                 println!("Pkid: {:?}", pkid);
             }
             else => break,

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -94,7 +94,7 @@ impl AsyncClient {
             return Err(ClientError::Request(publish));
         }
         self.request_tx.send_async(publish).await?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     /// Attempts to send a MQTT Publish to the `EventLoop`.
@@ -125,7 +125,7 @@ impl AsyncClient {
             return Err(ClientError::TryRequest(publish));
         }
         self.request_tx.try_send(publish)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     /// Sends a MQTT PubAck to the `EventLoop`. Only needed in if `manual_acks` flag is set.
@@ -170,7 +170,7 @@ impl AsyncClient {
 
         let publish = Request::Publish(publish);
         self.request_tx.send_async(publish).await?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     /// Sends a MQTT Subscribe to the `EventLoop`
@@ -186,7 +186,7 @@ impl AsyncClient {
 
         let request = Request::Subscribe(subscribe);
         self.request_tx.send_async(request).await?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     /// Attempts to send a MQTT Subscribe to the `EventLoop`
@@ -202,7 +202,7 @@ impl AsyncClient {
 
         let request = Request::Subscribe(subscribe);
         self.request_tx.try_send(request)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     /// Sends a MQTT Subscribe for multiple topics to the `EventLoop`
@@ -217,7 +217,7 @@ impl AsyncClient {
 
         let request = Request::Subscribe(subscribe);
         self.request_tx.send_async(request).await?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     /// Attempts to send a MQTT Subscribe for multiple topics to the `EventLoop`
@@ -232,7 +232,7 @@ impl AsyncClient {
 
         let request = Request::Subscribe(subscribe);
         self.request_tx.try_send(request)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     /// Sends a MQTT Unsubscribe to the `EventLoop`
@@ -244,7 +244,7 @@ impl AsyncClient {
 
         let request = Request::Unsubscribe(unsubscribe);
         self.request_tx.send_async(request).await?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     /// Attempts to send a MQTT Unsubscribe to the `EventLoop`
@@ -256,7 +256,7 @@ impl AsyncClient {
 
         let request = Request::Unsubscribe(unsubscribe);
         self.request_tx.try_send(request)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     /// Sends a MQTT disconnect to the `EventLoop`
@@ -352,7 +352,7 @@ impl Client {
             return Err(ClientError::Request(publish));
         }
         self.client.request_tx.send(publish)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub fn try_publish<S, V>(
@@ -398,7 +398,7 @@ impl Client {
 
         let request = Request::Subscribe(subscribe);
         self.client.request_tx.send(request)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     /// Sends a MQTT Subscribe to the `EventLoop`
@@ -422,7 +422,7 @@ impl Client {
 
         let request = Request::Subscribe(subscribe);
         self.client.request_tx.send(request)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub fn try_subscribe_many<T>(&self, topics: T) -> Result<PkidPromise, ClientError>
@@ -441,7 +441,7 @@ impl Client {
 
         let request = Request::Unsubscribe(unsubscribe);
         self.client.request_tx.send(request)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     /// Sends a MQTT Unsubscribe to the `EventLoop`

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -82,7 +82,12 @@ impl AsyncClient {
         publish.retain = retain;
 
         let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-        publish.place_pkid_tx(pkid_tx);
+        // Fulfill instantly for QoS 0
+        if qos == QoS::AtMostOnce {
+            _ = pkid_tx.send(0);
+        } else {
+            publish.place_pkid_tx(pkid_tx);
+        }
 
         let publish = Request::Publish(publish);
         if !valid_topic(&topic) {
@@ -109,7 +114,11 @@ impl AsyncClient {
         publish.retain = retain;
 
         let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-        publish.place_pkid_tx(pkid_tx);
+        if qos == QoS::AtMostOnce {
+            _ = pkid_tx.send(0);
+        } else {
+            publish.place_pkid_tx(pkid_tx);
+        }
 
         let publish = Request::Publish(publish);
         if !valid_topic(&topic) {
@@ -153,7 +162,11 @@ impl AsyncClient {
         publish.retain = retain;
 
         let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-        publish.place_pkid_tx(pkid_tx);
+        if qos == QoS::AtMostOnce {
+            _ = pkid_tx.send(0);
+        } else {
+            publish.place_pkid_tx(pkid_tx);
+        }
 
         let publish = Request::Publish(publish);
         self.request_tx.send_async(publish).await?;
@@ -328,7 +341,11 @@ impl Client {
         publish.retain = retain;
 
         let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-        publish.place_pkid_tx(pkid_tx);
+        if qos == QoS::AtMostOnce {
+            _ = pkid_tx.send(0);
+        } else {
+            publish.place_pkid_tx(pkid_tx);
+        }
 
         let publish = Request::Publish(publish);
         if !valid_topic(&topic) {

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -155,6 +155,9 @@ pub use proxy::{Proxy, ProxyAuth, ProxyType};
 
 pub type Incoming = Packet;
 
+pub type Pkid = u16;
+pub type PkidPromise = tokio::sync::oneshot::Receiver<Pkid>;
+
 /// Current outgoing activity on the eventloop
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Outgoing {

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -166,8 +166,14 @@ pub struct PkidPromise {
 
 #[derive(Debug, thiserror::Error)]
 pub enum PkidError {
-    #[error("Eventloop dropped Sender: {0}")]
-    Recv(#[from] oneshot::error::RecvError),
+    #[error("Eventloop dropped Sender")]
+    Recv,
+}
+
+impl From<oneshot::error::RecvError> for PkidError {
+    fn from(_: oneshot::error::RecvError) -> Self {
+        Self::Recv
+    }
 }
 
 impl PkidPromise {

--- a/rumqttc/src/mqttbytes/v4/publish.rs
+++ b/rumqttc/src/mqttbytes/v4/publish.rs
@@ -1,8 +1,10 @@
-use super::*;
 use bytes::{Buf, Bytes};
+use tokio::sync::oneshot::Sender;
+
+use super::*;
+use crate::Pkid;
 
 /// Publish packet
-#[derive(Clone, PartialEq, Eq)]
 pub struct Publish {
     pub dup: bool,
     pub qos: QoS,
@@ -10,7 +12,36 @@ pub struct Publish {
     pub topic: String,
     pub pkid: u16,
     pub payload: Bytes,
+    pub pkid_tx: Option<Sender<Pkid>>,
 }
+
+// TODO: figure out if this is even required
+impl Clone for Publish {
+    fn clone(&self) -> Self {
+        Self {
+            dup: self.dup,
+            qos: self.qos,
+            retain: self.retain,
+            topic: self.topic.clone(),
+            payload: self.payload.clone(),
+            pkid: self.pkid,
+            pkid_tx: None,
+        }
+    }
+}
+
+impl PartialEq for Publish {
+    fn eq(&self, other: &Self) -> bool {
+        self.dup == other.dup
+            && self.qos == other.qos
+            && self.retain == other.retain
+            && self.topic == other.topic
+            && self.payload == other.payload
+            && self.pkid == other.pkid
+    }
+}
+
+impl Eq for Publish {}
 
 impl Publish {
     pub fn new<S: Into<String>, P: Into<Vec<u8>>>(topic: S, qos: QoS, payload: P) -> Publish {
@@ -21,6 +52,7 @@ impl Publish {
             pkid: 0,
             topic: topic.into(),
             payload: Bytes::from(payload.into()),
+            pkid_tx: None,
         }
     }
 
@@ -32,6 +64,7 @@ impl Publish {
             pkid: 0,
             topic: topic.into(),
             payload,
+            pkid_tx: None,
         }
     }
 
@@ -77,6 +110,7 @@ impl Publish {
             pkid,
             topic,
             payload: bytes,
+            pkid_tx: None,
         };
 
         Ok(publish)
@@ -106,6 +140,10 @@ impl Publish {
 
         // TODO: Returned length is wrong in other packets. Fix it
         Ok(1 + count + len)
+    }
+
+    pub fn place_pkid_tx(&mut self, pkid_tx: Sender<Pkid>) {
+        self.pkid_tx = Some(pkid_tx)
     }
 }
 

--- a/rumqttc/src/mqttbytes/v4/publish.rs
+++ b/rumqttc/src/mqttbytes/v4/publish.rs
@@ -204,6 +204,7 @@ mod test {
                 topic: "a/b".to_owned(),
                 pkid: 10,
                 payload: Bytes::from(&payload[..]),
+                pkid_tx: None,
             }
         );
     }
@@ -240,6 +241,7 @@ mod test {
                 topic: "a/b".to_owned(),
                 pkid: 0,
                 payload: Bytes::from(&[0x01, 0x02][..]),
+                pkid_tx: None,
             }
         );
     }
@@ -253,6 +255,7 @@ mod test {
             topic: "a/b".to_owned(),
             pkid: 10,
             payload: Bytes::from(vec![0xF1, 0xF2, 0xF3, 0xF4]),
+            pkid_tx: None,
         };
 
         let mut buf = BytesMut::new();
@@ -287,6 +290,7 @@ mod test {
             topic: "a/b".to_owned(),
             pkid: 0,
             payload: Bytes::from(vec![0xE1, 0xE2, 0xE3, 0xE4]),
+            pkid_tx: None,
         };
 
         let mut buf = BytesMut::new();

--- a/rumqttc/src/mqttbytes/v4/publish.rs
+++ b/rumqttc/src/mqttbytes/v4/publish.rs
@@ -1,10 +1,8 @@
-use bytes::{Buf, Bytes};
-use tokio::sync::oneshot::Sender;
-
 use super::*;
-use crate::Pkid;
+use bytes::{Buf, Bytes};
 
 /// Publish packet
+#[derive(Clone, Eq, PartialEq)]
 pub struct Publish {
     pub dup: bool,
     pub qos: QoS,
@@ -12,36 +10,7 @@ pub struct Publish {
     pub topic: String,
     pub pkid: u16,
     pub payload: Bytes,
-    pub pkid_tx: Option<Sender<Pkid>>,
 }
-
-// TODO: figure out if this is even required
-impl Clone for Publish {
-    fn clone(&self) -> Self {
-        Self {
-            dup: self.dup,
-            qos: self.qos,
-            retain: self.retain,
-            topic: self.topic.clone(),
-            payload: self.payload.clone(),
-            pkid: self.pkid,
-            pkid_tx: None,
-        }
-    }
-}
-
-impl PartialEq for Publish {
-    fn eq(&self, other: &Self) -> bool {
-        self.dup == other.dup
-            && self.qos == other.qos
-            && self.retain == other.retain
-            && self.topic == other.topic
-            && self.payload == other.payload
-            && self.pkid == other.pkid
-    }
-}
-
-impl Eq for Publish {}
 
 impl Publish {
     pub fn new<S: Into<String>, P: Into<Vec<u8>>>(topic: S, qos: QoS, payload: P) -> Publish {
@@ -52,7 +21,6 @@ impl Publish {
             pkid: 0,
             topic: topic.into(),
             payload: Bytes::from(payload.into()),
-            pkid_tx: None,
         }
     }
 
@@ -64,7 +32,6 @@ impl Publish {
             pkid: 0,
             topic: topic.into(),
             payload,
-            pkid_tx: None,
         }
     }
 
@@ -110,7 +77,6 @@ impl Publish {
             pkid,
             topic,
             payload: bytes,
-            pkid_tx: None,
         };
 
         Ok(publish)
@@ -140,10 +106,6 @@ impl Publish {
 
         // TODO: Returned length is wrong in other packets. Fix it
         Ok(1 + count + len)
-    }
-
-    pub fn place_pkid_tx(&mut self, pkid_tx: Sender<Pkid>) {
-        self.pkid_tx = Some(pkid_tx)
     }
 }
 
@@ -204,7 +166,6 @@ mod test {
                 topic: "a/b".to_owned(),
                 pkid: 10,
                 payload: Bytes::from(&payload[..]),
-                pkid_tx: None,
             }
         );
     }
@@ -241,7 +202,6 @@ mod test {
                 topic: "a/b".to_owned(),
                 pkid: 0,
                 payload: Bytes::from(&[0x01, 0x02][..]),
-                pkid_tx: None,
             }
         );
     }
@@ -255,7 +215,6 @@ mod test {
             topic: "a/b".to_owned(),
             pkid: 10,
             payload: Bytes::from(vec![0xF1, 0xF2, 0xF3, 0xF4]),
-            pkid_tx: None,
         };
 
         let mut buf = BytesMut::new();
@@ -290,7 +249,6 @@ mod test {
             topic: "a/b".to_owned(),
             pkid: 0,
             payload: Bytes::from(vec![0xE1, 0xE2, 0xE3, 0xE4]),
-            pkid_tx: None,
         };
 
         let mut buf = BytesMut::new();

--- a/rumqttc/src/mqttbytes/v4/subscribe.rs
+++ b/rumqttc/src/mqttbytes/v4/subscribe.rs
@@ -1,12 +1,34 @@
-use super::*;
 use bytes::{Buf, Bytes};
+use tokio::sync::oneshot::Sender;
+
+use super::*;
+use crate::Pkid;
 
 /// Subscription packet
-#[derive(Clone, PartialEq, Eq)]
 pub struct Subscribe {
     pub pkid: u16,
     pub filters: Vec<SubscribeFilter>,
+    pub pkid_tx: Option<Sender<Pkid>>,
 }
+
+// TODO: figure out if this is even required
+impl Clone for Subscribe {
+    fn clone(&self) -> Self {
+        Self {
+            pkid: self.pkid,
+            filters: self.filters.clone(),
+            pkid_tx: None,
+        }
+    }
+}
+
+impl PartialEq for Subscribe {
+    fn eq(&self, other: &Self) -> bool {
+        self.pkid == other.pkid && self.filters == other.filters
+    }
+}
+
+impl Eq for Subscribe {}
 
 impl Subscribe {
     pub fn new<S: Into<String>>(path: S, qos: QoS) -> Subscribe {
@@ -18,6 +40,7 @@ impl Subscribe {
         Subscribe {
             pkid: 0,
             filters: vec![filter],
+            pkid_tx: None,
         }
     }
 
@@ -27,7 +50,11 @@ impl Subscribe {
     {
         let filters: Vec<SubscribeFilter> = topics.into_iter().collect();
 
-        Subscribe { pkid: 0, filters }
+        Subscribe {
+            pkid: 0,
+            filters,
+            pkid_tx: None,
+        }
     }
 
     pub fn add(&mut self, path: String, qos: QoS) -> &mut Self {
@@ -71,7 +98,11 @@ impl Subscribe {
 
         match filters.len() {
             0 => Err(Error::EmptySubscription),
-            _ => Ok(Subscribe { pkid, filters }),
+            _ => Ok(Subscribe {
+                pkid,
+                filters,
+                pkid_tx: None,
+            }),
         }
     }
 
@@ -92,6 +123,10 @@ impl Subscribe {
         }
 
         Ok(1 + remaining_len_bytes + remaining_len)
+    }
+
+    pub fn place_pkid_tx(&mut self, pkid_tx: Sender<Pkid>) {
+        self.pkid_tx = Some(pkid_tx)
     }
 }
 

--- a/rumqttc/src/mqttbytes/v4/subscribe.rs
+++ b/rumqttc/src/mqttbytes/v4/subscribe.rs
@@ -229,6 +229,7 @@ mod test {
                     SubscribeFilter::new("#".to_owned(), QoS::AtLeastOnce),
                     SubscribeFilter::new("a/b/c".to_owned(), QoS::ExactlyOnce)
                 ],
+                pkid_tx: None,
             }
         );
     }
@@ -242,6 +243,7 @@ mod test {
                 SubscribeFilter::new("#".to_owned(), QoS::AtLeastOnce),
                 SubscribeFilter::new("a/b/c".to_owned(), QoS::ExactlyOnce),
             ],
+            pkid_tx: None,
         };
 
         let mut buf = BytesMut::new();

--- a/rumqttc/src/mqttbytes/v4/unsubscribe.rs
+++ b/rumqttc/src/mqttbytes/v4/unsubscribe.rs
@@ -1,42 +1,18 @@
-use bytes::{Buf, Bytes};
-use tokio::sync::oneshot::Sender;
-
 use super::*;
-use crate::Pkid;
+use bytes::{Buf, Bytes};
 
 /// Unsubscribe packet
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Unsubscribe {
     pub pkid: u16,
     pub topics: Vec<String>,
-    pub pkid_tx: Option<Sender<Pkid>>,
 }
-
-// TODO: figure out if this is even required
-impl Clone for Unsubscribe {
-    fn clone(&self) -> Self {
-        Self {
-            pkid: self.pkid,
-            topics: self.topics.clone(),
-            pkid_tx: None,
-        }
-    }
-}
-
-impl PartialEq for Unsubscribe {
-    fn eq(&self, other: &Self) -> bool {
-        self.pkid == other.pkid && self.topics == other.topics
-    }
-}
-
-impl Eq for Unsubscribe {}
 
 impl Unsubscribe {
     pub fn new<S: Into<String>>(topic: S) -> Unsubscribe {
         Unsubscribe {
             pkid: 0,
             topics: vec![topic.into()],
-            pkid_tx: None,
         }
     }
 
@@ -66,11 +42,7 @@ impl Unsubscribe {
             topics.push(topic_filter);
         }
 
-        let unsubscribe = Unsubscribe {
-            pkid,
-            topics,
-            pkid_tx: None,
-        };
+        let unsubscribe = Unsubscribe { pkid, topics };
         Ok(unsubscribe)
     }
 
@@ -85,9 +57,5 @@ impl Unsubscribe {
             write_mqtt_string(payload, topic.as_str());
         }
         Ok(1 + remaining_len_bytes + remaining_len)
-    }
-
-    pub fn place_pkid_tx(&mut self, pkid_tx: Sender<Pkid>) {
-        self.pkid_tx = Some(pkid_tx)
     }
 }

--- a/rumqttc/src/mqttbytes/v4/unsubscribe.rs
+++ b/rumqttc/src/mqttbytes/v4/unsubscribe.rs
@@ -1,18 +1,42 @@
-use super::*;
 use bytes::{Buf, Bytes};
+use tokio::sync::oneshot::Sender;
+
+use super::*;
+use crate::Pkid;
 
 /// Unsubscribe packet
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct Unsubscribe {
     pub pkid: u16,
     pub topics: Vec<String>,
+    pub pkid_tx: Option<Sender<Pkid>>,
 }
+
+// TODO: figure out if this is even required
+impl Clone for Unsubscribe {
+    fn clone(&self) -> Self {
+        Self {
+            pkid: self.pkid,
+            topics: self.topics.clone(),
+            pkid_tx: None,
+        }
+    }
+}
+
+impl PartialEq for Unsubscribe {
+    fn eq(&self, other: &Self) -> bool {
+        self.pkid == other.pkid && self.topics == other.topics
+    }
+}
+
+impl Eq for Unsubscribe {}
 
 impl Unsubscribe {
     pub fn new<S: Into<String>>(topic: S) -> Unsubscribe {
         Unsubscribe {
             pkid: 0,
             topics: vec![topic.into()],
+            pkid_tx: None,
         }
     }
 
@@ -42,7 +66,11 @@ impl Unsubscribe {
             topics.push(topic_filter);
         }
 
-        let unsubscribe = Unsubscribe { pkid, topics };
+        let unsubscribe = Unsubscribe {
+            pkid,
+            topics,
+            pkid_tx: None,
+        };
         Ok(unsubscribe)
     }
 
@@ -57,5 +85,9 @@ impl Unsubscribe {
             write_mqtt_string(payload, topic.as_str());
         }
         Ok(1 + remaining_len_bytes + remaining_len)
+    }
+
+    pub fn place_pkid_tx(&mut self, pkid_tx: Sender<Pkid>) {
+        self.pkid_tx = Some(pkid_tx)
     }
 }

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -329,12 +329,19 @@ impl MqttState {
     /// Adds next packet identifier to QoS 1 and 2 publish packets and returns
     /// it buy wrapping publish in packet
     fn outgoing_publish(&mut self, mut publish: Publish) -> Result<(), StateError> {
+        // NOTE: pkid promise need not be fulfilled for QoS 0,
+        // user should know this but still handled in Client.
         if publish.qos != QoS::AtMostOnce {
             if publish.pkid == 0 {
                 publish.pkid = self.next_pkid();
             }
 
             let pkid = publish.pkid;
+            // Fulfill the pkid promise
+            if let Some(pkid_tx) = publish.pkid_tx.take() {
+                _ = pkid_tx.send(pkid);
+            }
+
             if self
                 .outgoing_pub
                 .get(publish.pkid as usize)
@@ -434,6 +441,10 @@ impl MqttState {
 
         let pkid = self.next_pkid();
         subscription.pkid = pkid;
+        // Fulfill the pkid promise
+        if let Some(pkid_tx) = subscription.pkid_tx.take() {
+            _ = pkid_tx.send(pkid);
+        }
 
         debug!(
             "Subscribe. Topics = {:?}, Pkid = {:?}",
@@ -449,6 +460,11 @@ impl MqttState {
     fn outgoing_unsubscribe(&mut self, mut unsub: Unsubscribe) -> Result<(), StateError> {
         let pkid = self.next_pkid();
         unsub.pkid = pkid;
+
+        // Fulfill the pkid promise
+        if let Some(pkid_tx) = unsub.pkid_tx.take() {
+            _ = pkid_tx.send(pkid);
+        }
 
         debug!(
             "Unsubscribe. Topics = {:?}, Pkid = {:?}",

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -887,6 +887,7 @@ mod test {
                     topic: "test".to_string(),
                     pkid: 1,
                     payload: "".into(),
+                    pkid_tx: None,
                 }),
                 Some(Publish {
                     dup: false,
@@ -895,6 +896,7 @@ mod test {
                     topic: "test".to_string(),
                     pkid: 2,
                     payload: "".into(),
+                    pkid_tx: None,
                 }),
                 Some(Publish {
                     dup: false,
@@ -903,6 +905,7 @@ mod test {
                     topic: "test".to_string(),
                     pkid: 3,
                     payload: "".into(),
+                    pkid_tx: None,
                 }),
                 None,
                 None,
@@ -913,6 +916,7 @@ mod test {
                     topic: "test".to_string(),
                     pkid: 6,
                     payload: "".into(),
+                    pkid_tx: None,
                 }),
             ]
         }

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -1,10 +1,11 @@
-use crate::{Event, Incoming, Outgoing, Request};
+use crate::{Event, Incoming, Outgoing, Pkid, Request};
 
 use crate::mqttbytes::v4::*;
 use crate::mqttbytes::{self, *};
 use bytes::BytesMut;
 use std::collections::VecDeque;
 use std::{io, time::Instant};
+use tokio::sync::oneshot;
 
 /// Errors during state handling
 #[derive(Debug, thiserror::Error)]
@@ -114,7 +115,7 @@ impl MqttState {
 
         for publish in second_half.iter_mut().chain(first_half) {
             if let Some(publish) = publish.take() {
-                let request = Request::Publish(publish);
+                let request = Request::Publish(None, publish);
                 pending.push(request);
             }
         }
@@ -149,10 +150,10 @@ impl MqttState {
         // Enforce max outgoing packet size
         self.check_size(request.size())?;
         match request {
-            Request::Publish(publish) => self.outgoing_publish(publish)?,
+            Request::Publish(tx, publish) => self.outgoing_publish(publish, tx)?,
             Request::PubRel(pubrel) => self.outgoing_pubrel(pubrel)?,
-            Request::Subscribe(subscribe) => self.outgoing_subscribe(subscribe)?,
-            Request::Unsubscribe(unsubscribe) => self.outgoing_unsubscribe(unsubscribe)?,
+            Request::Subscribe(tx, subscribe) => self.outgoing_subscribe(subscribe, tx)?,
+            Request::Unsubscribe(tx, unsubscribe) => self.outgoing_unsubscribe(unsubscribe, tx)?,
             Request::PingReq(_) => self.outgoing_ping()?,
             Request::Disconnect(_) => self.outgoing_disconnect()?,
             Request::PubAck(puback) => self.outgoing_puback(puback)?,
@@ -328,7 +329,11 @@ impl MqttState {
 
     /// Adds next packet identifier to QoS 1 and 2 publish packets and returns
     /// it buy wrapping publish in packet
-    fn outgoing_publish(&mut self, mut publish: Publish) -> Result<(), StateError> {
+    fn outgoing_publish(
+        &mut self,
+        mut publish: Publish,
+        pkid_tx: Option<oneshot::Sender<Pkid>>,
+    ) -> Result<(), StateError> {
         // NOTE: pkid promise need not be fulfilled for QoS 0,
         // user should know this but still handled in Client.
         if publish.qos != QoS::AtMostOnce {
@@ -338,7 +343,7 @@ impl MqttState {
 
             let pkid = publish.pkid;
             // Fulfill the pkid promise
-            if let Some(pkid_tx) = publish.pkid_tx.take() {
+            if let Some(pkid_tx) = pkid_tx {
                 _ = pkid_tx.send(pkid);
             }
 
@@ -434,7 +439,11 @@ impl MqttState {
         Ok(())
     }
 
-    fn outgoing_subscribe(&mut self, mut subscription: Subscribe) -> Result<(), StateError> {
+    fn outgoing_subscribe(
+        &mut self,
+        mut subscription: Subscribe,
+        pkid_tx: Option<oneshot::Sender<Pkid>>,
+    ) -> Result<(), StateError> {
         if subscription.filters.is_empty() {
             return Err(StateError::EmptySubscription);
         }
@@ -442,7 +451,7 @@ impl MqttState {
         let pkid = self.next_pkid();
         subscription.pkid = pkid;
         // Fulfill the pkid promise
-        if let Some(pkid_tx) = subscription.pkid_tx.take() {
+        if let Some(pkid_tx) = pkid_tx {
             _ = pkid_tx.send(pkid);
         }
 
@@ -457,12 +466,16 @@ impl MqttState {
         Ok(())
     }
 
-    fn outgoing_unsubscribe(&mut self, mut unsub: Unsubscribe) -> Result<(), StateError> {
+    fn outgoing_unsubscribe(
+        &mut self,
+        mut unsub: Unsubscribe,
+        pkid_tx: Option<oneshot::Sender<Pkid>>,
+    ) -> Result<(), StateError> {
         let pkid = self.next_pkid();
         unsub.pkid = pkid;
 
         // Fulfill the pkid promise
-        if let Some(pkid_tx) = unsub.pkid_tx.take() {
+        if let Some(pkid_tx) = pkid_tx {
             _ = pkid_tx.send(pkid);
         }
 
@@ -596,14 +609,14 @@ mod test {
 
         let small_publish = Publish::new("hello/world", QoS::AtLeastOnce, vec![1; 100]);
         assert_eq!(
-            mqtt.handle_outgoing_packet(Request::Publish(small_publish))
+            mqtt.handle_outgoing_packet(Request::Publish(None, small_publish))
                 .is_ok(),
             true
         );
 
         let large_publish = Publish::new("hello/world", QoS::AtLeastOnce, vec![1; 265]);
         assert_eq!(
-            mqtt.handle_outgoing_packet(Request::Publish(large_publish))
+            mqtt.handle_outgoing_packet(Request::Publish(None, large_publish))
                 .is_ok(),
             false
         );
@@ -617,7 +630,7 @@ mod test {
         let publish = build_outgoing_publish(QoS::AtMostOnce);
 
         // QoS 0 publish shouldn't be saved in queue
-        mqtt.outgoing_publish(publish).unwrap();
+        mqtt.outgoing_publish(publish, None).unwrap();
         assert_eq!(mqtt.last_pkid, 0);
         assert_eq!(mqtt.inflight, 0);
 
@@ -625,12 +638,12 @@ mod test {
         let publish = build_outgoing_publish(QoS::AtLeastOnce);
 
         // Packet id should be set and publish should be saved in queue
-        mqtt.outgoing_publish(publish.clone()).unwrap();
+        mqtt.outgoing_publish(publish.clone(), None).unwrap();
         assert_eq!(mqtt.last_pkid, 1);
         assert_eq!(mqtt.inflight, 1);
 
         // Packet id should be incremented and publish should be saved in queue
-        mqtt.outgoing_publish(publish).unwrap();
+        mqtt.outgoing_publish(publish, None).unwrap();
         assert_eq!(mqtt.last_pkid, 2);
         assert_eq!(mqtt.inflight, 2);
 
@@ -638,12 +651,12 @@ mod test {
         let publish = build_outgoing_publish(QoS::ExactlyOnce);
 
         // Packet id should be set and publish should be saved in queue
-        mqtt.outgoing_publish(publish.clone()).unwrap();
+        mqtt.outgoing_publish(publish.clone(), None).unwrap();
         assert_eq!(mqtt.last_pkid, 3);
         assert_eq!(mqtt.inflight, 3);
 
         // Packet id should be incremented and publish should be saved in queue
-        mqtt.outgoing_publish(publish).unwrap();
+        mqtt.outgoing_publish(publish, None).unwrap();
         assert_eq!(mqtt.last_pkid, 4);
         assert_eq!(mqtt.inflight, 4);
     }
@@ -733,8 +746,8 @@ mod test {
         let publish1 = build_outgoing_publish(QoS::AtLeastOnce);
         let publish2 = build_outgoing_publish(QoS::ExactlyOnce);
 
-        mqtt.outgoing_publish(publish1).unwrap();
-        mqtt.outgoing_publish(publish2).unwrap();
+        mqtt.outgoing_publish(publish1, None).unwrap();
+        mqtt.outgoing_publish(publish2, None).unwrap();
         assert_eq!(mqtt.inflight, 2);
 
         mqtt.handle_incoming_puback(&PubAck::new(1)).unwrap();
@@ -766,8 +779,8 @@ mod test {
         let publish1 = build_outgoing_publish(QoS::AtLeastOnce);
         let publish2 = build_outgoing_publish(QoS::ExactlyOnce);
 
-        let _publish_out = mqtt.outgoing_publish(publish1);
-        let _publish_out = mqtt.outgoing_publish(publish2);
+        let _publish_out = mqtt.outgoing_publish(publish1, None);
+        let _publish_out = mqtt.outgoing_publish(publish2, None);
 
         mqtt.handle_incoming_pubrec(&PubRec::new(2)).unwrap();
         assert_eq!(mqtt.inflight, 2);
@@ -785,7 +798,7 @@ mod test {
         let mut mqtt = build_mqttstate();
 
         let publish = build_outgoing_publish(QoS::ExactlyOnce);
-        mqtt.outgoing_publish(publish).unwrap();
+        mqtt.outgoing_publish(publish, None).unwrap();
         let packet = read(&mut mqtt.write, 10 * 1024).unwrap();
         match packet {
             Packet::Publish(publish) => assert_eq!(publish.pkid, 1),
@@ -825,7 +838,7 @@ mod test {
         let mut mqtt = build_mqttstate();
         let publish = build_outgoing_publish(QoS::ExactlyOnce);
 
-        mqtt.outgoing_publish(publish).unwrap();
+        mqtt.outgoing_publish(publish, None).unwrap();
         mqtt.handle_incoming_pubrec(&PubRec::new(1)).unwrap();
 
         mqtt.handle_incoming_pubcomp(&PubComp::new(1)).unwrap();
@@ -839,7 +852,7 @@ mod test {
 
         // network activity other than pingresp
         let publish = build_outgoing_publish(QoS::AtLeastOnce);
-        mqtt.handle_outgoing_packet(Request::Publish(publish))
+        mqtt.handle_outgoing_packet(Request::Publish(None, publish))
             .unwrap();
         mqtt.handle_incoming_packet(Incoming::PubAck(PubAck::new(1)))
             .unwrap();
@@ -887,7 +900,6 @@ mod test {
                     topic: "test".to_string(),
                     pkid: 1,
                     payload: "".into(),
-                    pkid_tx: None,
                 }),
                 Some(Publish {
                     dup: false,
@@ -896,7 +908,6 @@ mod test {
                     topic: "test".to_string(),
                     pkid: 2,
                     payload: "".into(),
-                    pkid_tx: None,
                 }),
                 Some(Publish {
                     dup: false,
@@ -905,7 +916,6 @@ mod test {
                     topic: "test".to_string(),
                     pkid: 3,
                     payload: "".into(),
-                    pkid_tx: None,
                 }),
                 None,
                 None,
@@ -916,7 +926,6 @@ mod test {
                     topic: "test".to_string(),
                     pkid: 6,
                     payload: "".into(),
-                    pkid_tx: None,
                 }),
             ]
         }
@@ -926,7 +935,7 @@ mod test {
         let requests = mqtt.clean();
         let res = vec![6, 1, 2, 3];
         for (req, idx) in requests.iter().zip(res) {
-            if let Request::Publish(publish) = req {
+            if let Request::Publish(_, publish) = req {
                 assert_eq!(publish.pkid, idx);
             } else {
                 unreachable!()
@@ -938,7 +947,7 @@ mod test {
         let requests = mqtt.clean();
         let res = vec![1, 2, 3, 6];
         for (req, idx) in requests.iter().zip(res) {
-            if let Request::Publish(publish) = req {
+            if let Request::Publish(_, publish) = req {
                 assert_eq!(publish.pkid, idx);
             } else {
                 unreachable!()
@@ -950,7 +959,7 @@ mod test {
         let requests = mqtt.clean();
         let res = vec![1, 2, 3, 6];
         for (req, idx) in requests.iter().zip(res) {
-            if let Request::Publish(publish) = req {
+            if let Request::Publish(_, publish) = req {
                 assert_eq!(publish.pkid, idx);
             } else {
                 unreachable!()

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -581,25 +581,6 @@ mod test {
     }
 
     #[test]
-    fn outgoing_max_packet_size_check() {
-        let mut mqtt = MqttState::new(100, false);
-
-        let small_publish = Publish::new("hello/world", QoS::AtLeastOnce, vec![1; 100]);
-        assert_eq!(
-            mqtt.handle_outgoing_packet(Request::Publish(None, small_publish))
-                .is_ok(),
-            true
-        );
-
-        let large_publish = Publish::new("hello/world", QoS::AtLeastOnce, vec![1; 265]);
-        assert_eq!(
-            mqtt.handle_outgoing_packet(Request::Publish(None, large_publish))
-                .is_ok(),
-            false
-        );
-    }
-
-    #[test]
     fn outgoing_publish_should_set_pkid_and_add_publish_to_queue() {
         let mut mqtt = build_mqttstate();
 

--- a/rumqttc/src/v5/client.rs
+++ b/rumqttc/src/v5/client.rs
@@ -100,7 +100,7 @@ impl AsyncClient {
             return Err(ClientError::Request(publish));
         }
         self.request_tx.send_async(publish).await?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub async fn publish_with_properties<S, P>(
@@ -163,7 +163,7 @@ impl AsyncClient {
             return Err(ClientError::TryRequest(publish));
         }
         self.request_tx.try_send(publish)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub fn try_publish_with_properties<S, P>(
@@ -243,7 +243,7 @@ impl AsyncClient {
             return Err(ClientError::TryRequest(publish));
         }
         self.request_tx.send_async(publish).await?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub async fn publish_bytes_with_properties<S>(
@@ -291,7 +291,7 @@ impl AsyncClient {
 
         let request: Request = Request::Subscribe(subscribe);
         self.request_tx.send_async(request).await?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub async fn subscribe_with_properties<S: Into<String>>(
@@ -326,7 +326,7 @@ impl AsyncClient {
 
         let request = Request::Subscribe(subscribe);
         self.request_tx.try_send(request)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub fn try_subscribe_with_properties<S: Into<String>>(
@@ -362,7 +362,7 @@ impl AsyncClient {
 
         let request = Request::Subscribe(subscribe);
         self.request_tx.send_async(request).await?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub async fn subscribe_many_with_properties<T>(
@@ -399,7 +399,7 @@ impl AsyncClient {
 
         let request = Request::Subscribe(subscribe);
         self.request_tx.try_send(request)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub fn try_subscribe_many_with_properties<T>(
@@ -433,7 +433,7 @@ impl AsyncClient {
 
         let request = Request::Unsubscribe(unsubscribe);
         self.request_tx.send_async(request).await?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub async fn unsubscribe_with_properties<S: Into<String>>(
@@ -461,7 +461,7 @@ impl AsyncClient {
 
         let request = Request::Unsubscribe(unsubscribe);
         self.request_tx.try_send(request)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub fn try_unsubscribe_with_properties<S: Into<String>>(
@@ -572,7 +572,7 @@ impl Client {
             return Err(ClientError::Request(publish));
         }
         self.client.request_tx.send(publish)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub fn publish_with_properties<S, P>(
@@ -665,7 +665,7 @@ impl Client {
 
         let request = Request::Subscribe(subscribe);
         self.client.request_tx.send(request)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub fn subscribe_with_properties<S: Into<String>>(
@@ -720,7 +720,7 @@ impl Client {
 
         let request = Request::Subscribe(subscribe);
         self.client.request_tx.send(request)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub fn subscribe_many_with_properties<T>(
@@ -773,7 +773,7 @@ impl Client {
 
         let request = Request::Unsubscribe(unsubscribe);
         self.client.request_tx.send(request)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub fn unsubscribe_with_properties<S: Into<String>>(

--- a/rumqttc/src/v5/mod.rs
+++ b/rumqttc/src/v5/mod.rs
@@ -7,6 +7,7 @@ use std::{
     pin::Pin,
     sync::Arc,
 };
+use tokio::sync::oneshot;
 
 mod client;
 mod eventloop;
@@ -14,8 +15,8 @@ mod framed;
 pub mod mqttbytes;
 mod state;
 
-use crate::Outgoing;
 use crate::{NetworkOptions, Transport};
+use crate::{Outgoing, Pkid};
 
 use mqttbytes::v5::*;
 
@@ -33,21 +34,62 @@ pub type Incoming = Packet;
 
 /// Requests by the client to mqtt event loop. Request are
 /// handled one by one.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum Request {
-    Publish(Publish),
+    Publish(Option<oneshot::Sender<Pkid>>, Publish),
     PubAck(PubAck),
     PubRec(PubRec),
     PubComp(PubComp),
     PubRel(PubRel),
     PingReq,
     PingResp,
-    Subscribe(Subscribe),
+    Subscribe(Option<oneshot::Sender<Pkid>>, Subscribe),
     SubAck(SubAck),
-    Unsubscribe(Unsubscribe),
+    Unsubscribe(Option<oneshot::Sender<Pkid>>, Unsubscribe),
     UnsubAck(UnsubAck),
     Disconnect,
 }
+
+impl Clone for Request {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Publish(_, p) => Self::Publish(None, p.clone()),
+            Self::PubAck(p) => Self::PubAck(p.clone()),
+            Self::PubRec(p) => Self::PubRec(p.clone()),
+            Self::PubRel(p) => Self::PubRel(p.clone()),
+            Self::PubComp(p) => Self::PubComp(p.clone()),
+            Self::Subscribe(_, p) => Self::Subscribe(None, p.clone()),
+            Self::SubAck(p) => Self::SubAck(p.clone()),
+            Self::PingReq => Self::PingReq,
+            Self::PingResp => Self::PingResp,
+            Self::Disconnect => Self::Disconnect,
+            Self::Unsubscribe(_, p) => Self::Unsubscribe(None, p.clone()),
+            Self::UnsubAck(p) => Self::UnsubAck(p.clone()),
+        }
+    }
+}
+
+impl PartialEq for Request {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Publish(_, p1), Self::Publish(_, p2)) => p1 == p2,
+            (Self::PubAck(p1), Self::PubAck(p2)) => p1 == p2,
+            (Self::PubRec(p1), Self::PubRec(p2)) => p1 == p2,
+            (Self::PubRel(p1), Self::PubRel(p2)) => p1 == p2,
+            (Self::PubComp(p1), Self::PubComp(p2)) => p1 == p2,
+            (Self::Subscribe(_, p1), Self::Subscribe(_, p2)) => p1 == p2,
+            (Self::SubAck(p1), Self::SubAck(p2)) => p1 == p2,
+            (Self::PingReq, Self::PingReq)
+            | (Self::PingResp, Self::PingResp)
+            | (Self::Disconnect, Self::Disconnect) => true,
+            (Self::Unsubscribe(_, p1), Self::Unsubscribe(_, p2)) => p1 == p2,
+            (Self::UnsubAck(p1), Self::UnsubAck(p2)) => p1 == p2,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for Request {}
 
 #[cfg(feature = "websocket")]
 type RequestModifierFn = Arc<

--- a/rumqttc/src/v5/mqttbytes/v5/publish.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/publish.rs
@@ -1,11 +1,8 @@
-use bytes::{Buf, Bytes};
-use tokio::sync::oneshot::Sender;
-
 use super::*;
-use crate::Pkid;
+use bytes::{Buf, Bytes};
 
 /// Publish packet
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Publish {
     pub dup: bool,
     pub qos: QoS,
@@ -14,38 +11,7 @@ pub struct Publish {
     pub pkid: u16,
     pub payload: Bytes,
     pub properties: Option<PublishProperties>,
-    pub pkid_tx: Option<Sender<Pkid>>,
 }
-
-// TODO: figure out if this is even required
-impl Clone for Publish {
-    fn clone(&self) -> Self {
-        Self {
-            dup: self.dup,
-            qos: self.qos,
-            retain: self.retain,
-            topic: self.topic.clone(),
-            payload: self.payload.clone(),
-            pkid: self.pkid,
-            properties: self.properties.clone(),
-            pkid_tx: None,
-        }
-    }
-}
-
-impl PartialEq for Publish {
-    fn eq(&self, other: &Self) -> bool {
-        self.dup == other.dup
-            && self.qos == other.qos
-            && self.retain == other.retain
-            && self.topic == other.topic
-            && self.payload == other.payload
-            && self.pkid == other.pkid
-            && self.properties == other.properties
-    }
-}
-
-impl Eq for Publish {}
 
 impl Publish {
     pub fn new<T: Into<String>, P: Into<Bytes>>(
@@ -119,7 +85,6 @@ impl Publish {
             topic,
             payload: bytes,
             properties,
-            pkid_tx: None,
         };
 
         Ok(publish)
@@ -154,10 +119,6 @@ impl Publish {
         buffer.extend_from_slice(&self.payload);
 
         Ok(1 + count + len)
-    }
-
-    pub fn place_pkid_tx(&mut self, pkid_tx: Sender<Pkid>) {
-        self.pkid_tx = Some(pkid_tx)
     }
 }
 

--- a/rumqttc/src/v5/mqttbytes/v5/subscribe.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/subscribe.rs
@@ -1,39 +1,13 @@
-use bytes::{Buf, Bytes};
-use tokio::sync::oneshot::Sender;
-
 use super::*;
-use crate::Pkid;
+use bytes::{Buf, Bytes};
 
 /// Subscription packet
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Subscribe {
     pub pkid: u16,
     pub filters: Vec<Filter>,
     pub properties: Option<SubscribeProperties>,
-    pub pkid_tx: Option<Sender<Pkid>>,
 }
-
-// TODO: figure out if this is even required
-impl Clone for Subscribe {
-    fn clone(&self) -> Self {
-        Self {
-            pkid: self.pkid,
-            filters: self.filters.clone(),
-            properties: self.properties.clone(),
-            pkid_tx: None,
-        }
-    }
-}
-
-impl PartialEq for Subscribe {
-    fn eq(&self, other: &Self) -> bool {
-        self.pkid == other.pkid
-            && self.filters == other.filters
-            && self.properties == other.properties
-    }
-}
-
-impl Eq for Subscribe {}
 
 impl Subscribe {
     pub fn new(filter: Filter, properties: Option<SubscribeProperties>) -> Self {
@@ -93,7 +67,6 @@ impl Subscribe {
                 pkid,
                 filters,
                 properties,
-                pkid_tx: None,
             }),
         }
     }
@@ -121,10 +94,6 @@ impl Subscribe {
         }
 
         Ok(1 + remaining_len_bytes + remaining_len)
-    }
-
-    pub fn place_pkid_tx(&mut self, pkid_tx: Sender<Pkid>) {
-        self.pkid_tx = Some(pkid_tx)
     }
 }
 

--- a/rumqttc/src/v5/mqttbytes/v5/subscribe.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/subscribe.rs
@@ -1,13 +1,39 @@
-use super::*;
 use bytes::{Buf, Bytes};
+use tokio::sync::oneshot::Sender;
+
+use super::*;
+use crate::Pkid;
 
 /// Subscription packet
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[derive(Debug, Default)]
 pub struct Subscribe {
     pub pkid: u16,
     pub filters: Vec<Filter>,
     pub properties: Option<SubscribeProperties>,
+    pub pkid_tx: Option<Sender<Pkid>>,
 }
+
+// TODO: figure out if this is even required
+impl Clone for Subscribe {
+    fn clone(&self) -> Self {
+        Self {
+            pkid: self.pkid,
+            filters: self.filters.clone(),
+            properties: self.properties.clone(),
+            pkid_tx: None,
+        }
+    }
+}
+
+impl PartialEq for Subscribe {
+    fn eq(&self, other: &Self) -> bool {
+        self.pkid == other.pkid
+            && self.filters == other.filters
+            && self.properties == other.properties
+    }
+}
+
+impl Eq for Subscribe {}
 
 impl Subscribe {
     pub fn new(filter: Filter, properties: Option<SubscribeProperties>) -> Self {
@@ -67,6 +93,7 @@ impl Subscribe {
                 pkid,
                 filters,
                 properties,
+                pkid_tx: None,
             }),
         }
     }
@@ -94,6 +121,10 @@ impl Subscribe {
         }
 
         Ok(1 + remaining_len_bytes + remaining_len)
+    }
+
+    pub fn place_pkid_tx(&mut self, pkid_tx: Sender<Pkid>) {
+        self.pkid_tx = Some(pkid_tx)
     }
 }
 

--- a/rumqttc/src/v5/mqttbytes/v5/unsubscribe.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/unsubscribe.rs
@@ -1,13 +1,37 @@
-use super::*;
 use bytes::{Buf, Bytes};
+use tokio::sync::oneshot::Sender;
+
+use super::*;
+use crate::Pkid;
 
 /// Unsubscribe packet
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Default)]
 pub struct Unsubscribe {
     pub pkid: u16,
     pub filters: Vec<String>,
     pub properties: Option<UnsubscribeProperties>,
+    pub pkid_tx: Option<Sender<Pkid>>,
 }
+
+// TODO: figure out if this is even required
+impl Clone for Unsubscribe {
+    fn clone(&self) -> Self {
+        Self {
+            pkid: self.pkid,
+            filters: self.filters.clone(),
+            properties: self.properties.clone(),
+            pkid_tx: None,
+        }
+    }
+}
+
+impl PartialEq for Unsubscribe {
+    fn eq(&self, other: &Self) -> bool {
+        self.pkid == other.pkid && self.filters == other.filters
+    }
+}
+
+impl Eq for Unsubscribe {}
 
 impl Unsubscribe {
     pub fn new<S: Into<String>>(filter: S, properties: Option<UnsubscribeProperties>) -> Self {
@@ -59,6 +83,7 @@ impl Unsubscribe {
             pkid,
             filters,
             properties,
+            pkid_tx: None,
         };
         Ok(unsubscribe)
     }
@@ -85,6 +110,10 @@ impl Unsubscribe {
         }
 
         Ok(1 + remaining_len_bytes + remaining_len)
+    }
+
+    pub fn place_pkid_tx(&mut self, pkid_tx: Sender<Pkid>) {
+        self.pkid_tx = Some(pkid_tx)
     }
 }
 

--- a/rumqttc/src/v5/mqttbytes/v5/unsubscribe.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/unsubscribe.rs
@@ -1,37 +1,14 @@
 use bytes::{Buf, Bytes};
-use tokio::sync::oneshot::Sender;
 
 use super::*;
-use crate::Pkid;
 
 /// Unsubscribe packet
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Unsubscribe {
     pub pkid: u16,
     pub filters: Vec<String>,
     pub properties: Option<UnsubscribeProperties>,
-    pub pkid_tx: Option<Sender<Pkid>>,
 }
-
-// TODO: figure out if this is even required
-impl Clone for Unsubscribe {
-    fn clone(&self) -> Self {
-        Self {
-            pkid: self.pkid,
-            filters: self.filters.clone(),
-            properties: self.properties.clone(),
-            pkid_tx: None,
-        }
-    }
-}
-
-impl PartialEq for Unsubscribe {
-    fn eq(&self, other: &Self) -> bool {
-        self.pkid == other.pkid && self.filters == other.filters
-    }
-}
-
-impl Eq for Unsubscribe {}
 
 impl Unsubscribe {
     pub fn new<S: Into<String>>(filter: S, properties: Option<UnsubscribeProperties>) -> Self {
@@ -83,7 +60,6 @@ impl Unsubscribe {
             pkid,
             filters,
             properties,
-            pkid_tx: None,
         };
         Ok(unsubscribe)
     }
@@ -110,10 +86,6 @@ impl Unsubscribe {
         }
 
         Ok(1 + remaining_len_bytes + remaining_len)
-    }
-
-    pub fn place_pkid_tx(&mut self, pkid_tx: Sender<Pkid>) {
-        self.pkid_tx = Some(pkid_tx)
     }
 }
 

--- a/rumqttc/src/v5/state.rs
+++ b/rumqttc/src/v5/state.rs
@@ -485,12 +485,19 @@ impl MqttState {
     /// Adds next packet identifier to QoS 1 and 2 publish packets and returns
     /// it buy wrapping publish in packet
     fn outgoing_publish(&mut self, mut publish: Publish) -> Result<(), StateError> {
+        // NOTE: pkid promise need not be fulfilled for QoS 0,
+        // user should know this but still handled in Client.
         if publish.qos != QoS::AtMostOnce {
             if publish.pkid == 0 {
                 publish.pkid = self.next_pkid();
             }
 
             let pkid = publish.pkid;
+            // Fulfill the pkid promise
+            if let Some(pkid_tx) = publish.pkid_tx.take() {
+                _ = pkid_tx.send(pkid);
+            }
+
             if self
                 .outgoing_pub
                 .get(publish.pkid as usize)
@@ -604,6 +611,10 @@ impl MqttState {
 
         let pkid = self.next_pkid();
         subscription.pkid = pkid;
+        // Fulfill the pkid promise
+        if let Some(pkid_tx) = subscription.pkid_tx.take() {
+            _ = pkid_tx.send(pkid);
+        }
 
         debug!(
             "Subscribe. Topics = {:?}, Pkid = {:?}",
@@ -620,6 +631,10 @@ impl MqttState {
     fn outgoing_unsubscribe(&mut self, mut unsub: Unsubscribe) -> Result<(), StateError> {
         let pkid = self.next_pkid();
         unsub.pkid = pkid;
+        // Fulfill the pkid promise
+        if let Some(pkid_tx) = unsub.pkid_tx.take() {
+            _ = pkid_tx.send(pkid);
+        }
 
         debug!(
             "Unsubscribe. Topics = {:?}, Pkid = {:?}",


### PR DESCRIPTION
<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

Fixes #349, implements #805 

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality) 
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

Allows user access to pkid information once it is assigned by rumqttc internals during run.

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.

### Tests performed
Ran this against provided example async code, output looks as follows
```
Event = Incoming(ConnAck(ConnAck { session_present: false, code: Success }))
Event = Outgoing(Subscribe(1))
Pkid: 1
Event = Outgoing(Publish(2))
Pkid: 2
Event = Incoming(SubAck(SubAck { pkid: 1, return_codes: [Success(AtMostOnce)] }))
Event = Outgoing(PubRel(2))
Event = Incoming(PubRec(PubRec { pkid: 2 }))
Event = Incoming(Publish(Topic = hello/world, Qos = AtMostOnce, Retain = false, Pkid = 0, Payload Size = 1))
Event = Incoming(PubComp(PubComp { pkid: 2 }))
Event = Outgoing(Publish(3))
Pkid: 3
Event = Outgoing(PubRel(3))
Event = Incoming(PubRec(PubRec { pkid: 3 }))
Event = Incoming(Publish(Topic = hello/world, Qos = AtMostOnce, Retain = false, Pkid = 0, Payload Size = 2))
Event = Incoming(PubComp(PubComp { pkid: 3 }))
Event = Outgoing(Publish(4))
Pkid: 4
Event = Outgoing(PubRel(4))
Event = Incoming(PubRec(PubRec { pkid: 4 }))
Event = Incoming(Publish(Topic = hello/world, Qos = AtMostOnce, Retain = false, Pkid = 0, Payload Size = 3))
Event = Incoming(PubComp(PubComp { pkid: 4 }))
Event = Outgoing(Publish(5))
Pkid: 5
Event = Outgoing(PubRel(5))
Event = Incoming(PubRec(PubRec { pkid: 5 }))
Event = Incoming(Publish(Topic = hello/world, Qos = AtMostOnce, Retain = false, Pkid = 0, Payload Size = 4))
Event = Incoming(PubComp(PubComp { pkid: 5 }))
Event = Outgoing(Publish(6))
Pkid: 6
Event = Outgoing(PubRel(6))
Event = Incoming(PubRec(PubRec { pkid: 6 }))
Event = Incoming(Publish(Topic = hello/world, Qos = AtMostOnce, Retain = false, Pkid = 0, Payload Size = 5))
Event = Incoming(PubComp(PubComp { pkid: 6 }))
Event = Outgoing(PingReq)
Event = Outgoing(Publish(7))
Pkid: 7
Event = Incoming(PingResp)
Event = Outgoing(PubRel(7))
Event = Incoming(PubRec(PubRec { pkid: 7 }))
Event = Incoming(Publish(Topic = hello/world, Qos = AtMostOnce, Retain = false, Pkid = 0, Payload Size = 6))
Event = Incoming(PubComp(PubComp { pkid: 7 }))
Event = Outgoing(Publish(8))
Pkid: 8
Event = Outgoing(PubRel(8))
Event = Incoming(PubRec(PubRec { pkid: 8 }))
Event = Incoming(Publish(Topic = hello/world, Qos = AtMostOnce, Retain = false, Pkid = 0, Payload Size = 7))
Event = Incoming(PubComp(PubComp { pkid: 8 }))
Event = Outgoing(Publish(9))
Pkid: 9
Event = Outgoing(PubRel(9))
Event = Incoming(PubRec(PubRec { pkid: 9 }))
Event = Incoming(Publish(Topic = hello/world, Qos = AtMostOnce, Retain = false, Pkid = 0, Payload Size = 8))
Event = Incoming(PubComp(PubComp { pkid: 9 }))
Event = Outgoing(Publish(10))
Pkid: 10
Event = Outgoing(PubRel(10))
Event = Incoming(PubRec(PubRec { pkid: 10 }))
Event = Incoming(Publish(Topic = hello/world, Qos = AtMostOnce, Retain = false, Pkid = 0, Payload Size = 9))
Event = Incoming(PubComp(PubComp { pkid: 10 }))
Event = Outgoing(Publish(11))
Pkid: 11
Event = Outgoing(PubRel(11))
Event = Incoming(PubRec(PubRec { pkid: 11 }))
Event = Incoming(Publish(Topic = hello/world, Qos = AtMostOnce, Retain = false, Pkid = 0, Payload Size = 10))
Event = Incoming(PubComp(PubComp { pkid: 11 }))
Event = Outgoing(PingReq)
Event = Incoming(PingResp)
```
Thus the implementation is complete.