### PR TITLE
Make Type::write return correct value for rumqttd

### DIFF
--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MQTT keep alive interval
 - record client id for remote link's span
 - session present flag in connack
+- Make Connect::write return the number of bytes written correctly everywhere
 
 ### Security
 

--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MQTT keep alive interval
 - record client id for remote link's span
 - session present flag in connack
-- Make Connect::write return the number of bytes written correctly everywhere
+- Make write method return the number of bytes written correctly everywhere
 
 ### Security
 

--- a/rumqttd/src/protocol/v4/connect.rs
+++ b/rumqttd/src/protocol/v4/connect.rs
@@ -92,7 +92,7 @@ pub fn write(
 
     // update connect flags
     buffer[flags_index] = connect_flags;
-    Ok(len)
+    Ok(1 + count + len)
 }
 
 mod will {

--- a/rumqttd/src/protocol/v4/publish.rs
+++ b/rumqttd/src/protocol/v4/publish.rs
@@ -63,6 +63,5 @@ pub fn write(publish: &Publish, buffer: &mut BytesMut) -> Result<usize, Error> {
 
     buffer.extend_from_slice(&publish.payload);
 
-    // TODO: Returned length is wrong in other packets. Fix it
     Ok(1 + count + len)
 }

--- a/rumqttd/src/protocol/v5/connect.rs
+++ b/rumqttd/src/protocol/v5/connect.rs
@@ -122,7 +122,7 @@ pub fn write(
 
     // update connect flags
     buffer[flags_index] = connect_flags;
-    Ok(len)
+    Ok(1 + count + len)
 }
 
 mod will {


### PR DESCRIPTION
<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

write method wasn't returning the number of bytes read correctly for some types in rumqttd.

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
