### PR TITLE
feat: buffer `Framed<.., Codec>`  packets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,6 +1951,8 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
  "url",
  "ws_stream_tungstenite",
 ]
@@ -2540,6 +2542,17 @@ checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
  "rustls",
  "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/benchmarks/parsers/v4.rs
+++ b/benchmarks/parsers/v4.rs
@@ -1,6 +1,7 @@
 use bytes::{Buf, BytesMut};
 use rumqttc::mqttbytes::v4;
 use rumqttc::mqttbytes::QoS;
+use rumqttc::Packet;
 use std::time::Instant;
 
 mod common;
@@ -31,7 +32,7 @@ fn main() {
     let start = Instant::now();
     let mut packets = Vec::with_capacity(count);
     while output.has_remaining() {
-        let packet = v4::read(&mut output, 10 * 1024).unwrap();
+        let packet = Packet::read(&mut output, 10 * 1024).unwrap();
         packets.push(packet);
     }
 

--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Refactor `Network`, simplify with `Framed`
+
 ### Deprecated
 
 ### Removed

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -25,6 +25,7 @@ proxy = ["dep:async-http-proxy"]
 [dependencies]
 futures-util = { version = "0.3", default_features = false, features = ["std"] }
 tokio = { version = "1.36", features = ["rt", "macros", "io-util", "net", "time"] }
+tokio-util = { version = "0.7", features = ["codec"] }
 bytes = "1.5"
 log = "0.4"
 flume = { version = "0.11", default-features = false, features = ["async"] }
@@ -47,6 +48,7 @@ native-tls = { version = "0.2.11", optional = true }
 url = { version = "2", default-features = false, optional = true }
 # proxy
 async-http-proxy = { version = "1.2.5", features = ["runtime-tokio", "basic-auth"], optional = true }
+tokio-stream = "0.1.15"
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -23,7 +23,7 @@ websocket = ["dep:async-tungstenite", "dep:ws_stream_tungstenite", "dep:http"]
 proxy = ["dep:async-http-proxy"]
 
 [dependencies]
-futures-util = { version = "0.3", default_features = false, features = ["std"] }
+futures-util = { version = "0.3", default_features = false, features = ["std", "sink"] }
 tokio = { version = "1.36", features = ["rt", "macros", "io-util", "net", "time"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 bytes = "1.5"

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -2,7 +2,7 @@ use crate::{framed::Network, Transport};
 use crate::{Incoming, MqttState, NetworkOptions, Packet, Request, StateError};
 use crate::{MqttOptions, Outgoing};
 
-use crate::framed::N;
+use crate::framed::AsyncReadWrite;
 use crate::mqttbytes::v4::*;
 use flume::{bounded, Receiver, Sender};
 use tokio::net::{lookup_host, TcpSocket, TcpStream};
@@ -369,7 +369,7 @@ async fn network_connect(
         _ => options.broker_address(),
     };
 
-    let tcp_stream: Box<dyn N> = {
+    let tcp_stream: Box<dyn AsyncReadWrite> = {
         #[cfg(feature = "proxy")]
         match options.proxy() {
             Some(proxy) => proxy.connect(&domain, port, network_options).await?,

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -81,7 +81,7 @@ pub struct EventLoop {
     /// Pending packets from last session
     pub pending: VecDeque<Request>,
     /// Network connection to the broker
-    network: Option<Network>,
+    pub network: Option<Network>,
     /// Keep alive time
     keepalive_timeout: Option<Pin<Box<Sleep>>>,
     pub network_options: NetworkOptions,
@@ -189,7 +189,7 @@ impl EventLoop {
             o = network.readb(&mut self.state) => {
                 o?;
                 // flush all the acks and return first incoming packet
-                match time::timeout(network_timeout, network.flush(&mut self.state.write)).await {
+                match time::timeout(network_timeout, network.flush()).await {
                     Ok(inner) => inner?,
                     Err(_)=> return Err(ConnectionError::FlushTimeout),
                 };
@@ -229,8 +229,8 @@ impl EventLoop {
                 self.mqtt_options.pending_throttle
             ), if !self.pending.is_empty() || (!inflight_full && !collision) => match o {
                 Ok(request) => {
-                    self.state.handle_outgoing_packet(request)?;
-                    match time::timeout(network_timeout, network.flush(&mut self.state.write)).await {
+                    self.state.handle_outgoing_packet(request, network)?;
+                    match time::timeout(network_timeout, network.flush()).await {
                         Ok(inner) => inner?,
                         Err(_)=> return Err(ConnectionError::FlushTimeout),
                     };
@@ -245,8 +245,8 @@ impl EventLoop {
                 let timeout = self.keepalive_timeout.as_mut().unwrap();
                 timeout.as_mut().reset(Instant::now() + self.mqtt_options.keep_alive);
 
-                self.state.handle_outgoing_packet(Request::PingReq(PingReq))?;
-                match time::timeout(network_timeout, network.flush(&mut self.state.write)).await {
+                self.state.handle_outgoing_packet(Request::PingReq(PingReq), network)?;
+                match time::timeout(network_timeout, network.flush()).await {
                     Ok(inner) => inner?,
                     Err(_)=> return Err(ConnectionError::FlushTimeout),
                 };

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -241,8 +241,6 @@ impl EventLoop {
                 if let Some(outgoing) = self.state.handle_outgoing_packet(Request::PingReq(PingReq))? {
                     network.write(outgoing).await?;
                 }
-                // NOTE: Pings should be sent instantly
-                network.flush().await?;
 
                 Ok(self.state.events.pop_front().unwrap())
             }
@@ -488,7 +486,6 @@ async fn mqtt_connect(
 
     // send mqtt connect packet
     network.write(Packet::Connect(connect)).await?;
-    network.flush().await?;
 
     // validate connack
     match network.read().await? {

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -356,7 +356,7 @@ async fn network_connect(
             options.max_incoming_packet_size,
             options.max_outgoing_packet_size,
             network_timeout,
-            options.max_request_batch,
+            options.network_buffer_capacity,
         );
         return Ok(network);
     }
@@ -394,7 +394,7 @@ async fn network_connect(
             options.max_incoming_packet_size,
             options.max_outgoing_packet_size,
             network_timeout,
-            options.max_request_batch,
+            options.network_buffer_capacity,
         ),
         #[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]
         Transport::Tls(tls_config) => {
@@ -406,7 +406,7 @@ async fn network_connect(
                 options.max_incoming_packet_size,
                 options.max_outgoing_packet_size,
                 network_timeout,
-                options.max_request_batch,
+                options.network_buffer_capacity,
             )
         }
         #[cfg(unix)]
@@ -431,7 +431,7 @@ async fn network_connect(
                 options.max_incoming_packet_size,
                 options.max_outgoing_packet_size,
                 network_timeout,
-                options.max_request_batch,
+                options.network_buffer_capacity,
             )
         }
         #[cfg(all(feature = "use-rustls", feature = "websocket"))]
@@ -460,7 +460,7 @@ async fn network_connect(
                 options.max_incoming_packet_size,
                 options.max_outgoing_packet_size,
                 network_timeout,
-                options.max_request_batch,
+                options.network_buffer_capacity,
             )
         }
     };

--- a/rumqttc/src/framed.rs
+++ b/rumqttc/src/framed.rs
@@ -58,7 +58,7 @@ impl Network {
 
     pub async fn read(&mut self) -> io::Result<Incoming> {
         loop {
-            let required = match read(&mut self.read, self.max_incoming_size) {
+            let required = match Packet::read(&mut self.read, self.max_incoming_size) {
                 Ok(packet) => return Ok(packet),
                 Err(mqttbytes::Error::InsufficientBytes(required)) => required,
                 Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidData, e.to_string())),
@@ -75,7 +75,7 @@ impl Network {
     pub async fn readb(&mut self, state: &mut MqttState) -> Result<(), StateError> {
         let mut count = 0;
         loop {
-            match read(&mut self.read, self.max_incoming_size) {
+            match Packet::read(&mut self.read, self.max_incoming_size) {
                 Ok(packet) => {
                     state.handle_incoming_packet(packet)?;
 

--- a/rumqttc/src/framed.rs
+++ b/rumqttc/src/framed.rs
@@ -10,7 +10,7 @@ use std::io;
 /// appropriate to achieve performance
 pub struct Network {
     /// Socket for IO
-    socket: Box<dyn N>,
+    socket: Box<dyn AsyncReadWrite>,
     /// Buffered reads
     read: BytesMut,
     /// Maximum packet size
@@ -20,8 +20,8 @@ pub struct Network {
 }
 
 impl Network {
-    pub fn new(socket: impl N + 'static, max_incoming_size: usize) -> Network {
-        let socket = Box::new(socket) as Box<dyn N>;
+    pub fn new(socket: impl AsyncReadWrite + 'static, max_incoming_size: usize) -> Network {
+        let socket = Box::new(socket) as Box<dyn AsyncReadWrite>;
         Network {
             socket,
             read: BytesMut::with_capacity(10 * 1024),
@@ -117,5 +117,5 @@ impl Network {
     }
 }
 
-pub trait N: AsyncRead + AsyncWrite + Send + Unpin {}
-impl<T> N for T where T: AsyncRead + AsyncWrite + Send + Unpin {}
+pub trait AsyncReadWrite: AsyncRead + AsyncWrite + Send + Unpin {}
+impl<T> AsyncReadWrite for T where T: AsyncRead + AsyncWrite + Send + Unpin {}

--- a/rumqttc/src/framed.rs
+++ b/rumqttc/src/framed.rs
@@ -118,7 +118,9 @@ impl Network {
 
     pub async fn connect(&mut self, connect: Connect) -> io::Result<()> {
         self.write(Packet::Connect(connect))
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+
+        self.flush().await
     }
 
     pub fn write(&mut self, packet: Packet) -> Result<(), crate::state::StateError> {

--- a/rumqttc/src/framed.rs
+++ b/rumqttc/src/framed.rs
@@ -13,12 +13,8 @@ use std::time::Duration;
 pub struct Network {
     /// Frame MQTT packets from network connection
     framed: Framed<Box<dyn AsyncReadWrite>, Codec>,
-    /// Time within which network operations should complete
+    /// Time within which network write operations should complete
     timeout: Duration,
-    /// Number of packets currently written into buffer
-    buffered_packets: usize,
-    /// Maximum number of packets that can be buffered
-    max_buffered_packets: usize,
 }
 
 impl Network {
@@ -27,48 +23,37 @@ impl Network {
         max_incoming_size: usize,
         max_outgoing_size: usize,
         timeout: Duration,
-        max_buffered_packets: usize,
+        buffer_capacity: usize,
     ) -> Network {
         let socket = Box::new(socket) as Box<dyn AsyncReadWrite>;
         let codec = Codec {
             max_incoming_size,
             max_outgoing_size,
         };
-        let framed = Framed::new(socket, codec);
+        let framed = Framed::with_capacity(socket, codec, buffer_capacity);
 
-        Network {
-            framed,
-            timeout,
-            buffered_packets: 0,
-            max_buffered_packets,
-        }
+        Network { framed, timeout }
     }
 
     pub async fn read(&mut self) -> Result<Incoming, StateError> {
         match self.framed.next().await {
             Some(Ok(packet)) => Ok(packet),
-            Some(Err(mqttbytes::Error::InsufficientBytes(_))) | None => unreachable!(),
+            Some(Err(mqttbytes::Error::InsufficientBytes(_))) => unreachable!(),
             Some(Err(e)) => Err(StateError::Deserialization(e)),
+            None => Err(StateError::ConnectionClosed),
         }
     }
 
-    /// Write packets into buffer, flush after `MAX_BUFFERED_PACKETS``
+    /// Write packets into buffer, flush instantly for `PingReq`/`PingResp`
     pub async fn write(&mut self, packet: Packet) -> Result<(), StateError> {
-        self.buffered_packets += 1;
-        self.framed
-            .feed(packet)
-            .await
-            .map_err(StateError::Deserialization)?;
-        if self.buffered_packets >= self.max_buffered_packets {
-            self.flush().await?;
+        match timeout(self.timeout, self.framed.send(packet)).await {
+            Ok(inner) => inner.map_err(StateError::Deserialization),
+            Err(_) => Err(StateError::FlushTimeout),
         }
-
-        Ok(())
     }
 
     /// Force flush all packets in buffer, reset count
     pub async fn flush(&mut self) -> Result<(), StateError> {
-        self.buffered_packets = 0;
         match timeout(self.timeout, self.framed.flush()).await {
             Ok(inner) => inner.map_err(StateError::Deserialization),
             Err(_) => Err(StateError::FlushTimeout),

--- a/rumqttc/src/framed.rs
+++ b/rumqttc/src/framed.rs
@@ -100,9 +100,11 @@ impl Network {
                     }
                 }
                 // If some packets are already framed, return those
-                Err(mqttbytes::Error::InsufficientBytes(_)) if count > 0 => break,
-                // TODO: figure out how not to block
-                Ok(_) => break,
+                Err(mqttbytes::Error::InsufficientBytes(_)) | Ok(_) if count > 0 => break,
+                // NOTE: read atleast 1 packet
+                Ok(_) => {
+                    self.read_bytes(2).await?;
+                }
                 // Wait for more bytes until a frame can be created
                 Err(mqttbytes::Error::InsufficientBytes(required)) => {
                     self.read_bytes(required).await?;

--- a/rumqttc/src/framed.rs
+++ b/rumqttc/src/framed.rs
@@ -1,25 +1,22 @@
-use bytes::BytesMut;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
-use tokio_util::codec::{Decoder, Encoder};
+use futures_util::{SinkExt, StreamExt};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::time::timeout;
+use tokio_util::codec::Framed;
 
 use crate::mqttbytes::{self, v4::*};
 use crate::{Incoming, MqttState, StateError};
-use std::io;
+use std::time::Duration;
 
 /// Network transforms packets <-> frames efficiently. It takes
 /// advantage of pre-allocation, buffering and vectorization when
 /// appropriate to achieve performance
 pub struct Network {
-    /// Socket for IO
-    socket: Box<dyn AsyncReadWrite>,
-    /// Buffered reads
-    read: BytesMut,
-    /// Buffered writes
-    pub write: BytesMut,
-    /// Use to decode MQTT packets
-    codec: Codec,
+    /// Frame MQTT packets from network connection
+    framed: Framed<Box<dyn AsyncReadWrite>, Codec>,
     /// Maximum readv count
     max_readb_count: usize,
+    /// Time within which network operations should complete
+    timeout: Duration,
 }
 
 impl Network {
@@ -27,59 +24,27 @@ impl Network {
         socket: impl AsyncReadWrite + 'static,
         max_incoming_size: usize,
         max_outgoing_size: usize,
+        timeout: Duration,
     ) -> Network {
         let socket = Box::new(socket) as Box<dyn AsyncReadWrite>;
+        let codec = Codec {
+            max_incoming_size,
+            max_outgoing_size,
+        };
+        let framed = Framed::new(socket, codec);
+
         Network {
-            socket,
-            read: BytesMut::with_capacity(10 * 1024),
-            write: BytesMut::with_capacity(10 * 1024),
-            codec: Codec {
-                max_incoming_size,
-                max_outgoing_size,
-            },
+            framed,
             max_readb_count: 10,
+            timeout,
         }
     }
 
-    /// Reads more than 'required' bytes to frame a packet into self.read buffer
-    async fn read_bytes(&mut self, required: usize) -> io::Result<usize> {
-        let mut total_read = 0;
-        loop {
-            let read = self.socket.read_buf(&mut self.read).await?;
-            if 0 == read {
-                return if self.read.is_empty() {
-                    Err(io::Error::new(
-                        io::ErrorKind::ConnectionAborted,
-                        "connection closed by peer",
-                    ))
-                } else {
-                    Err(io::Error::new(
-                        io::ErrorKind::ConnectionReset,
-                        "connection reset by peer",
-                    ))
-                };
-            }
-
-            total_read += read;
-            if total_read >= required {
-                return Ok(total_read);
-            }
-        }
-    }
-
-    pub async fn read(&mut self) -> io::Result<Incoming> {
-        loop {
-            let required = match self.codec.decode(&mut self.read) {
-                Ok(Some(packet)) => return Ok(packet),
-                // TODO: figure out how not to block
-                Ok(_) => 2,
-                Err(mqttbytes::Error::InsufficientBytes(required)) => required,
-                Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidData, e.to_string())),
-            };
-
-            // read more packets until a frame can be created. This function
-            // blocks until a frame can be created. Use this in a select! branch
-            self.read_bytes(required).await?;
+    pub async fn read(&mut self) -> Result<Incoming, StateError> {
+        match self.framed.next().await {
+            Some(Ok(packet)) => Ok(packet),
+            Some(Err(mqttbytes::Error::InsufficientBytes(_))) | None => unreachable!(),
+            Some(Err(e)) => Err(StateError::Deserialization(e)),
         }
     }
 
@@ -88,10 +53,10 @@ impl Network {
     pub async fn readb(&mut self, state: &mut MqttState) -> Result<(), StateError> {
         let mut count = 0;
         loop {
-            match self.codec.decode(&mut self.read) {
-                Ok(Some(packet)) => {
+            match self.framed.next().await {
+                Some(Ok(packet)) => {
                     if let Some(packet) = state.handle_incoming_packet(packet)? {
-                        self.write(packet)?;
+                        self.send(packet).await?;
                     }
 
                     count += 1;
@@ -100,43 +65,21 @@ impl Network {
                     }
                 }
                 // If some packets are already framed, return those
-                Err(mqttbytes::Error::InsufficientBytes(_)) | Ok(_) if count > 0 => break,
+                Some(Err(mqttbytes::Error::InsufficientBytes(_))) | None if count > 0 => break,
                 // NOTE: read atleast 1 packet
-                Ok(_) => {
-                    self.read_bytes(2).await?;
-                }
-                // Wait for more bytes until a frame can be created
-                Err(mqttbytes::Error::InsufficientBytes(required)) => {
-                    self.read_bytes(required).await?;
-                }
-                Err(e) => return Err(StateError::Deserialization(e)),
+                Some(Err(mqttbytes::Error::InsufficientBytes(_))) | None => unreachable!(),
+                Some(Err(e)) => return Err(StateError::Deserialization(e)),
             };
         }
 
         Ok(())
     }
 
-    pub async fn connect(&mut self, connect: Connect) -> io::Result<()> {
-        self.write(Packet::Connect(connect))
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
-
-        self.flush().await
-    }
-
-    pub fn write(&mut self, packet: Packet) -> Result<(), crate::state::StateError> {
-        self.codec
-            .encode(packet, &mut self.write)
-            .map_err(Into::into)
-    }
-
-    pub async fn flush(&mut self) -> io::Result<()> {
-        if self.write.is_empty() {
-            return Ok(());
+    pub async fn send(&mut self, packet: Packet) -> Result<(), crate::state::StateError> {
+        match timeout(self.timeout, self.framed.send(packet)).await {
+            Ok(inner) => inner.map_err(Into::into),
+            Err(_) => Err(StateError::FlushTimeout),
         }
-
-        self.socket.write_all(&self.write[..]).await?;
-        self.write.clear();
-        Ok(())
     }
 }
 

--- a/rumqttc/src/framed.rs
+++ b/rumqttc/src/framed.rs
@@ -14,6 +14,8 @@ pub struct Network {
     socket: Box<dyn AsyncReadWrite>,
     /// Buffered reads
     read: BytesMut,
+    /// Buffered writes
+    pub write: BytesMut,
     /// Use to decode MQTT packets
     codec: Codec,
     /// Maximum readv count
@@ -30,6 +32,7 @@ impl Network {
         Network {
             socket,
             read: BytesMut::with_capacity(10 * 1024),
+            write: BytesMut::with_capacity(10 * 1024),
             codec: Codec {
                 max_incoming_size,
                 max_outgoing_size,
@@ -87,7 +90,7 @@ impl Network {
         loop {
             match self.codec.decode(&mut self.read) {
                 Ok(Some(packet)) => {
-                    state.handle_incoming_packet(packet)?;
+                    state.handle_incoming_packet(packet, self)?;
 
                     count += 1;
                     if count >= self.max_readb_count {
@@ -119,13 +122,17 @@ impl Network {
         Ok(())
     }
 
-    pub async fn flush(&mut self, write: &mut BytesMut) -> io::Result<()> {
-        if write.is_empty() {
+    pub fn write(&mut self, packet: Packet) -> Result<(), crate::mqttbytes::Error> {
+        self.codec.encode(packet, &mut self.write)
+    }
+
+    pub async fn flush(&mut self) -> io::Result<()> {
+        if self.write.is_empty() {
             return Ok(());
         }
 
-        self.socket.write_all(&write[..]).await?;
-        write.clear();
+        self.socket.write_all(&self.write[..]).await?;
+        self.write.clear();
         Ok(())
     }
 }

--- a/rumqttc/src/framed.rs
+++ b/rumqttc/src/framed.rs
@@ -15,6 +15,8 @@ pub struct Network {
     framed: Framed<Box<dyn AsyncReadWrite>, Codec>,
     /// Time within which network write operations should complete
     timeout: Duration,
+    /// Capacity upto which buffering is good
+    buffer_capacity: usize,
 }
 
 impl Network {
@@ -32,7 +34,11 @@ impl Network {
         };
         let framed = Framed::with_capacity(socket, codec, buffer_capacity);
 
-        Network { framed, timeout }
+        Network {
+            framed,
+            timeout,
+            buffer_capacity,
+        }
     }
 
     pub async fn read(&mut self) -> Result<Incoming, StateError> {
@@ -44,12 +50,24 @@ impl Network {
         }
     }
 
-    /// Write packets into buffer, flush instantly for `PingReq`/`PingResp`
+    /// Write packets into buffer, flushes `Connect`/`PingReq`/`PingResp` packets instantly,
+    /// or on breaching buffer capacity
     pub async fn write(&mut self, packet: Packet) -> Result<(), StateError> {
-        match timeout(self.timeout, self.framed.send(packet)).await {
-            Ok(inner) => inner.map_err(StateError::Deserialization),
-            Err(_) => Err(StateError::FlushTimeout),
+        let packet_size = packet.size();
+        let should_flush = match packet {
+            Packet::Connect(_) | Packet::PingReq | Packet::PingResp => true,
+            _ => false,
+        };
+        self.framed
+            .feed(packet)
+            .await
+            .map_err(StateError::Deserialization)?;
+
+        if should_flush || self.framed.write_buffer().len() + packet_size >= self.buffer_capacity {
+            self.flush().await?;
         }
+
+        Ok(())
     }
 
     /// Force flush all packets in buffer, reset count

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -200,25 +200,6 @@ pub enum Request {
     Disconnect(Disconnect),
 }
 
-impl Request {
-    fn size(&self) -> usize {
-        match &self {
-            Request::Publish(publish) => publish.size(),
-            Request::PubAck(puback) => puback.size(),
-            Request::PubRec(pubrec) => pubrec.size(),
-            Request::PubComp(pubcomp) => pubcomp.size(),
-            Request::PubRel(pubrel) => pubrel.size(),
-            Request::PingReq(pingreq) => pingreq.size(),
-            Request::PingResp(pingresp) => pingresp.size(),
-            Request::Subscribe(subscribe) => subscribe.size(),
-            Request::SubAck(suback) => suback.size(),
-            Request::Unsubscribe(unsubscribe) => unsubscribe.size(),
-            Request::UnsubAck(unsuback) => unsuback.size(),
-            Request::Disconnect(disconn) => disconn.size(),
-        }
-    }
-}
-
 impl From<Publish> for Request {
     fn from(publish: Publish) -> Request {
         Request::Publish(publish)

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -483,7 +483,7 @@ impl MqttOptions {
             max_incoming_packet_size: 10 * 1024,
             max_outgoing_packet_size: 10 * 1024,
             request_channel_capacity: 10,
-            max_request_batch: 0,
+            max_request_batch: 10,
             pending_throttle: Duration::from_micros(0),
             inflight: 100,
             last_will: None,
@@ -640,6 +640,12 @@ impl MqttOptions {
     /// Request channel capacity
     pub fn request_channel_capacity(&self) -> usize {
         self.request_channel_capacity
+    }
+
+    /// set maximum request batch count
+    pub fn set_max_request_batch(&mut self, max_request_batch: usize) -> &mut Self {
+        self.max_request_batch = max_request_batch;
+        self
     }
 
     /// Enables throttling and sets outoing message rate to the specified 'rate'

--- a/rumqttc/src/mqttbytes/mod.rs
+++ b/rumqttc/src/mqttbytes/mod.rs
@@ -13,7 +13,7 @@ pub mod v4;
 pub use topic::*;
 
 /// Error during serialization and deserialization
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("Expected Connect, received: {0:?}")]
     NotConnect(PacketType),
@@ -60,6 +60,8 @@ pub enum Error {
     /// proceed further
     #[error("At least {0} more bytes required to frame packet")]
     InsufficientBytes(usize),
+    #[error("IO: {0}")]
+    Io(#[from] std::io::Error),
 }
 
 /// MQTT packet type

--- a/rumqttc/src/mqttbytes/mod.rs
+++ b/rumqttc/src/mqttbytes/mod.rs
@@ -62,6 +62,8 @@ pub enum Error {
     InsufficientBytes(usize),
     #[error("IO: {0}")]
     Io(#[from] std::io::Error),
+    #[error("Cannot send packet of size '{pkt_size:?}'. It's greater than the broker's maximum packet size of: '{max:?}'")]
+    OutgoingPacketTooLarge { pkt_size: usize, max: usize },
 }
 
 /// MQTT packet type

--- a/rumqttc/src/mqttbytes/v4/codec.rs
+++ b/rumqttc/src/mqttbytes/v4/codec.rs
@@ -28,10 +28,43 @@ impl Decoder for Codec {
 
 impl Encoder<Packet> for Codec {
     type Error = Error;
-    
+
     fn encode(&mut self, item: Packet, dst: &mut BytesMut) -> Result<(), Self::Error> {
         item.write(dst, self.max_outgoing_size)?;
 
         Ok(())
-    } 
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::BytesMut;
+    use tokio_util::codec::Encoder;
+
+    use super::Codec;
+    use crate::{mqttbytes::Error, Packet, Publish, QoS};
+
+    #[test]
+    fn outgoing_max_packet_size_check() {
+        let mut buf = BytesMut::new();
+        let mut codec = Codec {
+            max_incoming_size: 100,
+            max_outgoing_size: 200,
+        };
+
+        let mut small_publish = Publish::new("hello/world", QoS::AtLeastOnce, vec![1; 100]);
+        small_publish.pkid = 1;
+        codec
+            .encode(Packet::Publish(small_publish), &mut buf)
+            .unwrap();
+
+        let large_publish = Publish::new("hello/world", QoS::AtLeastOnce, vec![1; 265]);
+        match codec.encode(Packet::Publish(large_publish), &mut buf) {
+            Err(Error::OutgoingPacketTooLarge {
+                pkt_size: 281,
+                max: 200,
+            }) => {}
+            _ => unreachable!(),
+        }
+    }
 }

--- a/rumqttc/src/mqttbytes/v4/codec.rs
+++ b/rumqttc/src/mqttbytes/v4/codec.rs
@@ -1,0 +1,24 @@
+use bytes::{Buf, BytesMut};
+use tokio_util::codec::Decoder;
+
+use super::{Error, Packet};
+
+/// MQTT v4 codec
+pub struct Codec {
+    /// Maximum packet size
+    pub max_incoming_size: usize,
+}
+
+impl Decoder for Codec {
+    type Item = Packet;
+    type Error = Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        if src.remaining() == 0 {
+            return Ok(None);
+        }
+
+        let packet = Packet::read(src, self.max_incoming_size)?;
+        Ok(Some(packet))
+    }
+}

--- a/rumqttc/src/mqttbytes/v4/codec.rs
+++ b/rumqttc/src/mqttbytes/v4/codec.rs
@@ -1,12 +1,15 @@
 use bytes::{Buf, BytesMut};
-use tokio_util::codec::Decoder;
+use tokio_util::codec::{Decoder, Encoder};
 
 use super::{Error, Packet};
 
 /// MQTT v4 codec
+#[derive(Debug, Clone)]
 pub struct Codec {
-    /// Maximum packet size
+    /// Maximum packet size allowed by client
     pub max_incoming_size: usize,
+    /// Maximum packet size allowed by broker
+    pub max_outgoing_size: usize,
 }
 
 impl Decoder for Codec {
@@ -21,4 +24,14 @@ impl Decoder for Codec {
         let packet = Packet::read(src, self.max_incoming_size)?;
         Ok(Some(packet))
     }
+}
+
+impl Encoder<Packet> for Codec {
+    type Error = Error;
+    
+    fn encode(&mut self, item: Packet, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        item.write(dst, self.max_outgoing_size)?;
+
+        Ok(())
+    } 
 }

--- a/rumqttc/src/mqttbytes/v4/codec.rs
+++ b/rumqttc/src/mqttbytes/v4/codec.rs
@@ -1,4 +1,4 @@
-use bytes::{Buf, BytesMut};
+use bytes::BytesMut;
 use tokio_util::codec::{Decoder, Encoder};
 
 use super::{Error, Packet};
@@ -17,12 +17,15 @@ impl Decoder for Codec {
     type Error = Error;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        if src.remaining() == 0 {
-            return Ok(None);
+        match Packet::read(src, self.max_incoming_size) {
+            Ok(packet) => Ok(Some(packet)),
+            // NOTE: not enough bytes to construct packet, reserve enough in src buffer
+            Err(Error::InsufficientBytes(b)) => {
+                src.reserve(b);
+                Ok(None)
+            }
+            Err(e) => Err(e),
         }
-
-        let packet = Packet::read(src, self.max_incoming_size)?;
-        Ok(Some(packet))
     }
 }
 

--- a/rumqttc/src/mqttbytes/v4/connack.rs
+++ b/rumqttc/src/mqttbytes/v4/connack.rs
@@ -61,6 +61,13 @@ impl ConnAck {
 
         Ok(1 + count + len)
     }
+
+    pub fn size(&self) -> usize {
+        let len = self.len();
+        let remaining_len_size = len_len(len);
+
+        1 + remaining_len_size + len
+    }
 }
 
 /// Connection return code type

--- a/rumqttc/src/mqttbytes/v4/connect.rs
+++ b/rumqttc/src/mqttbytes/v4/connect.rs
@@ -132,6 +132,13 @@ impl Connect {
         buffer[flags_index] = connect_flags;
         Ok(1 + count + len)
     }
+
+    pub fn size(&self) -> usize {
+        let len = self.len();
+        let remaining_len_size = len_len(len);
+
+        1 + remaining_len_size + len
+    }
 }
 
 /// LastWill that broker forwards on behalf of the client

--- a/rumqttc/src/mqttbytes/v4/mod.rs
+++ b/rumqttc/src/mqttbytes/v4/mod.rs
@@ -47,6 +47,27 @@ pub enum Packet {
     Disconnect,
 }
 
+impl Packet {
+    pub fn size(&self) -> usize {
+        match self {
+            Self::Publish(publish) => publish.size(),
+            Self::Subscribe(subscription) => subscription.size(),
+            Self::Unsubscribe(unsubscribe) => unsubscribe.size(),
+            Self::ConnAck(ack) => ack.size(),
+            Self::PubAck(ack) => ack.size(),
+            Self::SubAck(ack) => ack.size(),
+            Self::UnsubAck(unsuback) => unsuback.size(),
+            Self::PubRec(pubrec) => pubrec.size(),
+            Self::PubRel(pubrel) => pubrel.size(),
+            Self::PubComp(pubcomp) => pubcomp.size(),
+            Self::Connect(connect) => connect.size(),
+            Self::PingReq => PingReq.size(),
+            Self::PingResp => PingResp.size(),
+            Self::Disconnect => Disconnect.size(),
+        }
+    }
+}
+
 /// Reads a stream of bytes and extracts next MQTT packet out of it
 pub fn read(stream: &mut BytesMut, max_size: usize) -> Result<Packet, Error> {
     let fixed_header = check(stream.iter(), max_size)?;

--- a/rumqttc/src/mqttbytes/v4/mod.rs
+++ b/rumqttc/src/mqttbytes/v4/mod.rs
@@ -15,6 +15,7 @@ mod subscribe;
 mod unsuback;
 mod unsubscribe;
 
+pub use codec::*;
 pub use connack::*;
 pub use connect::*;
 pub use disconnect::*;
@@ -28,7 +29,6 @@ pub use suback::*;
 pub use subscribe::*;
 pub use unsuback::*;
 pub use unsubscribe::*;
-pub use codec::*;
 
 /// Encapsulates all MQTT packet types
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -116,7 +116,7 @@ impl Packet {
             return Err(Error::OutgoingPacketTooLarge {
                 pkt_size: self.size(),
                 max: max_size,
-            })
+            });
         }
 
         match self {

--- a/rumqttc/src/mqttbytes/v4/mod.rs
+++ b/rumqttc/src/mqttbytes/v4/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+mod codec;
 mod connack;
 mod connect;
 mod disconnect;
@@ -27,6 +28,7 @@ pub use suback::*;
 pub use subscribe::*;
 pub use unsuback::*;
 pub use unsubscribe::*;
+pub use codec::*;
 
 /// Encapsulates all MQTT packet types
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/rumqttc/src/mqttbytes/v4/mod.rs
+++ b/rumqttc/src/mqttbytes/v4/mod.rs
@@ -111,7 +111,14 @@ impl Packet {
     }
 
     /// Serializes the MQTT packet into a stream of bytes
-    pub fn write(&self, stream: &mut BytesMut) -> Result<usize, Error> {
+    pub fn write(&self, stream: &mut BytesMut, max_size: usize) -> Result<usize, Error> {
+        if self.size() > max_size {
+            return Err(Error::OutgoingPacketTooLarge {
+                pkt_size: self.size(),
+                max: max_size,
+            })
+        }
+
         match self {
             Packet::Connect(c) => c.write(stream),
             Packet::ConnAck(c) => c.write(stream),

--- a/rumqttc/src/proxy.rs
+++ b/rumqttc/src/proxy.rs
@@ -1,5 +1,5 @@
 use crate::eventloop::socket_connect;
-use crate::framed::N;
+use crate::framed::AsyncReadWrite;
 use crate::NetworkOptions;
 
 use std::io;
@@ -46,10 +46,10 @@ impl Proxy {
         broker_addr: &str,
         broker_port: u16,
         network_options: NetworkOptions,
-    ) -> Result<Box<dyn N>, ProxyError> {
+    ) -> Result<Box<dyn AsyncReadWrite>, ProxyError> {
         let proxy_addr = format!("{}:{}", self.addr, self.port);
 
-        let tcp: Box<dyn N> = Box::new(socket_connect(proxy_addr, network_options).await?);
+        let tcp: Box<dyn AsyncReadWrite> = Box::new(socket_connect(proxy_addr, network_options).await?);
         let mut tcp = match self.ty {
             ProxyType::Http => tcp,
             #[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]
@@ -67,7 +67,7 @@ impl ProxyAuth {
         self,
         host: &str,
         port: u16,
-        tcp_stream: &mut Box<dyn N>,
+        tcp_stream: &mut Box<dyn AsyncReadWrite>,
     ) -> Result<(), ProxyError> {
         match self {
             Self::None => async_http_proxy::http_connect_tokio(tcp_stream, host, port).await?,

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -703,7 +703,7 @@ mod test {
         let publish = build_incoming_publish(QoS::ExactlyOnce, 1);
 
         mqtt.handle_incoming_publish(&publish).unwrap();
-        let packet = read(&mut mqtt.write, 10 * 1024).unwrap();
+        let packet = Packet::read(&mut mqtt.write, 10 * 1024).unwrap();
         match packet {
             Packet::PubRec(pubrec) => assert_eq!(pubrec.pkid, 1),
             _ => panic!("Invalid network request: {:?}", packet),
@@ -770,14 +770,14 @@ mod test {
 
         let publish = build_outgoing_publish(QoS::ExactlyOnce);
         mqtt.outgoing_publish(publish).unwrap();
-        let packet = read(&mut mqtt.write, 10 * 1024).unwrap();
+        let packet = Packet::read(&mut mqtt.write, 10 * 1024).unwrap();
         match packet {
             Packet::Publish(publish) => assert_eq!(publish.pkid, 1),
             packet => panic!("Invalid network request: {:?}", packet),
         }
 
         mqtt.handle_incoming_pubrec(&PubRec::new(1)).unwrap();
-        let packet = read(&mut mqtt.write, 10 * 1024).unwrap();
+        let packet = Packet::read(&mut mqtt.write, 10 * 1024).unwrap();
         match packet {
             Packet::PubRel(pubrel) => assert_eq!(pubrel.pkid, 1),
             packet => panic!("Invalid network request: {:?}", packet),
@@ -790,14 +790,14 @@ mod test {
         let publish = build_incoming_publish(QoS::ExactlyOnce, 1);
 
         mqtt.handle_incoming_publish(&publish).unwrap();
-        let packet = read(&mut mqtt.write, 10 * 1024).unwrap();
+        let packet = Packet::read(&mut mqtt.write, 10 * 1024).unwrap();
         match packet {
             Packet::PubRec(pubrec) => assert_eq!(pubrec.pkid, 1),
             packet => panic!("Invalid network request: {:?}", packet),
         }
 
         mqtt.handle_incoming_pubrel(&PubRel::new(1)).unwrap();
-        let packet = read(&mut mqtt.write, 10 * 1024).unwrap();
+        let packet = Packet::read(&mut mqtt.write, 10 * 1024).unwrap();
         match packet {
             Packet::PubComp(pubcomp) => assert_eq!(pubcomp.pkid, 1),
             packet => panic!("Invalid network request: {:?}", packet),

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -31,6 +31,8 @@ pub enum StateError {
     Deserialization(#[from] mqttbytes::Error),
     #[error("Flush timeout")]
     FlushTimeout,
+    #[error("Connection Closed")]
+    ConnectionClosed,
 }
 
 /// State of the mqtt connection.

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -29,6 +29,8 @@ pub enum StateError {
     EmptySubscription,
     #[error("Mqtt serialization/deserialization error: {0}")]
     Deserialization(#[from] mqttbytes::Error),
+    #[error("Flush timeout")]
+    FlushTimeout,
 }
 
 /// State of the mqtt connection.

--- a/rumqttc/src/tls.rs
+++ b/rumqttc/src/tls.rs
@@ -16,7 +16,7 @@ use std::io::{BufReader, Cursor};
 #[cfg(feature = "use-rustls")]
 use std::sync::Arc;
 
-use crate::framed::N;
+use crate::framed::AsyncReadWrite;
 use crate::TlsConfiguration;
 
 #[cfg(feature = "use-native-tls")]
@@ -166,9 +166,9 @@ pub async fn tls_connect(
     addr: &str,
     _port: u16,
     tls_config: &TlsConfiguration,
-    tcp: Box<dyn N>,
-) -> Result<Box<dyn N>, Error> {
-    let tls: Box<dyn N> = match tls_config {
+    tcp: Box<dyn AsyncReadWrite>,
+) -> Result<Box<dyn AsyncReadWrite>, Error> {
+    let tls: Box<dyn AsyncReadWrite> = match tls_config {
         #[cfg(feature = "use-rustls")]
         TlsConfiguration::Simple { .. } | TlsConfiguration::Rustls(_) => {
             let connector = rustls_connector(tls_config).await?;

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -2,7 +2,7 @@ use super::framed::Network;
 use super::mqttbytes::v5::*;
 use super::{Incoming, MqttOptions, MqttState, Outgoing, Request, StateError, Transport};
 use crate::eventloop::socket_connect;
-use crate::framed::N;
+use crate::framed::AsyncReadWrite;
 
 use flume::{bounded, Receiver, Sender};
 use tokio::select;
@@ -304,7 +304,7 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
         _ => options.broker_address(),
     };
 
-    let tcp_stream: Box<dyn N> = {
+    let tcp_stream: Box<dyn AsyncReadWrite> = {
         #[cfg(feature = "proxy")]
         match options.proxy() {
             Some(proxy) => {

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -305,7 +305,7 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
             max_incoming_pkt_size,
             max_outgoing_pkt_size,
             network_timeout,
-            options.max_request_batch,
+            options.network_buffer_capacity,
         );
         return Ok(network);
     }
@@ -347,7 +347,7 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
             max_incoming_pkt_size,
             max_outgoing_pkt_size,
             network_timeout,
-            options.max_request_batch,
+            options.network_buffer_capacity,
         ),
         #[cfg(any(feature = "use-native-tls", feature = "use-rustls"))]
         Transport::Tls(tls_config) => {
@@ -359,7 +359,7 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
                 max_incoming_pkt_size,
                 max_outgoing_pkt_size,
                 network_timeout,
-                options.max_request_batch,
+                options.network_buffer_capacity,
             )
         }
         #[cfg(unix)]
@@ -384,7 +384,7 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
                 max_incoming_pkt_size,
                 max_outgoing_pkt_size,
                 network_timeout,
-                options.max_request_batch,
+                options.network_buffer_capacity,
             )
         }
         #[cfg(all(feature = "use-rustls", feature = "websocket"))]
@@ -413,7 +413,7 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
                 max_incoming_pkt_size,
                 max_outgoing_pkt_size,
                 network_timeout,
-                options.max_request_batch,
+                options.network_buffer_capacity,
             )
         }
     };

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -236,7 +236,6 @@ impl EventLoop {
                 if let Some(outgoing) = self.state.handle_outgoing_packet(Request::PingReq)? {
                     network.write(outgoing).await?;
                 }
-                network.flush().await?;
 
                 Ok(self.state.events.pop_front().unwrap())
             }
@@ -442,7 +441,6 @@ async fn mqtt_connect(
     network
         .write(Packet::Connect(connect, last_will, None))
         .await?;
-    network.flush().await?;
 
     // validate connack
     match network.read().await? {

--- a/rumqttc/src/v5/framed.rs
+++ b/rumqttc/src/v5/framed.rs
@@ -1,132 +1,53 @@
-use bytes::BytesMut;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use futures_util::SinkExt;
+use tokio::time::timeout;
+use tokio_stream::StreamExt;
+use tokio_util::codec::Framed;
 
-use super::mqttbytes;
-use super::mqttbytes::v5::{Connect, Login, Packet};
-use super::{Incoming, MqttOptions, MqttState, StateError};
-use std::io;
+use crate::framed::AsyncReadWrite;
+
+use super::mqttbytes::v5::Packet;
+use super::{mqttbytes, Codec};
+use super::{Incoming, StateError};
+use std::time::Duration;
 
 /// Network transforms packets <-> frames efficiently. It takes
 /// advantage of pre-allocation, buffering and vectorization when
 /// appropriate to achieve performance
 pub struct Network {
-    /// Socket for IO
-    socket: Box<dyn N>,
-    /// Buffered reads
-    read: BytesMut,
-    /// Maximum packet size
-    max_incoming_size: Option<usize>,
-    /// Maximum readv count
-    max_readb_count: usize,
+    /// Frame MQTT packets from network connection
+    framed: Framed<Box<dyn AsyncReadWrite>, Codec>,
+    /// Time within which network operations should complete
+    timeout: Duration,
 }
-
 impl Network {
-    pub fn new(socket: impl N + 'static, max_incoming_size: Option<usize>) -> Network {
-        let socket = Box::new(socket) as Box<dyn N>;
-        Network {
-            socket,
-            read: BytesMut::with_capacity(10 * 1024),
+    pub fn new(
+        socket: impl AsyncReadWrite + 'static,
+        max_incoming_size: Option<usize>,
+        max_outgoing_size: Option<usize>,
+        timeout: Duration,
+    ) -> Network {
+        let socket = Box::new(socket) as Box<dyn AsyncReadWrite>;
+        let codec = Codec {
             max_incoming_size,
-            max_readb_count: 10,
-        }
-    }
-
-    /// Reads more than 'required' bytes to frame a packet into self.read buffer
-    async fn read_bytes(&mut self, required: usize) -> io::Result<usize> {
-        let mut total_read = 0;
-        loop {
-            let read = self.socket.read_buf(&mut self.read).await?;
-            if 0 == read {
-                return if self.read.is_empty() {
-                    Err(io::Error::new(
-                        io::ErrorKind::ConnectionAborted,
-                        "connection closed by peer",
-                    ))
-                } else {
-                    Err(io::Error::new(
-                        io::ErrorKind::ConnectionReset,
-                        "connection reset by peer",
-                    ))
-                };
-            }
-
-            total_read += read;
-            if total_read >= required {
-                return Ok(total_read);
-            }
-        }
-    }
-
-    pub async fn read(&mut self) -> io::Result<Incoming> {
-        loop {
-            let required = match Packet::read(&mut self.read, self.max_incoming_size) {
-                Ok(packet) => return Ok(packet),
-                Err(mqttbytes::Error::InsufficientBytes(required)) => required,
-                Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidData, e.to_string())),
-            };
-
-            // read more packets until a frame can be created. This function
-            // blocks until a frame can be created. Use this in a select! branch
-            self.read_bytes(required).await?;
-        }
-    }
-
-    /// Read packets in bulk. This allow replies to be in bulk. This method is used
-    /// after the connection is established to read a bunch of incoming packets
-    pub async fn readb(&mut self, state: &mut MqttState) -> Result<(), StateError> {
-        let mut count = 0;
-        loop {
-            match Packet::read(&mut self.read, self.max_incoming_size) {
-                Ok(packet) => {
-                    state.handle_incoming_packet(packet)?;
-
-                    count += 1;
-                    if count >= self.max_readb_count {
-                        return Ok(());
-                    }
-                }
-                // If some packets are already framed, return those
-                Err(mqttbytes::Error::InsufficientBytes(_)) if count > 0 => return Ok(()),
-                // Wait for more bytes until a frame can be created
-                Err(mqttbytes::Error::InsufficientBytes(required)) => {
-                    self.read_bytes(required).await?;
-                }
-                Err(mqttbytes::Error::PayloadSizeLimitExceeded { pkt_size, max }) => {
-                    state.handle_protocol_error()?;
-                    return Err(StateError::IncomingPacketTooLarge { pkt_size, max });
-                }
-                Err(e) => return Err(StateError::Deserialization(e)),
-            };
-        }
-    }
-
-    pub async fn connect(&mut self, connect: Connect, options: &MqttOptions) -> io::Result<usize> {
-        let mut write = BytesMut::new();
-        let last_will = options.last_will();
-        let login = options.credentials().map(|l| Login {
-            username: l.0,
-            password: l.1,
-        });
-
-        let len = match Packet::Connect(connect, last_will, login).write(&mut write) {
-            Ok(size) => size,
-            Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidData, e.to_string())),
+            max_outgoing_size,
         };
+        let framed = Framed::new(socket, codec);
 
-        self.socket.write_all(&write[..]).await?;
-        Ok(len)
+        Network { framed, timeout }
     }
 
-    pub async fn flush(&mut self, write: &mut BytesMut) -> io::Result<()> {
-        if write.is_empty() {
-            return Ok(());
+    pub async fn read(&mut self) -> Result<Incoming, StateError> {
+        match self.framed.next().await {
+            Some(Ok(packet)) => Ok(packet),
+            Some(Err(mqttbytes::Error::InsufficientBytes(_))) | None => unreachable!(),
+            Some(Err(e)) => Err(StateError::Deserialization(e)),
         }
+    }
 
-        self.socket.write_all(&write[..]).await?;
-        write.clear();
-        Ok(())
+    pub async fn send(&mut self, packet: Packet) -> Result<(), StateError> {
+        match timeout(self.timeout, self.framed.send(packet)).await {
+            Ok(inner) => inner.map_err(StateError::Deserialization),
+            Err(e) => Err(StateError::Timeout(e)),
+        }
     }
 }
-
-pub trait N: AsyncRead + AsyncWrite + Send + Unpin {}
-impl<T> N for T where T: AsyncRead + AsyncWrite + Send + Unpin {}

--- a/rumqttc/src/v5/framed.rs
+++ b/rumqttc/src/v5/framed.rs
@@ -16,12 +16,8 @@ use std::time::Duration;
 pub struct Network {
     /// Frame MQTT packets from network connection
     framed: Framed<Box<dyn AsyncReadWrite>, Codec>,
-    /// Time within which network operations should complete
+    /// Time within which network write operations should complete
     timeout: Duration,
-    /// Number of packets currently written into buffer
-    buffered_packets: usize,
-    /// Maximum number of packets that can be buffered
-    max_buffered_packets: usize,
 }
 impl Network {
     pub fn new(
@@ -29,48 +25,37 @@ impl Network {
         max_incoming_size: Option<usize>,
         max_outgoing_size: Option<usize>,
         timeout: Duration,
-        max_buffered_packets: usize,
+        buffer_capacity: usize,
     ) -> Network {
         let socket = Box::new(socket) as Box<dyn AsyncReadWrite>;
         let codec = Codec {
             max_incoming_size,
             max_outgoing_size,
         };
-        let framed = Framed::new(socket, codec);
+        let framed = Framed::with_capacity(socket, codec, buffer_capacity);
 
-        Network {
-            framed,
-            timeout,
-            buffered_packets: 0,
-            max_buffered_packets,
-        }
+        Network { framed, timeout }
     }
 
     pub async fn read(&mut self) -> Result<Incoming, StateError> {
         match self.framed.next().await {
             Some(Ok(packet)) => Ok(packet),
-            Some(Err(mqttbytes::Error::InsufficientBytes(_))) | None => unreachable!(),
+            Some(Err(mqttbytes::Error::InsufficientBytes(_))) => unreachable!(),
             Some(Err(e)) => Err(StateError::Deserialization(e)),
+            None => Err(StateError::ConnectionClosed),
         }
     }
 
     /// Write packets into buffer, flush after `MAX_BUFFERED_PACKETS`
     pub async fn write(&mut self, packet: Packet) -> Result<(), StateError> {
-        self.buffered_packets += 1;
-        self.framed
-            .feed(packet)
-            .await
-            .map_err(StateError::Deserialization)?;
-        if self.buffered_packets >= self.max_buffered_packets {
-            self.flush().await?;
+        match timeout(self.timeout, self.framed.send(packet)).await {
+            Ok(inner) => inner.map_err(StateError::Deserialization),
+            Err(e) => Err(StateError::Timeout(e)),
         }
-
-        Ok(())
     }
 
     /// Force flush all packets in buffer, reset count
     pub async fn flush(&mut self) -> Result<(), StateError> {
-        self.buffered_packets = 0;
         match timeout(self.timeout, self.framed.flush()).await {
             Ok(inner) => inner.map_err(StateError::Deserialization),
             Err(e) => Err(StateError::Timeout(e)),

--- a/rumqttc/src/v5/mod.rs
+++ b/rumqttc/src/v5/mod.rs
@@ -126,7 +126,7 @@ impl MqttOptions {
             client_id: id.into(),
             credentials: None,
             request_channel_capacity: 10,
-            max_request_batch: 0,
+            max_request_batch: 10,
             pending_throttle: Duration::from_micros(0),
             last_will: None,
             conn_timeout: 5,
@@ -271,6 +271,12 @@ impl MqttOptions {
     /// Set request channel capacity
     pub fn set_request_channel_capacity(&mut self, capacity: usize) -> &mut Self {
         self.request_channel_capacity = capacity;
+        self
+    }
+
+    /// set maximum request batch count
+    pub fn set_max_request_batch(&mut self, max_request_batch: usize) -> &mut Self {
+        self.max_request_batch = max_request_batch;
         self
     }
 

--- a/rumqttc/src/v5/mqttbytes/mod.rs
+++ b/rumqttc/src/v5/mqttbytes/mod.rs
@@ -130,7 +130,7 @@ pub fn matches(topic: &str, filter: &str) -> bool {
 }
 
 /// Error during serialization and deserialization
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("Invalid return code received as response for connect = {0}")]
     InvalidConnectReturnCode(u8),
@@ -183,4 +183,8 @@ pub enum Error {
     /// proceed further
     #[error("Insufficient number of bytes to frame packet, {0} more bytes required")]
     InsufficientBytes(usize),
+    #[error("IO: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Cannot send packet of size '{pkt_size:?}'. It's greater than the broker's maximum packet size of: '{max:?}'")]
+    OutgoingPacketTooLarge { pkt_size: u32, max: u32 },
 }

--- a/rumqttc/src/v5/mqttbytes/v5/codec.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/codec.rs
@@ -1,0 +1,73 @@
+use bytes::{Buf, BytesMut};
+use tokio_util::codec::{Decoder, Encoder};
+
+use super::{Error, Packet};
+
+/// MQTT v4 codec
+#[derive(Debug, Clone)]
+pub struct Codec {
+    /// Maximum packet size allowed by client
+    pub max_incoming_size: Option<usize>,
+    /// Maximum packet size allowed by broker
+    pub max_outgoing_size: Option<usize>,
+}
+
+impl Decoder for Codec {
+    type Item = Packet;
+    type Error = Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        if src.remaining() == 0 {
+            return Ok(None);
+        }
+
+        let packet = Packet::read(src, self.max_incoming_size)?;
+        Ok(Some(packet))
+    }
+}
+
+impl Encoder<Packet> for Codec {
+    type Error = Error;
+
+    fn encode(&mut self, item: Packet, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        item.write(dst, self.max_outgoing_size)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::BytesMut;
+    use tokio_util::codec::Encoder;
+
+    use super::Codec;
+    use crate::v5::{
+        mqttbytes::{Error, QoS},
+        Packet, Publish,
+    };
+
+    #[test]
+    fn outgoing_max_packet_size_check() {
+        let mut buf = BytesMut::new();
+        let mut codec = Codec {
+            max_incoming_size: Some(100),
+            max_outgoing_size: Some(200),
+        };
+
+        let mut small_publish = Publish::new("hello/world", QoS::AtLeastOnce, vec![1; 100], None);
+        small_publish.pkid = 1;
+        codec
+            .encode(Packet::Publish(small_publish), &mut buf)
+            .unwrap();
+
+        let large_publish = Publish::new("hello/world", QoS::AtLeastOnce, vec![1; 265], None);
+        match codec.encode(Packet::Publish(large_publish), &mut buf) {
+            Err(Error::OutgoingPacketTooLarge {
+                pkt_size: 282,
+                max: 200,
+            }) => {}
+            _ => unreachable!(),
+        }
+    }
+}

--- a/rumqttc/src/v5/mqttbytes/v5/codec.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/codec.rs
@@ -1,4 +1,4 @@
-use bytes::{Buf, BytesMut};
+use bytes::BytesMut;
 use tokio_util::codec::{Decoder, Encoder};
 
 use super::{Error, Packet};
@@ -17,12 +17,15 @@ impl Decoder for Codec {
     type Error = Error;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        if src.remaining() == 0 {
-            return Ok(None);
+        match Packet::read(src, self.max_incoming_size) {
+            Ok(packet) => Ok(Some(packet)),
+            // NOTE: not enough bytes to construct packet, reserve enough in src buffer
+            Err(Error::InsufficientBytes(b)) => {
+                src.reserve(b);
+                Ok(None)
+            }
+            Err(e) => Err(e),
         }
-
-        let packet = Packet::read(src, self.max_incoming_size)?;
-        Ok(Some(packet))
     }
 }
 

--- a/rumqttc/src/v5/mqttbytes/v5/connect.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/connect.rs
@@ -127,6 +127,13 @@ impl Connect {
         buffer[flags_index] = connect_flags;
         Ok(1 + count + len)
     }
+
+    pub fn size(&self, will: &Option<LastWill>, login: &Option<Login>) -> usize {
+        let len = self.len(will, login);
+        let remaining_len_size = len_len(len);
+
+        1 + remaining_len_size + len
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/rumqttc/src/v5/mqttbytes/v5/mod.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/mod.rs
@@ -144,6 +144,25 @@ impl Packet {
             Self::Disconnect(disconnect) => disconnect.write(write),
         }
     }
+
+    pub fn size(&self) -> usize {
+        match self {
+            Self::Publish(publish) => publish.size(),
+            Self::Subscribe(subscription) => subscription.size(),
+            Self::Unsubscribe(unsubscribe) => unsubscribe.size(),
+            Self::ConnAck(ack) => ack.size(),
+            Self::PubAck(ack) => ack.size(),
+            Self::SubAck(ack) => ack.size(),
+            Self::UnsubAck(unsuback) => unsuback.size(),
+            Self::PubRec(pubrec) => pubrec.size(),
+            Self::PubRel(pubrel) => pubrel.size(),
+            Self::PubComp(pubcomp) => pubcomp.size(),
+            Self::Connect(connect, will, login) => connect.size(will, login),
+            Self::PingReq(req) => req.size(),
+            Self::PingResp(resp) => resp.size(),
+            Self::Disconnect(disconnect) => disconnect.size(),
+        }
+    }
 }
 
 /// MQTT packet type

--- a/rumqttc/src/v5/mqttbytes/v5/ping.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/ping.rs
@@ -9,6 +9,10 @@ impl PingReq {
         payload.put_slice(&[0xC0, 0x00]);
         Ok(2)
     }
+
+    pub fn size(&self) -> usize {
+        2
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -18,5 +22,9 @@ impl PingResp {
     pub fn write(payload: &mut BytesMut) -> Result<usize, Error> {
         payload.put_slice(&[0xD0, 0x00]);
         Ok(2)
+    }
+
+    pub fn size(&self) -> usize {
+        2
     }
 }

--- a/rumqttc/src/v5/state.rs
+++ b/rumqttc/src/v5/state.rs
@@ -63,6 +63,8 @@ pub enum StateError {
     ConnFail { reason: ConnectReturnCode },
     #[error("Timeout")]
     Timeout(#[from] Elapsed),
+    #[error("Connection Closed")]
+    ConnectionClosed,
 }
 
 /// State of the mqtt connection.

--- a/rumqttc/tests/broker.rs
+++ b/rumqttc/tests/broker.rs
@@ -232,7 +232,7 @@ impl Network {
     pub async fn readb(&mut self, incoming: &mut VecDeque<Incoming>) -> io::Result<()> {
         let mut count = 0;
         loop {
-            match read(&mut self.read, self.max_incoming_size) {
+            match Packet::read(&mut self.read, self.max_incoming_size) {
                 Ok(packet) => {
                     incoming.push_back(packet);
                     count += 1;

--- a/rumqttc/tests/broker.rs
+++ b/rumqttc/tests/broker.rs
@@ -147,6 +147,9 @@ impl Broker {
 
     /// Selects between outgoing and incoming packets
     pub async fn tick(&mut self) -> Event {
+        if let Some(incoming) = self.incoming.pop_front() {
+            return Event::Incoming(incoming);
+        }
         select! {
             request = self.outgoing_rx.recv_async() => {
                 let request = request.unwrap();

--- a/rumqttc/tests/reliability.rs
+++ b/rumqttc/tests/reliability.rs
@@ -292,7 +292,7 @@ async fn requests_are_blocked_after_max_inflight_queue_size() {
 #[tokio::test]
 async fn requests_are_recovered_after_inflight_queue_size_falls_below_max() {
     let mut options = MqttOptions::new("dummy", "127.0.0.1", 1888);
-    options.set_inflight(3);
+    options.set_inflight(3).set_max_request_batch(1);
 
     let (client, mut eventloop) = AsyncClient::new(options, 5);
 
@@ -474,7 +474,9 @@ async fn next_poll_after_connect_failure_reconnects() {
 #[tokio::test]
 async fn reconnection_resumes_from_the_previous_state() {
     let mut options = MqttOptions::new("dummy", "127.0.0.1", 3001);
-    options.set_keep_alive(Duration::from_secs(5));
+    options
+        .set_keep_alive(Duration::from_secs(5))
+        .set_max_request_batch(1);
 
     // start sending qos0 publishes. Makes sure that there is out activity but no in activity
     let (client, mut eventloop) = AsyncClient::new(options, 5);
@@ -514,7 +516,9 @@ async fn reconnection_resumes_from_the_previous_state() {
 #[tokio::test]
 async fn reconnection_resends_unacked_packets_from_the_previous_connection_first() {
     let mut options = MqttOptions::new("dummy", "127.0.0.1", 3002);
-    options.set_keep_alive(Duration::from_secs(5));
+    options
+        .set_keep_alive(Duration::from_secs(5))
+        .set_max_request_batch(1);
 
     // start sending qos0 publishes. this makes sure that there is
     // outgoing activity but no incoming activity

--- a/rumqttc/tests/reliability.rs
+++ b/rumqttc/tests/reliability.rs
@@ -292,7 +292,7 @@ async fn requests_are_blocked_after_max_inflight_queue_size() {
 #[tokio::test]
 async fn requests_are_recovered_after_inflight_queue_size_falls_below_max() {
     let mut options = MqttOptions::new("dummy", "127.0.0.1", 1888);
-    options.set_inflight(3).set_max_request_batch(1);
+    options.set_inflight(3).set_network_buffer_capacity(0); // NOTE: to instantly flush
 
     let (client, mut eventloop) = AsyncClient::new(options, 5);
 
@@ -476,7 +476,7 @@ async fn reconnection_resumes_from_the_previous_state() {
     let mut options = MqttOptions::new("dummy", "127.0.0.1", 3001);
     options
         .set_keep_alive(Duration::from_secs(5))
-        .set_max_request_batch(1);
+        .set_network_buffer_capacity(0); // NOTE: to instantly flush
 
     // start sending qos0 publishes. Makes sure that there is out activity but no in activity
     let (client, mut eventloop) = AsyncClient::new(options, 5);
@@ -518,7 +518,7 @@ async fn reconnection_resends_unacked_packets_from_the_previous_connection_first
     let mut options = MqttOptions::new("dummy", "127.0.0.1", 3002);
     options
         .set_keep_alive(Duration::from_secs(5))
-        .set_max_request_batch(1);
+        .set_network_buffer_capacity(0); // NOTE: to instantly flush
 
     // start sending qos0 publishes. this makes sure that there is
     // outgoing activity but no incoming activity

--- a/rumqttc/tests/reliability.rs
+++ b/rumqttc/tests/reliability.rs
@@ -570,7 +570,7 @@ async fn state_is_being_cleaned_properly_and_pending_request_calculated_properly
         if let Err(e) = res {
             match e {
                 ConnectionError::FlushTimeout => {
-                    assert!(eventloop.state.write.is_empty());
+                    assert!(eventloop.network.as_ref().unwrap().write.is_empty());
                     println!("State is being clean properly");
                 }
                 _ => {

--- a/rumqttc/tests/reliability.rs
+++ b/rumqttc/tests/reliability.rs
@@ -569,7 +569,7 @@ async fn state_is_being_cleaned_properly_and_pending_request_calculated_properly
         let res = run(&mut eventloop, false).await;
         if let Err(e) = res {
             match e {
-                ConnectionError::FlushTimeout => {
+                ConnectionError::MqttState(StateError::FlushTimeout) => {
                     assert!(eventloop.network.is_none());
                     println!("State is being clean properly");
                 }

--- a/rumqttc/tests/reliability.rs
+++ b/rumqttc/tests/reliability.rs
@@ -570,7 +570,7 @@ async fn state_is_being_cleaned_properly_and_pending_request_calculated_properly
         if let Err(e) = res {
             match e {
                 ConnectionError::FlushTimeout => {
-                    assert!(eventloop.network.as_ref().unwrap().write.is_empty());
+                    assert!(eventloop.network.is_none());
                     println!("State is being clean properly");
                 }
                 _ => {


### PR DESCRIPTION
<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->
resolves #810 on top of #825 

Defaults to buffering 10 packets before each flush, behavior can be changed with `MqttOptions.set_max_request_batch()`. Instantly flushes outgoing `PingReq` as well(required to not close the connection).

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [ ] Formatted with `cargo fmt`
- [ ] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
