### PR TITLE
refactor: simplify `Network`with `Framed<.., Codec>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,6 +1951,8 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
  "url",
  "ws_stream_tungstenite",
 ]
@@ -2540,6 +2542,17 @@ checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
  "rustls",
  "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * rename `N` as `AsyncReadWrite` to describe usage.
+* use `Framed` to encode/decode MQTT packets.
 
 ### Deprecated
 

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -25,6 +25,7 @@ proxy = ["dep:async-http-proxy"]
 [dependencies]
 futures-util = { version = "0.3", default_features = false, features = ["std"] }
 tokio = { version = "1.36", features = ["rt", "macros", "io-util", "net", "time"] }
+tokio-util = { version = "0.7", features = ["codec"] }
 bytes = "1.5"
 log = "0.4"
 flume = { version = "0.11", default-features = false, features = ["async"] }
@@ -47,6 +48,7 @@ native-tls = { version = "0.2.11", optional = true }
 url = { version = "2", default-features = false, optional = true }
 # proxy
 async-http-proxy = { version = "1.2.5", features = ["runtime-tokio", "basic-auth"], optional = true }
+tokio-stream = "0.1.15"
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -23,7 +23,7 @@ websocket = ["dep:async-tungstenite", "dep:ws_stream_tungstenite", "dep:http"]
 proxy = ["dep:async-http-proxy"]
 
 [dependencies]
-futures-util = { version = "0.3", default_features = false, features = ["std"] }
+futures-util = { version = "0.3", default_features = false, features = ["std", "sink"] }
 tokio = { version = "1.36", features = ["rt", "macros", "io-util", "net", "time"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 bytes = "1.5"

--- a/rumqttc/src/framed.rs
+++ b/rumqttc/src/framed.rs
@@ -100,9 +100,11 @@ impl Network {
                     }
                 }
                 // If some packets are already framed, return those
-                Err(mqttbytes::Error::InsufficientBytes(_)) if count > 0 => break,
-                // TODO: figure out how not to block
-                Ok(_) => break,
+                Err(mqttbytes::Error::InsufficientBytes(_)) | Ok(_) if count > 0 => break,
+                // NOTE: read atleast 1 packet
+                Ok(_) => {
+                    self.read_bytes(2).await?;
+                }
                 // Wait for more bytes until a frame can be created
                 Err(mqttbytes::Error::InsufficientBytes(required)) => {
                     self.read_bytes(required).await?;

--- a/rumqttc/src/framed.rs
+++ b/rumqttc/src/framed.rs
@@ -52,8 +52,8 @@ impl Network {
         loop {
             match res {
                 Some(Ok(packet)) => {
-                    if let Some(packet) = state.handle_incoming_packet(packet)? {
-                        self.write(packet).await?;
+                    if let Some(outgoing) = state.handle_incoming_packet(packet)? {
+                        self.write(outgoing).await?;
                     }
 
                     count += 1;

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -200,25 +200,6 @@ pub enum Request {
     Disconnect(Disconnect),
 }
 
-impl Request {
-    fn size(&self) -> usize {
-        match &self {
-            Request::Publish(publish) => publish.size(),
-            Request::PubAck(puback) => puback.size(),
-            Request::PubRec(pubrec) => pubrec.size(),
-            Request::PubComp(pubcomp) => pubcomp.size(),
-            Request::PubRel(pubrel) => pubrel.size(),
-            Request::PingReq(pingreq) => pingreq.size(),
-            Request::PingResp(pingresp) => pingresp.size(),
-            Request::Subscribe(subscribe) => subscribe.size(),
-            Request::SubAck(suback) => suback.size(),
-            Request::Unsubscribe(unsubscribe) => unsubscribe.size(),
-            Request::UnsubAck(unsuback) => unsuback.size(),
-            Request::Disconnect(disconn) => disconn.size(),
-        }
-    }
-}
-
 impl From<Publish> for Request {
     fn from(publish: Publish) -> Request {
         Request::Publish(publish)

--- a/rumqttc/src/mqttbytes/mod.rs
+++ b/rumqttc/src/mqttbytes/mod.rs
@@ -13,7 +13,7 @@ pub mod v4;
 pub use topic::*;
 
 /// Error during serialization and deserialization
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("Expected Connect, received: {0:?}")]
     NotConnect(PacketType),
@@ -60,6 +60,8 @@ pub enum Error {
     /// proceed further
     #[error("At least {0} more bytes required to frame packet")]
     InsufficientBytes(usize),
+    #[error("IO: {0}")]
+    Io(#[from] std::io::Error),
 }
 
 /// MQTT packet type

--- a/rumqttc/src/mqttbytes/mod.rs
+++ b/rumqttc/src/mqttbytes/mod.rs
@@ -62,6 +62,8 @@ pub enum Error {
     InsufficientBytes(usize),
     #[error("IO: {0}")]
     Io(#[from] std::io::Error),
+    #[error("Cannot send packet of size '{pkt_size:?}'. It's greater than the broker's maximum packet size of: '{max:?}'")]
+    OutgoingPacketTooLarge { pkt_size: usize, max: usize },
 }
 
 /// MQTT packet type

--- a/rumqttc/src/mqttbytes/v4/codec.rs
+++ b/rumqttc/src/mqttbytes/v4/codec.rs
@@ -28,10 +28,43 @@ impl Decoder for Codec {
 
 impl Encoder<Packet> for Codec {
     type Error = Error;
-    
+
     fn encode(&mut self, item: Packet, dst: &mut BytesMut) -> Result<(), Self::Error> {
         item.write(dst, self.max_outgoing_size)?;
 
         Ok(())
-    } 
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::BytesMut;
+    use tokio_util::codec::Encoder;
+
+    use super::Codec;
+    use crate::{mqttbytes::Error, Packet, Publish, QoS};
+
+    #[test]
+    fn outgoing_max_packet_size_check() {
+        let mut buf = BytesMut::new();
+        let mut codec = Codec {
+            max_incoming_size: 100,
+            max_outgoing_size: 200,
+        };
+
+        let mut small_publish = Publish::new("hello/world", QoS::AtLeastOnce, vec![1; 100]);
+        small_publish.pkid = 1;
+        codec
+            .encode(Packet::Publish(small_publish), &mut buf)
+            .unwrap();
+
+        let large_publish = Publish::new("hello/world", QoS::AtLeastOnce, vec![1; 265]);
+        match codec.encode(Packet::Publish(large_publish), &mut buf) {
+            Err(Error::OutgoingPacketTooLarge {
+                pkt_size: 281,
+                max: 200,
+            }) => {}
+            _ => unreachable!(),
+        }
+    }
 }

--- a/rumqttc/src/mqttbytes/v4/codec.rs
+++ b/rumqttc/src/mqttbytes/v4/codec.rs
@@ -1,0 +1,24 @@
+use bytes::{Buf, BytesMut};
+use tokio_util::codec::Decoder;
+
+use super::{Error, Packet};
+
+/// MQTT v4 codec
+pub struct Codec {
+    /// Maximum packet size
+    pub max_incoming_size: usize,
+}
+
+impl Decoder for Codec {
+    type Item = Packet;
+    type Error = Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        if src.remaining() == 0 {
+            return Ok(None);
+        }
+
+        let packet = Packet::read(src, self.max_incoming_size)?;
+        Ok(Some(packet))
+    }
+}

--- a/rumqttc/src/mqttbytes/v4/codec.rs
+++ b/rumqttc/src/mqttbytes/v4/codec.rs
@@ -1,12 +1,15 @@
 use bytes::{Buf, BytesMut};
-use tokio_util::codec::Decoder;
+use tokio_util::codec::{Decoder, Encoder};
 
 use super::{Error, Packet};
 
 /// MQTT v4 codec
+#[derive(Debug, Clone)]
 pub struct Codec {
-    /// Maximum packet size
+    /// Maximum packet size allowed by client
     pub max_incoming_size: usize,
+    /// Maximum packet size allowed by broker
+    pub max_outgoing_size: usize,
 }
 
 impl Decoder for Codec {
@@ -21,4 +24,14 @@ impl Decoder for Codec {
         let packet = Packet::read(src, self.max_incoming_size)?;
         Ok(Some(packet))
     }
+}
+
+impl Encoder<Packet> for Codec {
+    type Error = Error;
+    
+    fn encode(&mut self, item: Packet, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        item.write(dst, self.max_outgoing_size)?;
+
+        Ok(())
+    } 
 }

--- a/rumqttc/src/mqttbytes/v4/mod.rs
+++ b/rumqttc/src/mqttbytes/v4/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+mod codec;
 mod connack;
 mod connect;
 mod disconnect;
@@ -27,6 +28,7 @@ pub use suback::*;
 pub use subscribe::*;
 pub use unsuback::*;
 pub use unsubscribe::*;
+pub use codec::*;
 
 /// Encapsulates all MQTT packet types
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/rumqttc/src/mqttbytes/v4/mod.rs
+++ b/rumqttc/src/mqttbytes/v4/mod.rs
@@ -111,7 +111,14 @@ impl Packet {
     }
 
     /// Serializes the MQTT packet into a stream of bytes
-    pub fn write(&self, stream: &mut BytesMut) -> Result<usize, Error> {
+    pub fn write(&self, stream: &mut BytesMut, max_size: usize) -> Result<usize, Error> {
+        if self.size() > max_size {
+            return Err(Error::OutgoingPacketTooLarge {
+                pkt_size: self.size(),
+                max: max_size,
+            })
+        }
+
         match self {
             Packet::Connect(c) => c.write(stream),
             Packet::ConnAck(c) => c.write(stream),

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -9,7 +9,6 @@ use tokio::select;
 use tokio::time::{self, error::Elapsed, Instant, Sleep};
 
 use std::collections::VecDeque;
-use std::convert::TryInto;
 use std::io;
 use std::pin::Pin;
 use std::time::Duration;
@@ -211,7 +210,7 @@ impl EventLoop {
             ), if !self.pending.is_empty() || (!inflight_full && !collision) => match o {
                 Ok(request) => {
                     self.state.handle_outgoing_packet(request)?;
-                    network.flush(&mut self.state.write).await?;
+                    network.flush().await?;
                     Ok(self.state.events.pop_front().unwrap())
                 }
                 Err(_) => Err(ConnectionError::RequestsDone),
@@ -220,7 +219,7 @@ impl EventLoop {
             o = network.readb(&mut self.state) => {
                 o?;
                 // flush all the acks and return first incoming packet
-                network.flush(&mut self.state.write).await?;
+                network.flush().await?;
                 Ok(self.state.events.pop_front().unwrap())
             },
             // We generate pings irrespective of network activity. This keeps the ping logic
@@ -230,7 +229,7 @@ impl EventLoop {
                 timeout.as_mut().reset(Instant::now() + self.options.keep_alive);
 
                 self.state.handle_outgoing_packet(Request::PingReq)?;
-                network.flush(&mut self.state.write).await?;
+                network.flush().await?;
                 Ok(self.state.events.pop_front().unwrap())
             }
         }
@@ -281,7 +280,6 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
     // Override default value if max_packet_size is set on `connect_properties`
     if let Some(connect_props) = &options.connect_properties {
         if let Some(max_size) = connect_props.max_packet_size {
-            let max_size = max_size.try_into().map_err(StateError::Coversion)?;
             max_incoming_pkt_size = Some(max_size);
         }
     }
@@ -409,6 +407,7 @@ async fn mqtt_connect(
                 if let Some(keep_alive) = props.server_keep_alive {
                     options.keep_alive = Duration::from_secs(keep_alive as u64);
                 }
+                network.set_max_outgoing_size(props.max_packet_size);
             }
             Ok(Packet::ConnAck(connack))
         }

--- a/rumqttc/src/v5/framed.rs
+++ b/rumqttc/src/v5/framed.rs
@@ -1,131 +1,109 @@
-use bytes::BytesMut;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use futures_util::{FutureExt, SinkExt};
+use tokio_stream::StreamExt;
+use tokio_util::codec::Framed;
 
 use crate::framed::AsyncReadWrite;
 
-use super::mqttbytes;
-use super::mqttbytes::v5::{Connect, Login, Packet};
-use super::{Incoming, MqttOptions, MqttState, StateError};
-use std::io;
+use super::mqttbytes::v5::Packet;
+use super::{mqttbytes, Codec, Connect, Login, MqttOptions, MqttState};
+use super::{Incoming, StateError};
 
 /// Network transforms packets <-> frames efficiently. It takes
 /// advantage of pre-allocation, buffering and vectorization when
 /// appropriate to achieve performance
 pub struct Network {
-    /// Socket for IO
-    socket: Box<dyn AsyncReadWrite>,
-    /// Buffered reads
-    read: BytesMut,
-    /// Maximum packet size
-    max_incoming_size: Option<usize>,
+    /// Frame MQTT packets from network connection
+    framed: Framed<Box<dyn AsyncReadWrite>, Codec>,
     /// Maximum readv count
     max_readb_count: usize,
 }
-
 impl Network {
-    pub fn new(socket: impl AsyncReadWrite + 'static, max_incoming_size: Option<usize>) -> Network {
+    pub fn new(socket: impl AsyncReadWrite + 'static, max_incoming_size: Option<u32>) -> Network {
         let socket = Box::new(socket) as Box<dyn AsyncReadWrite>;
-        Network {
-            socket,
-            read: BytesMut::with_capacity(10 * 1024),
+        let codec = Codec {
             max_incoming_size,
+            max_outgoing_size: None,
+        };
+        let framed = Framed::new(socket, codec);
+
+        Network {
+            framed,
             max_readb_count: 10,
         }
     }
 
-    /// Reads more than 'required' bytes to frame a packet into self.read buffer
-    async fn read_bytes(&mut self, required: usize) -> io::Result<usize> {
-        let mut total_read = 0;
-        loop {
-            let read = self.socket.read_buf(&mut self.read).await?;
-            if 0 == read {
-                return if self.read.is_empty() {
-                    Err(io::Error::new(
-                        io::ErrorKind::ConnectionAborted,
-                        "connection closed by peer",
-                    ))
-                } else {
-                    Err(io::Error::new(
-                        io::ErrorKind::ConnectionReset,
-                        "connection reset by peer",
-                    ))
-                };
-            }
-
-            total_read += read;
-            if total_read >= required {
-                return Ok(total_read);
-            }
-        }
+    pub fn set_max_outgoing_size(&mut self, max_outgoing_size: Option<u32>) {
+        self.framed.codec_mut().max_outgoing_size = max_outgoing_size;
     }
 
-    pub async fn read(&mut self) -> io::Result<Incoming> {
-        loop {
-            let required = match Packet::read(&mut self.read, self.max_incoming_size) {
-                Ok(packet) => return Ok(packet),
-                Err(mqttbytes::Error::InsufficientBytes(required)) => required,
-                Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidData, e.to_string())),
-            };
-
-            // read more packets until a frame can be created. This function
-            // blocks until a frame can be created. Use this in a select! branch
-            self.read_bytes(required).await?;
+    /// Reads and returns a single packet from network
+    pub async fn read(&mut self) -> Result<Incoming, StateError> {
+        match self.framed.next().await {
+            Some(Ok(packet)) => Ok(packet),
+            Some(Err(mqttbytes::Error::InsufficientBytes(_))) | None => unreachable!(),
+            Some(Err(e)) => Err(StateError::Deserialization(e)),
         }
     }
 
     /// Read packets in bulk. This allow replies to be in bulk. This method is used
     /// after the connection is established to read a bunch of incoming packets
     pub async fn readb(&mut self, state: &mut MqttState) -> Result<(), StateError> {
-        let mut count = 0;
+        // wait for the first read
+        let mut res = self.framed.next().await;
+        let mut count = 1;
         loop {
-            match Packet::read(&mut self.read, self.max_incoming_size) {
-                Ok(packet) => {
-                    state.handle_incoming_packet(packet)?;
+            match res {
+                Some(Ok(packet)) => {
+                    if let Some(outgoing) = state.handle_incoming_packet(packet)? {
+                        self.write(outgoing).await?;
+                    }
 
                     count += 1;
                     if count >= self.max_readb_count {
-                        return Ok(());
+                        break;
                     }
                 }
-                // If some packets are already framed, return those
-                Err(mqttbytes::Error::InsufficientBytes(_)) if count > 0 => return Ok(()),
-                // Wait for more bytes until a frame can be created
-                Err(mqttbytes::Error::InsufficientBytes(required)) => {
-                    self.read_bytes(required).await?;
-                }
-                Err(mqttbytes::Error::PayloadSizeLimitExceeded { pkt_size, max }) => {
-                    state.handle_protocol_error()?;
-                    return Err(StateError::IncomingPacketTooLarge { pkt_size, max });
-                }
-                Err(e) => return Err(StateError::Deserialization(e)),
+                Some(Err(mqttbytes::Error::InsufficientBytes(_))) | None => unreachable!(),
+                Some(Err(e)) => return Err(StateError::Deserialization(e)),
+            }
+            // do not wait for subsequent reads
+            match self.framed.next().now_or_never() {
+                Some(r) => res = r,
+                _ => break,
             };
         }
+
+        Ok(())
     }
 
-    pub async fn connect(&mut self, connect: Connect, options: &MqttOptions) -> io::Result<usize> {
-        let mut write = BytesMut::new();
+    /// Serializes packet into write buffer
+    pub async fn write(&mut self, packet: Packet) -> Result<(), StateError> {
+        self.framed
+            .feed(packet)
+            .await
+            .map_err(StateError::Deserialization)
+    }
+
+    pub async fn connect(
+        &mut self,
+        connect: Connect,
+        options: &MqttOptions,
+    ) -> Result<(), StateError> {
         let last_will = options.last_will();
         let login = options.credentials().map(|l| Login {
             username: l.0,
             password: l.1,
         });
+        self.write(Packet::Connect(connect, last_will, login))
+            .await?;
 
-        let len = match Packet::Connect(connect, last_will, login).write(&mut write) {
-            Ok(size) => size,
-            Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidData, e.to_string())),
-        };
-
-        self.socket.write_all(&write[..]).await?;
-        Ok(len)
+        self.flush().await
     }
 
-    pub async fn flush(&mut self, write: &mut BytesMut) -> io::Result<()> {
-        if write.is_empty() {
-            return Ok(());
-        }
-
-        self.socket.write_all(&write[..]).await?;
-        write.clear();
-        Ok(())
+    pub async fn flush(&mut self) -> Result<(), StateError> {
+        self.framed
+            .flush()
+            .await
+            .map_err(StateError::Deserialization)
     }
 }

--- a/rumqttc/src/v5/mod.rs
+++ b/rumqttc/src/v5/mod.rs
@@ -89,7 +89,7 @@ pub struct MqttOptions {
     conn_timeout: u64,
     /// Default value of for maximum incoming packet size.
     /// Used when `max_incomming_size` in `connect_properties` is NOT available.
-    default_max_incoming_size: usize,
+    default_max_incoming_size: u32,
     /// Connect Properties
     connect_properties: Option<ConnectProperties>,
     /// If set to `true` MQTT acknowledgements are not sent automatically.

--- a/rumqttc/src/v5/mqttbytes/mod.rs
+++ b/rumqttc/src/v5/mqttbytes/mod.rs
@@ -130,7 +130,7 @@ pub fn matches(topic: &str, filter: &str) -> bool {
 }
 
 /// Error during serialization and deserialization
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("Invalid return code received as response for connect = {0}")]
     InvalidConnectReturnCode(u8),
@@ -163,7 +163,7 @@ pub enum Error {
     #[error("Payload is too long")]
     PayloadTooLong,
     #[error("Max Payload size of {max:?} has been exceeded by packet of {pkt_size:?} bytes")]
-    PayloadSizeLimitExceeded { pkt_size: usize, max: usize },
+    PayloadSizeLimitExceeded { pkt_size: usize, max: u32 },
     #[error("Payload is required")]
     PayloadRequired,
     #[error("Payload is required = {0}")]
@@ -183,4 +183,8 @@ pub enum Error {
     /// proceed further
     #[error("Insufficient number of bytes to frame packet, {0} more bytes required")]
     InsufficientBytes(usize),
+    #[error("IO: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Cannot send packet of size '{pkt_size:?}'. It's greater than the broker's maximum packet size of: '{max:?}'")]
+    OutgoingPacketTooLarge { pkt_size: u32, max: u32 },
 }

--- a/rumqttc/src/v5/mqttbytes/v5/codec.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/codec.rs
@@ -1,0 +1,76 @@
+use bytes::BytesMut;
+use tokio_util::codec::{Decoder, Encoder};
+
+use super::{Error, Packet};
+
+/// MQTT v4 codec
+#[derive(Debug, Clone)]
+pub struct Codec {
+    /// Maximum packet size allowed by client
+    pub max_incoming_size: Option<u32>,
+    /// Maximum packet size allowed by broker
+    pub max_outgoing_size: Option<u32>,
+}
+
+impl Decoder for Codec {
+    type Item = Packet;
+    type Error = Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        match Packet::read(src, self.max_incoming_size) {
+            Ok(packet) => Ok(Some(packet)),
+            Err(Error::InsufficientBytes(b)) => {
+                // Get more packets to construct the incomplete packet
+                src.reserve(b);
+                Ok(None)
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+impl Encoder<Packet> for Codec {
+    type Error = Error;
+
+    fn encode(&mut self, item: Packet, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        item.write(dst, self.max_outgoing_size)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::BytesMut;
+    use tokio_util::codec::Encoder;
+
+    use super::Codec;
+    use crate::v5::{
+        mqttbytes::{Error, QoS},
+        Packet, Publish,
+    };
+
+    #[test]
+    fn outgoing_max_packet_size_check() {
+        let mut buf = BytesMut::new();
+        let mut codec = Codec {
+            max_incoming_size: Some(100),
+            max_outgoing_size: Some(200),
+        };
+
+        let mut small_publish = Publish::new("hello/world", QoS::AtLeastOnce, vec![1; 100], None);
+        small_publish.pkid = 1;
+        codec
+            .encode(Packet::Publish(small_publish), &mut buf)
+            .unwrap();
+
+        let large_publish = Publish::new("hello/world", QoS::AtLeastOnce, vec![1; 265], None);
+        match codec.encode(Packet::Publish(large_publish), &mut buf) {
+            Err(Error::OutgoingPacketTooLarge {
+                pkt_size: 282,
+                max: 200,
+            }) => {}
+            _ => unreachable!(),
+        }
+    }
+}

--- a/rumqttc/src/v5/mqttbytes/v5/mod.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/mod.rs
@@ -1,6 +1,7 @@
 use std::slice::Iter;
 
 pub use self::{
+    codec::Codec,
     connack::{ConnAck, ConnAckProperties, ConnectReturnCode},
     connect::{Connect, ConnectProperties, LastWill, LastWillProperties, Login},
     disconnect::{Disconnect, DisconnectReasonCode},
@@ -19,6 +20,7 @@ pub use self::{
 use super::*;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
+mod codec;
 mod connack;
 mod connect;
 mod disconnect;
@@ -53,7 +55,7 @@ pub enum Packet {
 
 impl Packet {
     /// Reads a stream of bytes and extracts next MQTT packet out of it
-    pub fn read(stream: &mut BytesMut, max_size: Option<usize>) -> Result<Packet, Error> {
+    pub fn read(stream: &mut BytesMut, max_size: Option<u32>) -> Result<Packet, Error> {
         let fixed_header = check(stream.iter(), max_size)?;
 
         // Test with a stream with exactly the size to check border panics
@@ -126,7 +128,16 @@ impl Packet {
         Ok(packet)
     }
 
-    pub fn write(&self, write: &mut BytesMut) -> Result<usize, Error> {
+    pub fn write(&self, write: &mut BytesMut, max_size: Option<u32>) -> Result<usize, Error> {
+        if let Some(max_size) = max_size {
+            if self.size() > max_size as usize {
+                return Err(Error::OutgoingPacketTooLarge {
+                    pkt_size: self.size() as u32,
+                    max: max_size,
+                });
+            }
+        }
+
         match self {
             Self::Publish(publish) => publish.write(write),
             Self::Subscribe(subscription) => subscription.write(write),
@@ -320,7 +331,7 @@ fn property(num: u8) -> Result<PropertyType, Error> {
 /// The passed stream doesn't modify parent stream's cursor. If this function
 /// returned an error, next `check` on the same parent stream is forced start
 /// with cursor at 0 again (Iter is owned. Only Iter's cursor is changed internally)
-pub fn check(stream: Iter<u8>, max_packet_size: Option<usize>) -> Result<FixedHeader, Error> {
+pub fn check(stream: Iter<u8>, max_packet_size: Option<u32>) -> Result<FixedHeader, Error> {
     // Create fixed header if there are enough bytes in the stream
     // to frame full packet
     let stream_len = stream.len();
@@ -329,7 +340,7 @@ pub fn check(stream: Iter<u8>, max_packet_size: Option<usize>) -> Result<FixedHe
     // Don't let rogue connections attack with huge payloads.
     // Disconnect them before reading all that data
     if let Some(max_size) = max_packet_size {
-        if fixed_header.remaining_len > max_size {
+        if fixed_header.remaining_len > max_size as usize {
             return Err(Error::PayloadSizeLimitExceeded {
                 pkt_size: fixed_header.remaining_len,
                 max: max_size,

--- a/rumqttc/src/v5/state.rs
+++ b/rumqttc/src/v5/state.rs
@@ -3,13 +3,12 @@ use super::mqttbytes::v5::{
     PubAckReason, PubComp, PubCompReason, PubRec, PubRecReason, PubRel, PubRelReason, Publish,
     SubAck, Subscribe, SubscribeReasonCode, UnsubAck, UnsubAckReason, Unsubscribe,
 };
-use super::mqttbytes::{self, QoS};
+use super::mqttbytes::{self, Error as MqttError, QoS};
 
 use super::{Event, Incoming, Outgoing, Request};
 
 use bytes::{Bytes, BytesMut};
 use std::collections::{HashMap, VecDeque};
-use std::convert::TryInto;
 use std::{io, time::Instant};
 
 /// Errors during state handling
@@ -37,7 +36,7 @@ pub enum StateError {
     #[error("A Subscribe packet must contain atleast one filter")]
     EmptySubscription,
     #[error("Mqtt serialization/deserialization error: {0}")]
-    Deserialization(#[from] mqttbytes::Error),
+    Deserialization(MqttError),
     #[error(
         "Cannot use topic alias '{alias:?}'. It's greater than the broker's maximum of '{max:?}'."
     )]
@@ -65,6 +64,17 @@ pub enum StateError {
     PubCompFail { reason: PubCompReason },
     #[error("Connection failed with reason '{reason:?}' ")]
     ConnFail { reason: ConnectReturnCode },
+}
+
+impl From<mqttbytes::Error> for StateError {
+    fn from(value: MqttError) -> Self {
+        match value {
+            MqttError::OutgoingPacketTooLarge { pkt_size, max } => {
+                StateError::OutgoingPacketTooLarge { pkt_size, max }
+            }
+            e => StateError::Deserialization(e),
+        }
+    }
 }
 
 /// State of the mqtt connection.
@@ -107,8 +117,6 @@ pub struct MqttState {
     topic_alises: HashMap<u16, Bytes>,
     /// `topic_alias_maximum` RECEIVED via connack packet
     pub broker_topic_alias_max: u16,
-    /// The broker's `max_packet_size` received via connack
-    pub max_outgoing_packet_size: Option<u32>,
     /// Maximum number of allowed inflight QoS1 & QoS2 requests
     pub(crate) max_outgoing_inflight: u16,
     /// Upper limit on the maximum number of allowed inflight QoS1 & QoS2 requests
@@ -139,7 +147,6 @@ impl MqttState {
             topic_alises: HashMap::new(),
             // Set via CONNACK
             broker_topic_alias_max: 0,
-            max_outgoing_packet_size: None,
             max_outgoing_inflight: max_inflight,
             max_outgoing_inflight_upper_limit: max_inflight,
         }
@@ -181,77 +188,67 @@ impl MqttState {
 
     /// Consolidates handling of all outgoing mqtt packet logic. Returns a packet which should
     /// be put on to the network by the eventloop
-    pub fn handle_outgoing_packet(&mut self, request: Request) -> Result<(), StateError> {
-        match request {
-            Request::Publish(publish) => {
-                self.check_size(publish.size())?;
-                self.outgoing_publish(publish)?
-            }
-            Request::PubRel(pubrel) => {
-                self.check_size(pubrel.size())?;
-                self.outgoing_pubrel(pubrel)?
-            }
-            Request::Subscribe(subscribe) => {
-                self.check_size(subscribe.size())?;
-                self.outgoing_subscribe(subscribe)?
-            }
-            Request::Unsubscribe(unsubscribe) => {
-                self.check_size(unsubscribe.size())?;
-                self.outgoing_unsubscribe(unsubscribe)?
-            }
+    pub fn handle_outgoing_packet(
+        &mut self,
+        request: Request,
+    ) -> Result<Option<Packet>, StateError> {
+        let packet = match request {
+            Request::Publish(publish) => self.outgoing_publish(publish)?,
+            Request::PubRel(pubrel) => self.outgoing_pubrel(pubrel)?,
+            Request::Subscribe(subscribe) => self.outgoing_subscribe(subscribe)?,
+            Request::Unsubscribe(unsubscribe) => self.outgoing_unsubscribe(unsubscribe)?,
             Request::PingReq => self.outgoing_ping()?,
             Request::Disconnect => {
                 self.outgoing_disconnect(DisconnectReasonCode::NormalDisconnection)?
             }
-            Request::PubAck(puback) => {
-                self.check_size(puback.size())?;
-                self.outgoing_puback(puback)?
-            }
-            Request::PubRec(pubrec) => {
-                self.check_size(pubrec.size())?;
-                self.outgoing_pubrec(pubrec)?
-            }
+            Request::PubAck(puback) => self.outgoing_puback(puback)?,
+            Request::PubRec(pubrec) => self.outgoing_pubrec(pubrec)?,
             _ => unimplemented!(),
         };
 
         self.last_outgoing = Instant::now();
-        Ok(())
+        Ok(packet)
     }
 
     /// Consolidates handling of all incoming mqtt packets. Returns a `Notification` which for the
     /// user to consume and `Packet` which for the eventloop to put on the network
     /// E.g For incoming QoS1 publish packet, this method returns (Publish, Puback). Publish packet will
     /// be forwarded to user and Pubck packet will be written to network
-    pub fn handle_incoming_packet(&mut self, mut packet: Incoming) -> Result<(), StateError> {
-        let out = match &mut packet {
-            Incoming::PingResp(_) => self.handle_incoming_pingresp(),
-            Incoming::Publish(publish) => self.handle_incoming_publish(publish),
-            Incoming::SubAck(suback) => self.handle_incoming_suback(suback),
-            Incoming::UnsubAck(unsuback) => self.handle_incoming_unsuback(unsuback),
-            Incoming::PubAck(puback) => self.handle_incoming_puback(puback),
-            Incoming::PubRec(pubrec) => self.handle_incoming_pubrec(pubrec),
-            Incoming::PubRel(pubrel) => self.handle_incoming_pubrel(pubrel),
-            Incoming::PubComp(pubcomp) => self.handle_incoming_pubcomp(pubcomp),
-            Incoming::ConnAck(connack) => self.handle_incoming_connack(connack),
-            Incoming::Disconnect(disconn) => self.handle_incoming_disconn(disconn),
+    pub fn handle_incoming_packet(
+        &mut self,
+        mut packet: Incoming,
+    ) -> Result<Option<Packet>, StateError> {
+        let outgoing = match &mut packet {
+            Incoming::PingResp(_) => self.handle_incoming_pingresp()?,
+            Incoming::Publish(publish) => self.handle_incoming_publish(publish)?,
+            Incoming::SubAck(suback) => self.handle_incoming_suback(suback)?,
+            Incoming::UnsubAck(unsuback) => self.handle_incoming_unsuback(unsuback)?,
+            Incoming::PubAck(puback) => self.handle_incoming_puback(puback)?,
+            Incoming::PubRec(pubrec) => self.handle_incoming_pubrec(pubrec)?,
+            Incoming::PubRel(pubrel) => self.handle_incoming_pubrel(pubrel)?,
+            Incoming::PubComp(pubcomp) => self.handle_incoming_pubcomp(pubcomp)?,
+            Incoming::ConnAck(connack) => self.handle_incoming_connack(connack)?,
+            Incoming::Disconnect(disconn) => self.handle_incoming_disconn(disconn)?,
             _ => {
                 error!("Invalid incoming packet = {:?}", packet);
                 return Err(StateError::WrongPacket);
             }
         };
 
-        out?;
         self.events.push_back(Event::Incoming(packet));
         self.last_incoming = Instant::now();
-        Ok(())
+        Ok(outgoing)
     }
 
-    pub fn handle_protocol_error(&mut self) -> Result<(), StateError> {
+    pub fn handle_protocol_error(&mut self) -> Result<Option<Packet>, StateError> {
         // send DISCONNECT packet with REASON_CODE 0x82
         self.outgoing_disconnect(DisconnectReasonCode::ProtocolError)
     }
 
-    fn handle_incoming_suback(&mut self, suback: &mut SubAck) -> Result<(), StateError> {
+    fn handle_incoming_suback(
+        &mut self,
+        suback: &mut SubAck,
+    ) -> Result<Option<Packet>, StateError> {
         for reason in suback.return_codes.iter() {
             match reason {
                 SubscribeReasonCode::Success(qos) => {
@@ -260,19 +257,25 @@ impl MqttState {
                 _ => return Err(StateError::SubFail { reason: *reason }),
             }
         }
-        Ok(())
+        Ok(None)
     }
 
-    fn handle_incoming_unsuback(&mut self, unsuback: &mut UnsubAck) -> Result<(), StateError> {
+    fn handle_incoming_unsuback(
+        &mut self,
+        unsuback: &mut UnsubAck,
+    ) -> Result<Option<Packet>, StateError> {
         for reason in unsuback.reasons.iter() {
             if reason != &UnsubAckReason::Success {
                 return Err(StateError::UnsubFail { reason: *reason });
             }
         }
-        Ok(())
+        Ok(None)
     }
 
-    fn handle_incoming_connack(&mut self, connack: &mut ConnAck) -> Result<(), StateError> {
+    fn handle_incoming_connack(
+        &mut self,
+        connack: &mut ConnAck,
+    ) -> Result<Option<Packet>, StateError> {
         if connack.code != ConnectReturnCode::Success {
             return Err(StateError::ConnFail {
                 reason: connack.code,
@@ -290,13 +293,14 @@ impl MqttState {
                 // FIXME: Maybe resize the pubrec and pubrel queues here
                 // to save some space.
             }
-
-            self.max_outgoing_packet_size = props.max_packet_size;
         }
-        Ok(())
+        Ok(None)
     }
 
-    fn handle_incoming_disconn(&mut self, disconn: &mut Disconnect) -> Result<(), StateError> {
+    fn handle_incoming_disconn(
+        &mut self,
+        disconn: &mut Disconnect,
+    ) -> Result<Option<Packet>, StateError> {
         let reason_code = disconn.reason_code;
         let reason_string = if let Some(props) = &disconn.properties {
             props.reason_string.clone()
@@ -311,7 +315,10 @@ impl MqttState {
 
     /// Results in a publish notification in all the QoS cases. Replys with an ack
     /// in case of QoS1 and Replys rec in case of QoS while also storing the message
-    fn handle_incoming_publish(&mut self, publish: &mut Publish) -> Result<(), StateError> {
+    fn handle_incoming_publish(
+        &mut self,
+        publish: &mut Publish,
+    ) -> Result<Option<Packet>, StateError> {
         let qos = publish.qos;
 
         let topic_alias = match &publish.properties {
@@ -332,13 +339,13 @@ impl MqttState {
         }
 
         match qos {
-            QoS::AtMostOnce => Ok(()),
+            QoS::AtMostOnce => Ok(None),
             QoS::AtLeastOnce => {
                 if !self.manual_acks {
                     let puback = PubAck::new(publish.pkid, None);
                     self.outgoing_puback(puback)?;
                 }
-                Ok(())
+                Ok(None)
             }
             QoS::ExactlyOnce => {
                 let pkid = publish.pkid;
@@ -348,12 +355,12 @@ impl MqttState {
                     let pubrec = PubRec::new(pkid, None);
                     self.outgoing_pubrec(pubrec)?;
                 }
-                Ok(())
+                Ok(None)
             }
         }
     }
 
-    fn handle_incoming_puback(&mut self, puback: &PubAck) -> Result<(), StateError> {
+    fn handle_incoming_puback(&mut self, puback: &PubAck) -> Result<Option<Packet>, StateError> {
         let publish = self
             .outgoing_pub
             .get_mut(puback.pkid as usize)
@@ -361,7 +368,8 @@ impl MqttState {
         let v = match publish.take() {
             Some(_) => {
                 self.inflight -= 1;
-                Ok(())
+
+                Ok(None)
             }
             None => {
                 error!("Unsolicited puback packet: {:?}", puback.pkid);
@@ -382,16 +390,17 @@ impl MqttState {
             self.inflight += 1;
 
             let pkid = publish.pkid;
-            Packet::Publish(publish).write(&mut self.write)?;
             let event = Event::Outgoing(Outgoing::Publish(pkid));
             self.events.push_back(event);
             self.collision_ping_count = 0;
+
+            return Ok(Some(Packet::Publish(publish)));
         }
 
         v
     }
 
-    fn handle_incoming_pubrec(&mut self, pubrec: &PubRec) -> Result<(), StateError> {
+    fn handle_incoming_pubrec(&mut self, pubrec: &PubRec) -> Result<Option<Packet>, StateError> {
         let publish = self
             .outgoing_pub
             .get_mut(pubrec.pkid as usize)
@@ -408,11 +417,10 @@ impl MqttState {
 
                 // NOTE: Inflight - 1 for qos2 in comp
                 self.outgoing_rel[pubrec.pkid as usize] = Some(pubrec.pkid);
-                Packet::PubRel(PubRel::new(pubrec.pkid, None)).write(&mut self.write)?;
-
                 let event = Event::Outgoing(Outgoing::PubRel(pubrec.pkid));
                 self.events.push_back(event);
-                Ok(())
+
+                Ok(Some(Packet::PubRel(PubRel::new(pubrec.pkid, None))))
             }
             None => {
                 error!("Unsolicited pubrec packet: {:?}", pubrec.pkid);
@@ -421,7 +429,7 @@ impl MqttState {
         }
     }
 
-    fn handle_incoming_pubrel(&mut self, pubrel: &PubRel) -> Result<(), StateError> {
+    fn handle_incoming_pubrel(&mut self, pubrel: &PubRel) -> Result<Option<Packet>, StateError> {
         let publish = self
             .incoming_pub
             .get_mut(pubrel.pkid as usize)
@@ -434,10 +442,10 @@ impl MqttState {
                     });
                 }
 
-                Packet::PubComp(PubComp::new(pubrel.pkid, None)).write(&mut self.write)?;
                 let event = Event::Outgoing(Outgoing::PubComp(pubrel.pkid));
                 self.events.push_back(event);
-                Ok(())
+
+                Ok(Some(Packet::PubComp(PubComp::new(pubrel.pkid, None))))
             }
             None => {
                 error!("Unsolicited pubrel packet: {:?}", pubrel.pkid);
@@ -446,14 +454,15 @@ impl MqttState {
         }
     }
 
-    fn handle_incoming_pubcomp(&mut self, pubcomp: &PubComp) -> Result<(), StateError> {
-        if let Some(publish) = self.check_collision(pubcomp.pkid) {
+    fn handle_incoming_pubcomp(&mut self, pubcomp: &PubComp) -> Result<Option<Packet>, StateError> {
+        let outgoing = self.check_collision(pubcomp.pkid).map(|publish| {
             let pkid = publish.pkid;
-            Packet::Publish(publish).write(&mut self.write)?;
             let event = Event::Outgoing(Outgoing::Publish(pkid));
             self.events.push_back(event);
             self.collision_ping_count = 0;
-        }
+
+            Packet::Publish(publish)
+        });
 
         let pubrel = self
             .outgoing_rel
@@ -468,7 +477,7 @@ impl MqttState {
                 }
 
                 self.inflight -= 1;
-                Ok(())
+                Ok(outgoing)
             }
             None => {
                 error!("Unsolicited pubcomp packet: {:?}", pubcomp.pkid);
@@ -477,14 +486,14 @@ impl MqttState {
         }
     }
 
-    fn handle_incoming_pingresp(&mut self) -> Result<(), StateError> {
+    fn handle_incoming_pingresp(&mut self) -> Result<Option<Packet>, StateError> {
         self.await_pingresp = false;
-        Ok(())
+        Ok(None)
     }
 
     /// Adds next packet identifier to QoS 1 and 2 publish packets and returns
     /// it buy wrapping publish in packet
-    fn outgoing_publish(&mut self, mut publish: Publish) -> Result<(), StateError> {
+    fn outgoing_publish(&mut self, mut publish: Publish) -> Result<Option<Packet>, StateError> {
         if publish.qos != QoS::AtMostOnce {
             if publish.pkid == 0 {
                 publish.pkid = self.next_pkid();
@@ -501,7 +510,7 @@ impl MqttState {
                 self.collision = Some(publish);
                 let event = Event::Outgoing(Outgoing::AwaitAck(pkid));
                 self.events.push_back(event);
-                return Ok(());
+                return Ok(None);
             }
 
             // if there is an existing publish at this pkid, this implies that broker hasn't acked this
@@ -532,43 +541,43 @@ impl MqttState {
             }
         };
 
-        Packet::Publish(publish).write(&mut self.write)?;
         let event = Event::Outgoing(Outgoing::Publish(pkid));
         self.events.push_back(event);
-        Ok(())
+
+        Ok(Some(Packet::Publish(publish)))
     }
 
-    fn outgoing_pubrel(&mut self, pubrel: PubRel) -> Result<(), StateError> {
+    fn outgoing_pubrel(&mut self, pubrel: PubRel) -> Result<Option<Packet>, StateError> {
         let pubrel = self.save_pubrel(pubrel)?;
 
         debug!("Pubrel. Pkid = {}", pubrel.pkid);
-        Packet::PubRel(PubRel::new(pubrel.pkid, None)).write(&mut self.write)?;
 
         let event = Event::Outgoing(Outgoing::PubRel(pubrel.pkid));
         self.events.push_back(event);
-        Ok(())
+
+        Ok(Some(Packet::PubRel(PubRel::new(pubrel.pkid, None))))
     }
 
-    fn outgoing_puback(&mut self, puback: PubAck) -> Result<(), StateError> {
+    fn outgoing_puback(&mut self, puback: PubAck) -> Result<Option<Packet>, StateError> {
         let pkid = puback.pkid;
-        Packet::PubAck(puback).write(&mut self.write)?;
         let event = Event::Outgoing(Outgoing::PubAck(pkid));
         self.events.push_back(event);
-        Ok(())
+
+        Ok(Some(Packet::PubAck(puback)))
     }
 
-    fn outgoing_pubrec(&mut self, pubrec: PubRec) -> Result<(), StateError> {
+    fn outgoing_pubrec(&mut self, pubrec: PubRec) -> Result<Option<Packet>, StateError> {
         let pkid = pubrec.pkid;
-        Packet::PubRec(pubrec).write(&mut self.write)?;
         let event = Event::Outgoing(Outgoing::PubRec(pkid));
         self.events.push_back(event);
-        Ok(())
+
+        Ok(Some(Packet::PubRec(pubrec)))
     }
 
     /// check when the last control packet/pingreq packet is received and return
     /// the status which tells if keep alive time has exceeded
     /// NOTE: status will be checked for zero keepalive times also
-    fn outgoing_ping(&mut self) -> Result<(), StateError> {
+    fn outgoing_ping(&mut self) -> Result<Option<Packet>, StateError> {
         let elapsed_in = self.last_incoming.elapsed();
         let elapsed_out = self.last_outgoing.elapsed();
 
@@ -591,13 +600,16 @@ impl MqttState {
             elapsed_in, elapsed_out,
         );
 
-        Packet::PingReq(PingReq).write(&mut self.write)?;
         let event = Event::Outgoing(Outgoing::PingReq);
         self.events.push_back(event);
-        Ok(())
+
+        Ok(Some(Packet::PingReq(PingReq)))
     }
 
-    fn outgoing_subscribe(&mut self, mut subscription: Subscribe) -> Result<(), StateError> {
+    fn outgoing_subscribe(
+        &mut self,
+        mut subscription: Subscribe,
+    ) -> Result<Option<Packet>, StateError> {
         if subscription.filters.is_empty() {
             return Err(StateError::EmptySubscription);
         }
@@ -611,13 +623,16 @@ impl MqttState {
         );
 
         let pkid = subscription.pkid;
-        Packet::Subscribe(subscription).write(&mut self.write)?;
         let event = Event::Outgoing(Outgoing::Subscribe(pkid));
         self.events.push_back(event);
-        Ok(())
+
+        Ok(Some(Packet::Subscribe(subscription)))
     }
 
-    fn outgoing_unsubscribe(&mut self, mut unsub: Unsubscribe) -> Result<(), StateError> {
+    fn outgoing_unsubscribe(
+        &mut self,
+        mut unsub: Unsubscribe,
+    ) -> Result<Option<Packet>, StateError> {
         let pkid = self.next_pkid();
         unsub.pkid = pkid;
 
@@ -627,19 +642,21 @@ impl MqttState {
         );
 
         let pkid = unsub.pkid;
-        Packet::Unsubscribe(unsub).write(&mut self.write)?;
         let event = Event::Outgoing(Outgoing::Unsubscribe(pkid));
         self.events.push_back(event);
-        Ok(())
+
+        Ok(Some(Packet::Unsubscribe(unsub)))
     }
 
-    fn outgoing_disconnect(&mut self, reason: DisconnectReasonCode) -> Result<(), StateError> {
+    fn outgoing_disconnect(
+        &mut self,
+        reason: DisconnectReasonCode,
+    ) -> Result<Option<Packet>, StateError> {
         debug!("Disconnect with {:?}", reason);
-
-        Packet::Disconnect(Disconnect::new(reason)).write(&mut self.write)?;
         let event = Event::Outgoing(Outgoing::Disconnect);
         self.events.push_back(event);
-        Ok(())
+
+        Ok(Some(Packet::Disconnect(Disconnect::new(reason))))
     }
 
     fn check_collision(&mut self, pkid: u16) -> Option<Publish> {
@@ -650,18 +667,6 @@ impl MqttState {
         }
 
         None
-    }
-
-    fn check_size(&self, pkt_size: usize) -> Result<(), StateError> {
-        let pkt_size = pkt_size.try_into()?;
-
-        match self.max_outgoing_packet_size {
-            Some(max_size) if pkt_size > max_size => Err(StateError::OutgoingPacketTooLarge {
-                pkt_size,
-                max: max_size,
-            }),
-            _ => Ok(()),
-        }
     }
 
     fn save_pubrel(&mut self, mut pubrel: PubRel) -> Result<PubRel, StateError> {

--- a/rumqttc/tests/reliability.rs
+++ b/rumqttc/tests/reliability.rs
@@ -570,7 +570,7 @@ async fn state_is_being_cleaned_properly_and_pending_request_calculated_properly
         if let Err(e) = res {
             match e {
                 ConnectionError::FlushTimeout => {
-                    assert!(eventloop.state.write.is_empty());
+                    assert!(eventloop.network.as_ref().unwrap().write.is_empty());
                     println!("State is being clean properly");
                 }
                 _ => {

--- a/rumqttc/tests/reliability.rs
+++ b/rumqttc/tests/reliability.rs
@@ -570,7 +570,7 @@ async fn state_is_being_cleaned_properly_and_pending_request_calculated_properly
         if let Err(e) = res {
             match e {
                 ConnectionError::FlushTimeout => {
-                    assert!(eventloop.network.as_ref().unwrap().write.is_empty());
+                    assert!(eventloop.network.is_none());
                     println!("State is being clean properly");
                 }
                 _ => {


### PR DESCRIPTION
<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

As discussed in #814 this simplifies `Network` using `Framed` and `Codec`

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
* `mqttbytes::Error` is no longer `Clone, Copy, PartialEq, Eq` and 2 new variants, for io and packet size limit
* Refactors different parts of the codebase to regularize and simplify.
* Deprecates bulk read and moves write buffer into `Network`, which might lead to issues with packets in the buffer being dropped when an error is faced. But this seems like premature-optimization to be frank

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
