### PR TITLE
refactor: use `Login` to store credentials in MqttOptions

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * rename `N` as `AsyncReadWrite` to describe usage.
 * use `Framed` to encode/decode MQTT packets.
+* use `Login` to store credentials
 
 ### Deprecated
 

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -456,8 +456,7 @@ async fn mqtt_connect(
     connect.clean_session = clean_session;
     connect.last_will = last_will;
 
-    if let Some((username, password)) = options.credentials() {
-        let login = Login::new(username, password);
+    if let Some(login) = options.credentials() {
         connect.login = Some(login);
     }
 

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -455,10 +455,7 @@ async fn mqtt_connect(
     connect.keep_alive = keep_alive;
     connect.clean_session = clean_session;
     connect.last_will = last_will;
-
-    if let Some(login) = options.credentials() {
-        connect.login = Some(login);
-    }
+    connect.login = options.credentials();
 
     // send mqtt connect packet
     network.connect(connect).await?;

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -454,7 +454,7 @@ pub struct MqttOptions {
     /// client identifier
     client_id: String,
     /// username and password
-    credentials: Option<(String, String)>,
+    credentials: Option<Login>,
     /// maximum incoming packet size (verifies remaining length of the packet)
     max_incoming_packet_size: usize,
     /// Maximum outgoing packet size (only verifies publish payload size)
@@ -641,12 +641,12 @@ impl MqttOptions {
         username: U,
         password: P,
     ) -> &mut Self {
-        self.credentials = Some((username.into(), password.into()));
+        self.credentials = Some(Login::new(username, password));
         self
     }
 
     /// Security options
-    pub fn credentials(&self) -> Option<(String, String)> {
+    pub fn credentials(&self) -> Option<Login> {
         self.credentials.clone()
     }
 

--- a/rumqttc/src/v5/framed.rs
+++ b/rumqttc/src/v5/framed.rs
@@ -2,7 +2,7 @@ use bytes::BytesMut;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use super::mqttbytes;
-use super::mqttbytes::v5::{Connect, Login, Packet};
+use super::mqttbytes::v5::{Connect, Packet};
 use super::{Incoming, MqttOptions, MqttState, StateError};
 use std::io;
 
@@ -103,10 +103,7 @@ impl Network {
     pub async fn connect(&mut self, connect: Connect, options: &MqttOptions) -> io::Result<usize> {
         let mut write = BytesMut::new();
         let last_will = options.last_will();
-        let login = options.credentials().map(|l| Login {
-            username: l.0,
-            password: l.1,
-        });
+        let login = options.credentials();
 
         let len = match Packet::Connect(connect, last_will, login).write(&mut write) {
             Ok(size) => size,

--- a/rumqttc/src/v5/mod.rs
+++ b/rumqttc/src/v5/mod.rs
@@ -75,7 +75,7 @@ pub struct MqttOptions {
     /// client identifier
     client_id: String,
     /// username and password
-    credentials: Option<(String, String)>,
+    credentials: Option<Login>,
     /// request (publish, subscribe) channel capacity
     request_channel_capacity: usize,
     /// Max internal request batching
@@ -259,12 +259,12 @@ impl MqttOptions {
         username: U,
         password: P,
     ) -> &mut Self {
-        self.credentials = Some((username.into(), password.into()));
+        self.credentials = Some(Login::new(username, password));
         self
     }
 
     /// Security options
-    pub fn credentials(&self) -> Option<(String, String)> {
+    pub fn credentials(&self) -> Option<Login> {
         self.credentials.clone()
     }
 


### PR DESCRIPTION
<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [ ] Formatted with `cargo fmt`
- [ ] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
