### PR TITLE
Make sure `write` returns the number of bytes it writes everywhere

### DIFF
--- a/benchmarks/simplerouter/src/protocol/v4.rs
+++ b/benchmarks/simplerouter/src/protocol/v4.rs
@@ -102,7 +102,7 @@ pub(crate) mod connect {
 
             // update connect flags
             buffer[flags_index] = connect_flags;
-            Ok(len)
+            Ok(1 + count + len)
         }
     }
 

--- a/benchmarks/simplerouter/src/protocol/v4.rs
+++ b/benchmarks/simplerouter/src/protocol/v4.rs
@@ -497,7 +497,6 @@ pub(crate) mod publish {
 
         buffer.extend_from_slice(payload);
 
-        // TODO: Returned length is wrong in other packets. Fix it
         Ok(1 + count + len)
     }
 }

--- a/benchmarks/simplerouter/src/protocol/v5.rs
+++ b/benchmarks/simplerouter/src/protocol/v5.rs
@@ -1031,7 +1031,6 @@ pub(crate) mod publish {
 
         buffer.extend_from_slice(payload);
 
-        // TODO: Returned length is wrong in other packets. Fix it
         Ok(1 + count + len)
     }
 }

--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Make v4::Connect::write return correct value
+
 ### Security
 
 ---

--- a/rumqttc/src/mqttbytes/v4/connect.rs
+++ b/rumqttc/src/mqttbytes/v4/connect.rs
@@ -130,7 +130,7 @@ impl Connect {
 
         // update connect flags
         buffer[flags_index] = connect_flags;
-        Ok(len)
+        Ok(1 + count + len)
     }
 }
 

--- a/rumqttc/src/mqttbytes/v4/publish.rs
+++ b/rumqttc/src/mqttbytes/v4/publish.rs
@@ -104,7 +104,6 @@ impl Publish {
 
         buffer.extend_from_slice(&self.payload);
 
-        // TODO: Returned length is wrong in other packets. Fix it
         Ok(1 + count + len)
     }
 }

--- a/rumqttd/src/protocol/v4/publish.rs
+++ b/rumqttd/src/protocol/v4/publish.rs
@@ -63,6 +63,5 @@ pub fn write(publish: &Publish, buffer: &mut BytesMut) -> Result<usize, Error> {
 
     buffer.extend_from_slice(&publish.payload);
 
-    // TODO: Returned length is wrong in other packets. Fix it
     Ok(1 + count + len)
 }

--- a/rumqttd/src/protocol/v4/publish.rs
+++ b/rumqttd/src/protocol/v4/publish.rs
@@ -63,5 +63,6 @@ pub fn write(publish: &Publish, buffer: &mut BytesMut) -> Result<usize, Error> {
 
     buffer.extend_from_slice(&publish.payload);
 
+    // TODO: Returned length is wrong in other packets. Fix it
     Ok(1 + count + len)
 }


### PR DESCRIPTION
Solves #816 

## Type of change

`Connect::write` was returning wrong value in couple places.

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
