### PR TITLE
rumqttc: Fix: subscribe_many cannot work as implemented, always causing EmptySubscription error.

### DIFF
--- a/rumqttc/src/v5/client.rs
+++ b/rumqttc/src/v5/client.rs
@@ -258,12 +258,10 @@ impl AsyncClient {
         let filter = Filter::new(topic, qos);
         let subscribe = Subscribe::new(filter, properties);
         if !subscribe_has_valid_filters(&subscribe) {
-            return Err(ClientError::Request(Request::Subscribe(subscribe)));
+            return Err(ClientError::Request(subscribe.into()));
         }
 
-        self.request_tx
-            .send_async(Request::Subscribe(subscribe))
-            .await?;
+        self.request_tx.send_async(subscribe.into()).await?;
         Ok(())
     }
 
@@ -290,10 +288,10 @@ impl AsyncClient {
         let filter = Filter::new(topic, qos);
         let subscribe = Subscribe::new(filter, properties);
         if !subscribe_has_valid_filters(&subscribe) {
-            return Err(ClientError::TryRequest(Request::Subscribe(subscribe)));
+            return Err(ClientError::TryRequest(subscribe.into()));
         }
 
-        self.request_tx.try_send(Request::Subscribe(subscribe))?;
+        self.request_tx.try_send(subscribe.into())?;
         Ok(())
     }
 
@@ -321,12 +319,10 @@ impl AsyncClient {
     {
         let subscribe = Subscribe::new_many(topics, properties);
         if !subscribe_has_valid_filters(&subscribe) {
-            return Err(ClientError::Request(Request::Subscribe(subscribe)));
+            return Err(ClientError::Request(subscribe.into()));
         }
 
-        self.request_tx
-            .send_async(Request::Subscribe(subscribe))
-            .await?;
+        self.request_tx.send_async(subscribe.into()).await?;
 
         Ok(())
     }
@@ -360,10 +356,10 @@ impl AsyncClient {
     {
         let subscribe = Subscribe::new_many(topics, properties);
         if !subscribe_has_valid_filters(&subscribe) {
-            return Err(ClientError::TryRequest(Request::Subscribe(subscribe)));
+            return Err(ClientError::TryRequest(subscribe.into()));
         }
 
-        self.request_tx.try_send(Request::Subscribe(subscribe))?;
+        self.request_tx.try_send(subscribe.into())?;
         Ok(())
     }
 
@@ -608,10 +604,10 @@ impl Client {
         let filter = Filter::new(topic, qos);
         let subscribe = Subscribe::new(filter, properties);
         if !subscribe_has_valid_filters(&subscribe) {
-            return Err(ClientError::Request(Request::Subscribe(subscribe)));
+            return Err(ClientError::Request(subscribe.into()));
         }
 
-        self.client.request_tx.send(Request::Subscribe(subscribe))?;
+        self.client.request_tx.send(subscribe.into())?;
         Ok(())
     }
 
@@ -654,10 +650,10 @@ impl Client {
     {
         let subscribe = Subscribe::new_many(topics, properties);
         if !subscribe_has_valid_filters(&subscribe) {
-            return Err(ClientError::Request(Request::Subscribe(subscribe)));
+            return Err(ClientError::Request(subscribe.into()));
         }
 
-        self.client.request_tx.send(Request::Subscribe(subscribe))?;
+        self.client.request_tx.send(subscribe.into())?;
         Ok(())
     }
 

--- a/rumqttc/src/v5/mod.rs
+++ b/rumqttc/src/v5/mod.rs
@@ -49,6 +49,12 @@ pub enum Request {
     Disconnect,
 }
 
+impl From<Subscribe> for Request {
+    fn from(subscribe: Subscribe) -> Self {
+        Self::Subscribe(subscribe)
+    }
+}
+
 #[cfg(feature = "websocket")]
 type RequestModifierFn = Arc<
     dyn Fn(http::Request<()>) -> Pin<Box<dyn Future<Output = http::Request<()>> + Send>>


### PR DESCRIPTION
## Type of change

Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
  - Not making an entry in the changelog because this is a regression that was introduced on `main` and hasn't found it's way into a release yet.


## Notes

This fixes the issue with `subscribe_many` as detailed in #837.
I know that that PR was closed in favor of #813 but that apparently didn't go anywhere for months so I suggest to merge a smaller scoped fix in the meantime. This might also prevent others like me from having to search for this Bug for hours just to find out it was already known and had a fix that just wasn't merged.

To recap: The issue is that `subscribe_many` consumes the iterator over topics in order to validate them, leaving no actual topics left to subscribe to. This then always leads to an `EmptySubscription` error in the `EventLoop`.