### PR TITLE
feat: add `bind_addr` for `NetworkOptions` to enable `TCPSocket.bind()`

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `size()` method on `Packet` calculates size once serialized.
 * `read()` and `write()` methods on `Packet`.
 * `ConnectionAborted` variant on `StateError` type to denote abrupt end to a connection
+* `bind_addr` for `NetworkOptions` to enable `TCPSocket.bind()`
 
 ### Changed
 

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -324,6 +324,10 @@ pub(crate) async fn socket_connect(
             socket.set_recv_buffer_size(recv_buffer_size).unwrap();
         }
 
+        if let Some(bind_addr) = network_options.bind_addr {
+            socket.bind(bind_addr)?;
+        }
+
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
         {
             if let Some(bind_device) = &network_options.bind_device {

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -98,7 +98,10 @@
 #[macro_use]
 extern crate log;
 
-use std::fmt::{self, Debug, Formatter};
+use std::{
+    fmt::{self, Debug, Formatter},
+    net::SocketAddr,
+};
 
 #[cfg(any(feature = "use-rustls", feature = "websocket"))]
 use std::sync::Arc;
@@ -370,6 +373,7 @@ pub struct NetworkOptions {
     tcp_send_buffer_size: Option<u32>,
     tcp_recv_buffer_size: Option<u32>,
     conn_timeout: u64,
+    bind_addr: Option<SocketAddr>,
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
     bind_device: Option<String>,
 }
@@ -380,6 +384,7 @@ impl NetworkOptions {
             tcp_send_buffer_size: None,
             tcp_recv_buffer_size: None,
             conn_timeout: 5,
+            bind_addr: None,
             #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
             bind_device: None,
         }
@@ -402,6 +407,11 @@ impl NetworkOptions {
     /// get timeout in secs
     pub fn connection_timeout(&self) -> u64 {
         self.conn_timeout
+    }
+
+    pub fn set_bind_addr(&mut self, bind_addr: SocketAddr) -> &mut Self {
+        self.bind_addr = Some(bind_addr);
+        self
     }
 
     /// bind connection to a specific network device by name


### PR DESCRIPTION
<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [ ] Formatted with `cargo fmt`
- [ ] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
