### PR TITLE
fix: filter unexpected PubAck in event loop pending queue.

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Validate filters while creating subscription requests.
 * Make v4::Connect::write return correct value
+* Filter PUBACK in pending save requests to fix unexpected PUBACK sent to reconnected broker.
 
 ### Security
 

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -130,7 +130,15 @@ impl EventLoop {
         self.pending.extend(self.state.clean());
 
         // drain requests from channel which weren't yet received
-        let requests_in_channel = self.requests_rx.drain();
+        let mut requests_in_channel:Vec<_> = self.requests_rx.drain().collect();
+
+        requests_in_channel.retain(|request| {
+            match request {
+                Request::PubAck(_) => false, // Remove this request,wait for publish retransmittion. Or else isolate puback will be recived by broker.
+                _ => true,                   // Keep this request
+            }
+        });
+        
         self.pending.extend(requests_in_channel);
     }
 

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -130,7 +130,7 @@ impl EventLoop {
         self.pending.extend(self.state.clean());
 
         // drain requests from channel which weren't yet received
-        let mut requests_in_channel:Vec<_> = self.requests_rx.drain().collect();
+        let mut requests_in_channel: Vec<_> = self.requests_rx.drain().collect();
 
         requests_in_channel.retain(|request| {
             match request {
@@ -138,7 +138,7 @@ impl EventLoop {
                 _ => true,                   // Keep this request
             }
         });
-        
+
         self.pending.extend(requests_in_channel);
     }
 

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -134,8 +134,8 @@ impl EventLoop {
 
         requests_in_channel.retain(|request| {
             match request {
-                Request::PubAck(_) => false, // Remove this request,wait for publish retransmittion. Or else isolate puback will be recived by broker.
-                _ => true,                   // Keep this request
+                Request::PubAck(_) => false,  // Wait for publish retransmission, else the broker could be confused by an unexpected ack
+                _ => true,
             }
         });
 

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -130,8 +130,8 @@ impl EventLoop {
 
         requests_in_channel.retain(|request| {
             match request {
-                Request::PubAck(_) => false, // Remove this request,wait for publish retransmittion. Or else isolate puback will be recived by broker.
-                _ => true,                   // Keep this request
+                Request::PubAck(_) => false,  // Wait for publish retransmission, else the broker could be confused by an unexpected ack
+                _ => true,
             }
         });
 

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -126,7 +126,7 @@ impl EventLoop {
         self.pending.extend(self.state.clean());
 
         // drain requests from channel which weren't yet received
-        let mut requests_in_channel:Vec<_> = self.requests_rx.drain().collect();
+        let mut requests_in_channel: Vec<_> = self.requests_rx.drain().collect();
 
         requests_in_channel.retain(|request| {
             match request {
@@ -134,7 +134,7 @@ impl EventLoop {
                 _ => true,                   // Keep this request
             }
         });
-        
+
         self.pending.extend(requests_in_channel);
     }
 

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -126,7 +126,15 @@ impl EventLoop {
         self.pending.extend(self.state.clean());
 
         // drain requests from channel which weren't yet received
-        let requests_in_channel = self.requests_rx.drain();
+        let mut requests_in_channel:Vec<_> = self.requests_rx.drain().collect();
+
+        requests_in_channel.retain(|request| {
+            match request {
+                Request::PubAck(_) => false, // Remove this request,wait for publish retransmittion. Or else isolate puback will be recived by broker.
+                _ => true,                   // Keep this request
+            }
+        });
+        
         self.pending.extend(requests_in_channel);
     }
 


### PR DESCRIPTION
<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change
bug fix: #849
An isolated PUBACK packet is being sent to the broker after the client reconnects.


