### PR TITLE
fix(rumqtt): validate topic and topic filter

### DIFF
--- a/rumqttc/src/v5/client.rs
+++ b/rumqttc/src/v5/client.rs
@@ -6,7 +6,7 @@ use super::mqttbytes::v5::{
     Filter, PubAck, PubRec, Publish, PublishProperties, Subscribe, SubscribeProperties,
     Unsubscribe, UnsubscribeProperties,
 };
-use super::mqttbytes::QoS;
+use super::mqttbytes::{validate_topic_name_and_alias, QoS};
 use super::{ConnectionError, Event, EventLoop, MqttOptions, Request};
 use crate::valid_topic;
 
@@ -84,10 +84,11 @@ impl AsyncClient {
         P: Into<Bytes>,
     {
         let topic = topic.into();
+        let is_ok = validate_topic_name_and_alias(&topic, &properties);
         let mut publish = Publish::new(&topic, qos, payload, properties);
         publish.retain = retain;
         let publish = Request::Publish(publish);
-        if !valid_topic(&topic) {
+        if !is_ok {
             return Err(ClientError::Request(publish));
         }
         self.request_tx.send_async(publish).await?;


### PR DESCRIPTION
- fix(mqttbytes): add function to validate topic name and filter according to MQTTv3 spec
- fix(v5/client): validate topic name and alias

<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

- Bug fix (non-breaking change which fixes an issue)
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [x] Formatted with `cargo fmt`
- [ ] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.


> [!IMPORTANT]
> This is a proof of concept. We validate topic name/filter everytime client publishes/subscribes, respectively.
