### PR TITLE
Store outgoing_pub in a HashMap for more memory efficient storage of unassigned pkids

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * use `Login` to store credentials
 * Made `DisconnectProperties` struct public.
 * Replace `Vec<Option<u16>>` with `FixedBitSet` for managing packet ids of released QoS 2 publishes and incoming QoS 2 publishes in `MqttState`.
+* Replace `Vec<Option<Publish>>` with `HashMap` for storing outgoing pub packet ids in `MqttState`. This dramatically reduces memory usage in processes with a large number of clients.
 
 ### Deprecated
 


### PR DESCRIPTION
<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

Bug fix (non-breaking change which fixes an issue)
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.


I wrote an MQTT traffic simulator and noticed that creating many clients within a single process consumes a large amount of memory. The below example is for 1000 clients.

<img width="1111" alt="mqtt_before" src="https://github.com/bytebeamio/rumqtt/assets/15006780/1871990d-8843-4187-ace4-882a2b00ddec">

This is due to rumqttc pre-allocating `MqttState.outgoing_pub` for each client. I replaced the Vec with a HashMap and dramatically reduced memory usage.

<img width="1117" alt="mqtt_after" src="https://github.com/bytebeamio/rumqtt/assets/15006780/35bc55ee-f829-4ce9-82f9-300f94fb11b1">

I know that `MqttState.outgoing_pub` is most likely pre-allocated for low powered devices. Would it be possible to make using a HashMap either a runtime configuration or feature flag?
