### PR TITLE
fix(rumqttd): Implement constant-time password comparison

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1979,6 +1979,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slab",
+ "subtle",
  "thiserror",
  "tokio",
  "tokio-native-tls",

--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make write method return the number of bytes written correctly everywhere
 
 ### Security
-
+- Implement constant-time password comparison in authentication logic
 ---
 
 ## [rumqttd 0.19.0] - 12-12-2023

--- a/rumqttd/Cargo.toml
+++ b/rumqttd/Cargo.toml
@@ -38,6 +38,7 @@ clap = { version = "4.4", features = ["derive"] }
 axum = "0.7.4"
 rand = "0.8.5"
 uuid = { version = "1.7.0", features = ["v4", "fast-rng"] }
+subtle = "2.5"
 
 [features]
 default = ["use-rustls", "websocket"]


### PR DESCRIPTION

Fixes https://github.com/bytebeamio/rumqtt/issues/796

Password Authentication in constant time using subtle::ConstantTimeEq

<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

- Bug fix (non-breaking change which fixes an issue)
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
