### PR TITLE
Disable default feature for `metrics-exporter-prometheus`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,19 +1033,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.28",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,7 +1232,6 @@ checksum = "9bf4e7146e30ad172c42c39b3246864bd2d3c6396780711a1baf749cfe423e21"
 dependencies = [
  "base64 0.21.7",
  "hyper 0.14.28",
- "hyper-tls",
  "indexmap",
  "ipnet",
  "metrics",
@@ -1253,7 +1239,6 @@ dependencies = [
  "quanta",
  "thiserror",
  "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/rumqttd/Cargo.toml
+++ b/rumqttd/Cargo.toml
@@ -33,7 +33,7 @@ config = "0.14"
 tracing = { version="0.1", features=["log"] }
 tracing-subscriber = { version="0.3.18", features=["env-filter"] }
 metrics = "0.22.1"
-metrics-exporter-prometheus = "0.13.1"
+metrics-exporter-prometheus = { version = "0.13.1", default-features = false, features = ["http-listener"] }
 clap = { version = "4.4", features = ["derive"] }
 axum = "0.7.4"
 rand = "0.8.5"


### PR DESCRIPTION
Disable default feature for `metrics-exporter-prometheus`, because we do not use the feature `push-gateway`, which introduce `native-tls` to the lib.
