### PR TITLE
rumqttc: fix subscribe many

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Validate filters while creating subscription requests.
 * Make v4::Connect::write return correct value
+* Fix `Client*::subscribe_many`
 
 ### Security
 

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -177,10 +177,13 @@ impl AsyncClient {
     where
         T: IntoIterator<Item = SubscribeFilter>,
     {
-        let mut topics_iter = topics.into_iter();
-        let is_valid_filters = topics_iter.all(|filter| valid_filter(&filter.path));
-        let subscribe = Subscribe::new_many(topics_iter);
+        let subscribe = Subscribe::new_many(topics);
+        let is_valid_filters = subscribe
+            .filters
+            .iter()
+            .all(|filter| valid_filter(&filter.path));
         let request = Request::Subscribe(subscribe);
+
         if !is_valid_filters {
             return Err(ClientError::Request(request));
         }
@@ -193,10 +196,13 @@ impl AsyncClient {
     where
         T: IntoIterator<Item = SubscribeFilter>,
     {
-        let mut topics_iter = topics.into_iter();
-        let is_valid_filters = topics_iter.all(|filter| valid_filter(&filter.path));
-        let subscribe = Subscribe::new_many(topics_iter);
+        let subscribe = Subscribe::new_many(topics);
+        let is_valid_filters = subscribe
+            .filters
+            .iter()
+            .all(|filter| valid_filter(&filter.path));
         let request = Request::Subscribe(subscribe);
+
         if !is_valid_filters {
             return Err(ClientError::TryRequest(request));
         }

--- a/rumqttc/src/v5/client.rs
+++ b/rumqttc/src/v5/client.rs
@@ -319,10 +319,13 @@ impl AsyncClient {
     where
         T: IntoIterator<Item = Filter>,
     {
-        let mut topics_iter = topics.into_iter();
-        let is_valid_filters = topics_iter.all(|filter| valid_filter(&filter.path));
-        let subscribe = Subscribe::new_many(topics_iter, properties);
+        let subscribe = Subscribe::new_many(topics, properties);
+        let is_valid_filters = subscribe
+            .filters
+            .iter()
+            .all(|filter| valid_filter(&filter.path));
         let request = Request::Subscribe(subscribe);
+
         if !is_valid_filters {
             return Err(ClientError::Request(request));
         }

--- a/rumqttc/src/v5/state.rs
+++ b/rumqttc/src/v5/state.rs
@@ -65,7 +65,7 @@ pub enum StateError {
     #[error("Connection failed with reason '{reason:?}' ")]
     ConnFail { reason: ConnectReturnCode },
     #[error("Connection closed by peer abruptly")]
-    ConnectionAborted
+    ConnectionAborted,
 }
 
 impl From<mqttbytes::Error> for StateError {


### PR DESCRIPTION
## Type of change

Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] Formatted with `cargo fmt`
- [X] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.

Fix a flaw in the construction of the `Subscribe` packets where a iterator shouldn't be used twice.