### PR TITLE
Remove SubAck/UnsubAck/PubAck/PubRec/PubRel/PubComp reason code errors from critical state error

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Ordering of `State.events` related to `QoS > 0` publishes
 * Filter PUBACK in pending save requests to fix unexpected PUBACK sent to reconnected broker.
 * Resume session only if broker sends `CONNACK` with `session_present == 1`.
-* Remove v5 PubAck/PubRec/PubRel/PubComp/Sub/Unsub failures from `StateError`.
+* Remove v5 PubAck/PubRec/PubRel/PubComp/Sub/Unsub failures from `StateError` and log warnings on these failures.
 
 ### Security
 

--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Ordering of `State.events` related to `QoS > 0` publishes
 * Filter PUBACK in pending save requests to fix unexpected PUBACK sent to reconnected broker.
 * Resume session only if broker sends `CONNACK` with `session_present == 1`.
+* No disconnection on v5 PubAck/PubRec/PubRel/PubComp/Sub/Unsub failures.
 
 ### Security
 

--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Ordering of `State.events` related to `QoS > 0` publishes
 * Filter PUBACK in pending save requests to fix unexpected PUBACK sent to reconnected broker.
 * Resume session only if broker sends `CONNACK` with `session_present == 1`.
-* No disconnection on v5 PubAck/PubRec/PubRel/PubComp/Sub/Unsub failures.
+* Remove v5 PubAck/PubRec/PubRel/PubComp/Sub/Unsub failures from `StateError`.
 
 ### Security
 

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -168,11 +168,12 @@ impl EventLoop {
             Err(e) => {
                 // MQTT requires that packets pending acknowledgement should be republished on session resume.
                 // Move pending messages from state to eventloop.
-                // The PubAckFail/PubRecFail/PubRelFail/SubFail/UnsubFail errors are not critical errors.
+                // The PubAckFail/PubRecFail/PubRelFail/PubCompFail/SubFail/UnsubFail errors are not critical errors.
                 match e {
                     ConnectionError::MqttState(StateError::PubAckFail { .. })
                     | ConnectionError::MqttState(StateError::PubRecFail { .. })
                     | ConnectionError::MqttState(StateError::PubRelFail { .. })
+                    | ConnectionError::MqttState(StateError::PubCompFail { .. })
                     | ConnectionError::MqttState(StateError::SubFail { .. })
                     | ConnectionError::MqttState(StateError::UnsubFail { .. }) => {}
                     _ => {

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -169,18 +169,8 @@ impl EventLoop {
                 // MQTT requires that packets pending acknowledgement should be republished on session resume.
                 // Move pending messages from state to eventloop.
                 // The PubAckFail/PubRecFail/PubRelFail/PubCompFail/SubFail/UnsubFail errors are not critical errors.
-                match e {
-                    ConnectionError::MqttState(StateError::PubAckFail { .. })
-                    | ConnectionError::MqttState(StateError::PubRecFail { .. })
-                    | ConnectionError::MqttState(StateError::PubRelFail { .. })
-                    | ConnectionError::MqttState(StateError::PubCompFail { .. })
-                    | ConnectionError::MqttState(StateError::SubFail { .. })
-                    | ConnectionError::MqttState(StateError::UnsubFail { .. }) => {}
-                    _ => {
-                        warn!("Disconnect due to a critical error: {:?}", e);
-                        self.clean()
-                    }
-                };
+                warn!("Disconnect due to a critical error: {:?}", e);
+                self.clean();
                 Err(e)
             }
         }

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -168,8 +168,6 @@ impl EventLoop {
             Err(e) => {
                 // MQTT requires that packets pending acknowledgement should be republished on session resume.
                 // Move pending messages from state to eventloop.
-                // The PubAckFail/PubRecFail/PubRelFail/PubCompFail/SubFail/UnsubFail errors are not critical errors.
-                warn!("Disconnect due to a critical error: {:?}", e);
                 self.clean();
                 Err(e)
             }

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -168,7 +168,18 @@ impl EventLoop {
             Err(e) => {
                 // MQTT requires that packets pending acknowledgement should be republished on session resume.
                 // Move pending messages from state to eventloop.
-                self.clean();
+                // The PubAckFail/PubRecFail/PubRelFail/SubFail/UnsubFail errors are not critical errors.
+                match e {
+                    ConnectionError::MqttState(StateError::PubAckFail { .. })
+                    | ConnectionError::MqttState(StateError::PubRecFail { .. })
+                    | ConnectionError::MqttState(StateError::PubRelFail { .. })
+                    | ConnectionError::MqttState(StateError::SubFail { .. })
+                    | ConnectionError::MqttState(StateError::UnsubFail { .. }) => {}
+                    _ => {
+                        warn!("Disconnect due to a critical error: {:?}", e);
+                        self.clean()
+                    }
+                };
                 Err(e)
             }
         }


### PR DESCRIPTION
## Type of change

Bug fix (non-breaking change which fixes an issue): https://github.com/bytebeamio/rumqtt/issues/875
In v5, filtered error cases so ACK fail cases are not disconnecting.

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
