### PR TITLE
Manual ACK packet support

### DIFF
--- a/rumqttc/examples/async_manual_acks.rs
+++ b/rumqttc/examples/async_manual_acks.rs
@@ -68,7 +68,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
             // Its important not to block eventloop as this can cause deadlock.
             let c = client.clone();
             tokio::spawn(async move {
-                c.ack(&publish).await.unwrap();
+                let ack = c.get_manual_ack(&publish);
+                c.manual_ack(ack).await.unwrap();
+                // c.ack(&publish).await.unwrap();
             });
         }
     }

--- a/rumqttc/examples/async_manual_acks.rs
+++ b/rumqttc/examples/async_manual_acks.rs
@@ -68,9 +68,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             // Its important not to block eventloop as this can cause deadlock.
             let c = client.clone();
             tokio::spawn(async move {
-                let ack = c.get_manual_ack(&publish);
-                c.manual_ack(ack).await.unwrap();
-                // c.ack(&publish).await.unwrap();
+                c.ack(&publish).await.unwrap();
             });
         }
     }

--- a/rumqttc/examples/async_manual_acks_v5.rs
+++ b/rumqttc/examples/async_manual_acks_v5.rs
@@ -77,7 +77,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 }
 
 async fn requests(client: &AsyncClient) {
-    for i in 1..=5 {
+    for i in 1..=10 {
         client
             .publish("hello/world", QoS::AtLeastOnce, false, vec![1; i])
             .await

--- a/rumqttc/examples/async_manual_acks_v5.rs
+++ b/rumqttc/examples/async_manual_acks_v5.rs
@@ -7,12 +7,11 @@ use std::error::Error;
 use std::time::Duration;
 
 fn create_conn() -> (AsyncClient, EventLoop) {
-    let mut mqttoptions = MqttOptions::new("test-1", "localhost", 1883);
+    let mut mqttoptions = MqttOptions::new("test-1", "localhost", 1884);
     mqttoptions
         .set_keep_alive(Duration::from_secs(5))
         .set_manual_acks(true)
-        .set_clean_start(false)
-        .set_session_expiry_interval(u32::MAX.into());
+        .set_clean_start(false);
 
     AsyncClient::new(mqttoptions, 10)
 }
@@ -21,9 +20,6 @@ fn create_conn() -> (AsyncClient, EventLoop) {
 async fn main() -> Result<(), Box<dyn Error>> {
     // todo!("fix this example with new way of spawning clients")
     pretty_env_logger::init();
-
-    println!("");
-    println!(">>>>>>>>>>> Create broker connection, do not ack broker publishes!!!");
 
     // create mqtt connection with clean_session = false and manual_acks = true
     let (client, mut eventloop) = create_conn();
@@ -54,9 +50,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
     }
 
-    println!("");
-    println!(">>>>>>>>>>> Create new broker connection to get unack packets again!!!");
-
     // create new broker connection
     let (client, mut eventloop) = create_conn();
 
@@ -73,10 +66,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
             let c = client.clone();
             tokio::spawn(async move {
                 let mut ack = c.get_manual_ack(&publish);
-                ack.set_reason(ManualAckReason::UnspecifiedError);
-                ack.set_reason_string("Testing error".to_string().into());
+                ack.set_reason(ManualAckReason::Success);
+                ack.set_reason_string("There is no error".to_string().into());
                 c.manual_ack(ack).await.unwrap();
-                // c.ack(&publish).await.unwrap();
             });
         }
     }

--- a/rumqttc/src/v5/mod.rs
+++ b/rumqttc/src/v5/mod.rs
@@ -19,7 +19,7 @@ use crate::{NetworkOptions, Transport};
 
 use mqttbytes::v5::*;
 
-pub use client::{AsyncClient, Client, ClientError, Connection, Iter};
+pub use client::{AsyncClient, Client, ClientError, Connection, Iter, ManualAckReason};
 pub use eventloop::{ConnectionError, Event, EventLoop};
 pub use state::{MqttState, StateError};
 

--- a/rumqttc/src/v5/mqttbytes/v5/puback.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/puback.rs
@@ -32,6 +32,32 @@ impl PubAck {
         }
     }
 
+    pub fn set_code(&mut self, code: u8) {
+        self.reason = reason(code).unwrap();
+    }
+
+    pub fn set_reason_string(&mut self, reason_string: Option<String>) {
+        if let Some(props) = &mut self.properties {
+            props.reason_string = reason_string;
+        } else {
+            self.properties = Some(PubAckProperties {
+                reason_string,
+                user_properties: Vec::<(String, String)>::new(),
+            });
+        }
+    }
+
+    pub fn set_user_properties(&mut self, user_properties: Vec<(String, String)>) {
+        if let Some(props) = &mut self.properties {
+            props.user_properties = user_properties;
+        } else {
+            self.properties = Some(PubAckProperties {
+                reason_string: None,
+                user_properties,
+            });
+        }
+    }
+
     pub fn size(&self) -> usize {
         if self.reason == PubAckReason::Success && self.properties.is_none() {
             return 4;

--- a/rumqttc/src/v5/mqttbytes/v5/pubrec.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/pubrec.rs
@@ -33,6 +33,32 @@ impl PubRec {
         }
     }
 
+    pub fn set_code(&mut self, code: u8) {
+        self.reason = reason(code).unwrap();
+    }
+
+    pub fn set_reason_string(&mut self, reason_string: Option<String>) {
+        if let Some(props) = &mut self.properties {
+            props.reason_string = reason_string;
+        } else {
+            self.properties = Some(PubRecProperties {
+                reason_string,
+                user_properties: Vec::<(String, String)>::new(),
+            });
+        }
+    }
+
+    pub fn set_user_properties(&mut self, user_properties: Vec<(String, String)>) {
+        if let Some(props) = &mut self.properties {
+            props.user_properties = user_properties;
+        } else {
+            self.properties = Some(PubRecProperties {
+                reason_string: None,
+                user_properties,
+            });
+        }
+    }
+
     pub fn size(&self) -> usize {
         let len = self.len();
         let remaining_len_size = len_len(len);
@@ -83,12 +109,12 @@ impl PubRec {
         }
 
         let properties = PubRecProperties::read(&mut bytes)?;
-        let puback = PubRec {
+        let pubrec = PubRec {
             pkid,
             reason: reason(ack_reason)?,
             properties,
         };
-        Ok(puback)
+        Ok(pubrec)
     }
 
     pub fn write(&self, buffer: &mut BytesMut) -> Result<usize, Error> {


### PR DESCRIPTION
A solution for issue https://github.com/bytebeamio/rumqtt/issues/841 and issue https://github.com/bytebeamio/rumqtt/issues/609.

Note the example of `async_manual_acks_v5` needs PR https://github.com/bytebeamio/rumqtt/pull/854 to make broker re-send publishes.

## Type of change

New feature (non-breaking change which adds functionality)
* `get_manual_ack` to return manual ack packet where
  * `set_reason`/`set_code` to update reason code
  * `set_reason_string` to set reason string
  * `set_user_properties` to set user properties
* `manual_ack`/`try_manual_ack` to send the modified packet (PUBACK/PUBREC) returned by `get_manual_ack`

## Checklist:

- [ ] Formatted with `cargo fmt`
- [ ] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
