### PR TITLE
WIP: publish / subscribe / unsubscribe methods return a promise that resolves once message is sent (with respective QoS)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2559,6 +2559,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
+ "slab",
  "tokio",
  "tracing",
 ]

--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -65,6 +65,7 @@ To update your code simply remove `Key::ECC()` or `Key::RSA()` from the initiali
   `rusttls-pemfile` to `2.0.0`, `async-tungstenite` to `0.24.0`, `ws_stream_tungstenite` to `0.12.0`
   and `http` to `1.0.0`. This is a breaking change as types from some of these crates are part of
   the public API.
+- `publish` / `subscribe` / `unsubscribe` methods on `AsyncClient` and `Client` now return a `PkidPromise` which resolves into the identifier value chosen by the `EventLoop` when handling the packet. 
 
 ### Deprecated
 

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -24,7 +24,7 @@ proxy = ["dep:async-http-proxy"]
 
 [dependencies]
 futures-util = { version = "0.3", default-features = false, features = ["std", "sink"] }
-tokio = { version = "1.36", features = ["rt", "macros", "io-util", "net", "time"] }
+tokio = { version = "1.36", features = ["rt", "macros", "io-util", "net", "time", "sync"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 bytes = "1.5"
 log = "0.4"

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -58,6 +58,7 @@ matches = "0.1"
 pretty_assertions = "1"
 pretty_env_logger = "0.5"
 serde = { version = "1", features = ["derive"] }
+tokio-util = { version = "0.7", features = ["time"] }
 
 [[example]]
 name = "tls"

--- a/rumqttc/examples/ack_notif.rs
+++ b/rumqttc/examples/ack_notif.rs
@@ -1,0 +1,65 @@
+use tokio::task::{self, JoinSet};
+
+use rumqttc::{AsyncClient, MqttOptions, QoS};
+use std::error::Error;
+use std::time::Duration;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn Error>> {
+    pretty_env_logger::init();
+    // color_backtrace::install();
+
+    let mut mqttoptions = MqttOptions::new("test-1", "localhost", 1883);
+    mqttoptions.set_keep_alive(Duration::from_secs(5));
+
+    let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    task::spawn(async move {
+        loop {
+            let event = eventloop.poll().await;
+            match &event {
+                Ok(v) => {
+                    println!("Event = {v:?}");
+                }
+                Err(e) => {
+                    println!("Error = {e:?}");
+                }
+            }
+        }
+    });
+
+    // Subscribe and wait for broker acknowledgement
+    client
+        .subscribe("hello/world", QoS::AtMostOnce)
+        .await
+        .unwrap()
+        .wait_async()
+        .await
+        .unwrap();
+
+    // Publish and spawn wait for notification
+    let mut set = JoinSet::new();
+
+    let future = client
+        .publish("hello/world", QoS::AtMostOnce, false, vec![1; 1024])
+        .await
+        .unwrap();
+    set.spawn(future.wait_async());
+
+    let future = client
+        .publish("hello/world", QoS::AtLeastOnce, false, vec![1; 1024])
+        .await
+        .unwrap();
+    set.spawn(future.wait_async());
+
+    let future = client
+        .publish("hello/world", QoS::ExactlyOnce, false, vec![1; 1024])
+        .await
+        .unwrap();
+    set.spawn(future.wait_async());
+
+    while let Some(res) = set.join_next().await {
+        println!("Acknoledged = {:?}", res?);
+    }
+
+    Ok(())
+}

--- a/rumqttc/examples/pkid_promise.rs
+++ b/rumqttc/examples/pkid_promise.rs
@@ -1,0 +1,61 @@
+use tokio::{
+    task::{self, JoinSet},
+    time,
+};
+
+use rumqttc::{AsyncClient, MqttOptions, QoS};
+use std::error::Error;
+use std::time::Duration;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn Error>> {
+    pretty_env_logger::init();
+    // color_backtrace::install();
+
+    let mut mqttoptions = MqttOptions::new("test-1", "localhost", 1883);
+    mqttoptions.set_keep_alive(Duration::from_secs(5));
+
+    let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    task::spawn(async move {
+        requests(client).await;
+    });
+
+    loop {
+        let event = eventloop.poll().await;
+        match &event {
+            Ok(v) => {
+                println!("Event = {v:?}");
+            }
+            Err(e) => {
+                println!("Error = {e:?}");
+                return Ok(());
+            }
+        }
+    }
+}
+
+async fn requests(client: AsyncClient) {
+    let mut joins = JoinSet::new();
+    joins.spawn(
+        client
+            .subscribe("hello/world", QoS::AtMostOnce)
+            .await
+            .unwrap(),
+    );
+
+    for i in 1..=10 {
+        joins.spawn(
+            client
+                .publish("hello/world", QoS::ExactlyOnce, false, vec![1; i])
+                .await
+                .unwrap(),
+        );
+
+        time::sleep(Duration::from_secs(1)).await;
+    }
+
+    // TODO: maybe rewrite to showcase in-between resolutions?
+    while let Some(Ok(Ok(pkid))) = joins.join_next().await {
+        println!("Pkid: {:?}", pkid);
+    }
+}

--- a/rumqttc/examples/pkid_promise.rs
+++ b/rumqttc/examples/pkid_promise.rs
@@ -61,7 +61,7 @@ async fn requests(client: AsyncClient) {
                         .unwrap().wait_async(),
                 );
             }
-            Some(Ok(Some(pkid))) = joins.join_next() => {
+            Some(Ok(Ok(pkid))) = joins.join_next() => {
                 println!("Pkid: {:?}", pkid);
             }
             else => break,

--- a/rumqttc/examples/pkid_promise.rs
+++ b/rumqttc/examples/pkid_promise.rs
@@ -42,7 +42,8 @@ async fn requests(client: AsyncClient) {
         client
             .subscribe("hello/world", QoS::AtMostOnce)
             .await
-            .unwrap(),
+            .unwrap()
+            .wait_async(),
     );
 
     let mut queue = DelayQueue::new();
@@ -57,10 +58,10 @@ async fn requests(client: AsyncClient) {
                     client
                         .publish("hello/world", QoS::ExactlyOnce, false, vec![1; i.into_inner()])
                         .await
-                        .unwrap(),
+                        .unwrap().wait_async(),
                 );
             }
-            Some(Ok(Ok(pkid))) = joins.join_next() => {
+            Some(Ok(Some(pkid))) = joins.join_next() => {
                 println!("Pkid: {:?}", pkid);
             }
             else => break,

--- a/rumqttc/examples/pkid_promise.rs
+++ b/rumqttc/examples/pkid_promise.rs
@@ -1,7 +1,9 @@
+use futures_util::stream::StreamExt;
 use tokio::{
+    select,
     task::{self, JoinSet},
-    time,
 };
+use tokio_util::time::DelayQueue;
 
 use rumqttc::{AsyncClient, MqttOptions, QoS};
 use std::error::Error;
@@ -12,7 +14,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
     // color_backtrace::install();
 
-    let mut mqttoptions = MqttOptions::new("test-1", "localhost", 1883);
+    let mut mqttoptions = MqttOptions::new("test-1", "broker.emqx.io", 1883);
     mqttoptions.set_keep_alive(Duration::from_secs(5));
 
     let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
@@ -43,19 +45,25 @@ async fn requests(client: AsyncClient) {
             .unwrap(),
     );
 
+    let mut queue = DelayQueue::new();
     for i in 1..=10 {
-        joins.spawn(
-            client
-                .publish("hello/world", QoS::ExactlyOnce, false, vec![1; i])
-                .await
-                .unwrap(),
-        );
-
-        time::sleep(Duration::from_secs(1)).await;
+        queue.insert(i as usize, Duration::from_secs(i));
     }
 
-    // TODO: maybe rewrite to showcase in-between resolutions?
-    while let Some(Ok(Ok(pkid))) = joins.join_next().await {
-        println!("Pkid: {:?}", pkid);
+    loop {
+        select! {
+            Some(i) = queue.next() => {
+                joins.spawn(
+                    client
+                        .publish("hello/world", QoS::ExactlyOnce, false, vec![1; i.into_inner()])
+                        .await
+                        .unwrap(),
+                );
+            }
+            Some(Ok(Ok(pkid))) = joins.join_next() => {
+                println!("Pkid: {:?}", pkid);
+            }
+            else => break,
+        }
     }
 }

--- a/rumqttc/examples/pkid_promise_v5.rs
+++ b/rumqttc/examples/pkid_promise_v5.rs
@@ -61,7 +61,7 @@ async fn requests(client: AsyncClient) {
                         .unwrap().wait_async(),
                 );
             }
-            Some(Ok(Some(pkid))) = joins.join_next() => {
+            Some(Ok(Ok(pkid))) = joins.join_next() => {
                 println!("Pkid: {:?}", pkid);
             }
             else => break,

--- a/rumqttc/examples/pkid_promise_v5.rs
+++ b/rumqttc/examples/pkid_promise_v5.rs
@@ -42,7 +42,8 @@ async fn requests(client: AsyncClient) {
         client
             .subscribe("hello/world", QoS::AtMostOnce)
             .await
-            .unwrap(),
+            .unwrap()
+            .wait_async(),
     );
 
     let mut queue = DelayQueue::new();
@@ -57,10 +58,10 @@ async fn requests(client: AsyncClient) {
                     client
                         .publish("hello/world", QoS::ExactlyOnce, false, vec![1; i.into_inner()])
                         .await
-                        .unwrap(),
+                        .unwrap().wait_async(),
                 );
             }
-            Some(Ok(Ok(pkid))) = joins.join_next() => {
+            Some(Ok(Some(pkid))) = joins.join_next() => {
                 println!("Pkid: {:?}", pkid);
             }
             else => break,

--- a/rumqttc/examples/pkid_promise_v5.rs
+++ b/rumqttc/examples/pkid_promise_v5.rs
@@ -1,0 +1,69 @@
+use futures_util::stream::StreamExt;
+use tokio::{
+    select,
+    task::{self, JoinSet},
+};
+use tokio_util::time::DelayQueue;
+
+use rumqttc::v5::{mqttbytes::QoS, AsyncClient, MqttOptions};
+use std::error::Error;
+use std::time::Duration;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn Error>> {
+    pretty_env_logger::init();
+    // color_backtrace::install();
+
+    let mut mqttoptions = MqttOptions::new("test-1", "broker.emqx.io", 1883);
+    mqttoptions.set_keep_alive(Duration::from_secs(5));
+
+    let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+    task::spawn(async move {
+        requests(client).await;
+    });
+
+    loop {
+        let event = eventloop.poll().await;
+        match &event {
+            Ok(v) => {
+                println!("Event = {v:?}");
+            }
+            Err(e) => {
+                println!("Error = {e:?}");
+                return Ok(());
+            }
+        }
+    }
+}
+
+async fn requests(client: AsyncClient) {
+    let mut joins = JoinSet::new();
+    joins.spawn(
+        client
+            .subscribe("hello/world", QoS::AtMostOnce)
+            .await
+            .unwrap(),
+    );
+
+    let mut queue = DelayQueue::new();
+    for i in 1..=10 {
+        queue.insert(i as usize, Duration::from_secs(i));
+    }
+
+    loop {
+        select! {
+            Some(i) = queue.next() => {
+                joins.spawn(
+                    client
+                        .publish("hello/world", QoS::ExactlyOnce, false, vec![1; i.into_inner()])
+                        .await
+                        .unwrap(),
+                );
+            }
+            Some(Ok(Ok(pkid))) = joins.join_next() => {
+                println!("Pkid: {:?}", pkid);
+            }
+            else => break,
+        }
+    }
+}

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -84,7 +84,12 @@ impl AsyncClient {
         publish.retain = retain;
 
         let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-        publish.place_pkid_tx(pkid_tx);
+        // Fulfill instantly for QoS 0
+        if qos == QoS::AtMostOnce {
+            _ = pkid_tx.send(0);
+        } else {
+            publish.place_pkid_tx(pkid_tx);
+        }
 
         let publish = Request::Publish(publish);
         if !valid_topic(&topic) {
@@ -111,7 +116,11 @@ impl AsyncClient {
         publish.retain = retain;
 
         let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-        publish.place_pkid_tx(pkid_tx);
+        if qos == QoS::AtMostOnce {
+            _ = pkid_tx.send(0);
+        } else {
+            publish.place_pkid_tx(pkid_tx);
+        }
 
         let publish = Request::Publish(publish);
         if !valid_topic(&topic) {
@@ -155,7 +164,11 @@ impl AsyncClient {
         publish.retain = retain;
 
         let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-        publish.place_pkid_tx(pkid_tx);
+        if qos == QoS::AtMostOnce {
+            _ = pkid_tx.send(0);
+        } else {
+            publish.place_pkid_tx(pkid_tx);
+        }
 
         let publish = Request::Publish(publish);
         self.request_tx.send_async(publish).await?;
@@ -348,7 +361,11 @@ impl Client {
         publish.retain = retain;
 
         let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-        publish.place_pkid_tx(pkid_tx);
+        if qos == QoS::AtMostOnce {
+            _ = pkid_tx.send(0);
+        } else {
+            publish.place_pkid_tx(pkid_tx);
+        }
 
         let publish = Request::Publish(publish);
         if !valid_topic(&topic) {

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -4,7 +4,8 @@ use std::time::Duration;
 
 use crate::mqttbytes::{v4::*, QoS};
 use crate::{
-    valid_filter, valid_topic, ConnectionError, Event, EventLoop, MqttOptions, PkidPromise, Request,
+    valid_filter, valid_topic, ConnectionError, Event, EventLoop, MqttOptions, NoticeFuture,
+    NoticeTx, Request,
 };
 
 use bytes::Bytes;
@@ -74,7 +75,7 @@ impl AsyncClient {
         qos: QoS,
         retain: bool,
         payload: V,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         S: Into<String>,
         V: Into<Vec<u8>>,
@@ -83,21 +84,15 @@ impl AsyncClient {
         let mut publish = Publish::new(&topic, qos, payload);
         publish.retain = retain;
 
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-        // Fulfill instantly for QoS 0
-        let pkid_tx = if qos == QoS::AtMostOnce {
-            _ = pkid_tx.send(0);
-            None
-        } else {
-            Some(pkid_tx)
-        };
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
+        let notice_tx = Some(NoticeTx(notice_tx));
 
-        let publish = Request::Publish(pkid_tx, publish);
+        let publish = Request::Publish(notice_tx, publish);
         if !valid_topic(&topic) {
             return Err(ClientError::Request(publish));
         }
         self.request_tx.send_async(publish).await?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     /// Attempts to send a MQTT Publish to the `EventLoop`.
@@ -107,7 +102,7 @@ impl AsyncClient {
         qos: QoS,
         retain: bool,
         payload: V,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         S: Into<String>,
         V: Into<Vec<u8>>,
@@ -116,21 +111,22 @@ impl AsyncClient {
         let mut publish = Publish::new(&topic, qos, payload);
         publish.retain = retain;
 
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
+        let notice_tx = NoticeTx(notice_tx);
         // Fulfill instantly for QoS 0
-        let pkid_tx = if qos == QoS::AtMostOnce {
-            _ = pkid_tx.send(0);
+        let notice_tx = if qos == QoS::AtMostOnce {
+            notice_tx.success();
             None
         } else {
-            Some(pkid_tx)
+            Some(notice_tx)
         };
 
-        let publish = Request::Publish(pkid_tx, publish);
+        let publish = Request::Publish(notice_tx, publish);
         if !valid_topic(&topic) {
             return Err(ClientError::TryRequest(publish));
         }
         self.request_tx.try_send(publish)?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     /// Sends a MQTT PubAck to the `EventLoop`. Only needed in if `manual_acks` flag is set.
@@ -159,25 +155,19 @@ impl AsyncClient {
         qos: QoS,
         retain: bool,
         payload: Bytes,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         S: Into<String>,
     {
         let mut publish = Publish::from_bytes(topic, qos, payload);
         publish.retain = retain;
 
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-        // Fulfill instantly for QoS 0
-        let pkid_tx = if qos == QoS::AtMostOnce {
-            _ = pkid_tx.send(0);
-            None
-        } else {
-            Some(pkid_tx)
-        };
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
+        let notice_tx = Some(NoticeTx(notice_tx));
 
-        let publish = Request::Publish(pkid_tx, publish);
+        let publish = Request::Publish(notice_tx, publish);
         self.request_tx.send_async(publish).await?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     /// Sends a MQTT Subscribe to the `EventLoop`
@@ -185,18 +175,17 @@ impl AsyncClient {
         &self,
         topic: S,
         qos: QoS,
-    ) -> Result<PkidPromise, ClientError> {
+    ) -> Result<NoticeFuture, ClientError> {
         let topic = topic.into();
         let subscribe = Subscribe::new(&topic, qos);
-
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-
-        let request = Request::Subscribe(Some(pkid_tx), subscribe);
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
+        let notice_tx = NoticeTx(notice_tx);
+        let request = Request::Subscribe(Some(notice_tx), subscribe);
         if !valid_filter(&topic) {
             return Err(ClientError::Request(request));
         }
         self.request_tx.send_async(request).await?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     /// Attempts to send a MQTT Subscribe to the `EventLoop`
@@ -204,78 +193,78 @@ impl AsyncClient {
         &self,
         topic: S,
         qos: QoS,
-    ) -> Result<PkidPromise, ClientError> {
+    ) -> Result<NoticeFuture, ClientError> {
         let topic = topic.into();
         let subscribe = Subscribe::new(&topic, qos);
-
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-
-        let request = Request::Subscribe(Some(pkid_tx), subscribe);
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
+        let notice_tx = NoticeTx(notice_tx);
+        let request = Request::Subscribe(Some(notice_tx), subscribe);
         if !valid_filter(&topic) {
             return Err(ClientError::TryRequest(request));
         }
         self.request_tx.try_send(request)?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     /// Sends a MQTT Subscribe for multiple topics to the `EventLoop`
-    pub async fn subscribe_many<T>(&self, topics: T) -> Result<PkidPromise, ClientError>
+    pub async fn subscribe_many<T>(&self, topics: T) -> Result<NoticeFuture, ClientError>
     where
         T: IntoIterator<Item = SubscribeFilter>,
     {
         let mut topics_iter = topics.into_iter();
         let is_valid_filters = topics_iter.all(|filter| valid_filter(&filter.path));
         let subscribe = Subscribe::new_many(topics_iter);
-
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-
-        let request = Request::Subscribe(Some(pkid_tx), subscribe);
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
+        let notice_tx = NoticeTx(notice_tx);
+        let request = Request::Subscribe(Some(notice_tx), subscribe);
         if !is_valid_filters {
             return Err(ClientError::Request(request));
         }
         self.request_tx.send_async(request).await?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     /// Attempts to send a MQTT Subscribe for multiple topics to the `EventLoop`
-    pub fn try_subscribe_many<T>(&self, topics: T) -> Result<PkidPromise, ClientError>
+    pub fn try_subscribe_many<T>(&self, topics: T) -> Result<NoticeFuture, ClientError>
     where
         T: IntoIterator<Item = SubscribeFilter>,
     {
         let mut topics_iter = topics.into_iter();
         let is_valid_filters = topics_iter.all(|filter| valid_filter(&filter.path));
         let subscribe = Subscribe::new_many(topics_iter);
-
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-
-        let request = Request::Subscribe(Some(pkid_tx), subscribe);
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
+        let notice_tx = NoticeTx(notice_tx);
+        let request = Request::Subscribe(Some(notice_tx), subscribe);
         if !is_valid_filters {
             return Err(ClientError::TryRequest(request));
         }
         self.request_tx.try_send(request)?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     /// Sends a MQTT Unsubscribe to the `EventLoop`
-    pub async fn unsubscribe<S: Into<String>>(&self, topic: S) -> Result<PkidPromise, ClientError> {
+    pub async fn unsubscribe<S: Into<String>>(
+        &self,
+        topic: S,
+    ) -> Result<NoticeFuture, ClientError> {
         let unsubscribe = Unsubscribe::new(topic.into());
 
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-
-        let request = Request::Unsubscribe(Some(pkid_tx), unsubscribe);
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
+        let notice_tx = NoticeTx(notice_tx);
+        let request = Request::Unsubscribe(Some(notice_tx), unsubscribe);
         self.request_tx.send_async(request).await?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     /// Attempts to send a MQTT Unsubscribe to the `EventLoop`
-    pub fn try_unsubscribe<S: Into<String>>(&self, topic: S) -> Result<PkidPromise, ClientError> {
+    pub fn try_unsubscribe<S: Into<String>>(&self, topic: S) -> Result<NoticeFuture, ClientError> {
         let unsubscribe = Unsubscribe::new(topic.into());
 
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-
-        let request = Request::Unsubscribe(Some(pkid_tx), unsubscribe);
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
+        let notice_tx = NoticeTx(notice_tx);
+        let request = Request::Unsubscribe(Some(notice_tx), unsubscribe);
         self.request_tx.try_send(request)?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     /// Sends a MQTT disconnect to the `EventLoop`
@@ -350,7 +339,7 @@ impl Client {
         qos: QoS,
         retain: bool,
         payload: V,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         S: Into<String>,
         V: Into<Vec<u8>>,
@@ -359,21 +348,15 @@ impl Client {
         let mut publish = Publish::new(&topic, qos, payload);
         publish.retain = retain;
 
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-        // Fulfill instantly for QoS 0
-        let pkid_tx = if qos == QoS::AtMostOnce {
-            _ = pkid_tx.send(0);
-            None
-        } else {
-            Some(pkid_tx)
-        };
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
+        let notice_tx = Some(NoticeTx(notice_tx));
 
-        let publish = Request::Publish(pkid_tx, publish);
+        let publish = Request::Publish(notice_tx, publish);
         if !valid_topic(&topic) {
             return Err(ClientError::Request(publish));
         }
         self.client.request_tx.send(publish)?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     pub fn try_publish<S, V>(
@@ -382,7 +365,7 @@ impl Client {
         qos: QoS,
         retain: bool,
         payload: V,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         S: Into<String>,
         V: Into<Vec<u8>>,
@@ -411,18 +394,17 @@ impl Client {
         &self,
         topic: S,
         qos: QoS,
-    ) -> Result<PkidPromise, ClientError> {
+    ) -> Result<NoticeFuture, ClientError> {
         let topic = topic.into();
         let subscribe = Subscribe::new(&topic, qos);
-
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-
-        let request = Request::Subscribe(Some(pkid_tx), subscribe);
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
+        let notice_tx = NoticeTx(notice_tx);
+        let request = Request::Subscribe(Some(notice_tx), subscribe);
         if !valid_filter(&topic) {
             return Err(ClientError::Request(request));
         }
         self.client.request_tx.send(request)?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     /// Sends a MQTT Subscribe to the `EventLoop`
@@ -430,30 +412,29 @@ impl Client {
         &self,
         topic: S,
         qos: QoS,
-    ) -> Result<PkidPromise, ClientError> {
+    ) -> Result<NoticeFuture, ClientError> {
         self.client.try_subscribe(topic, qos)
     }
 
     /// Sends a MQTT Subscribe for multiple topics to the `EventLoop`
-    pub fn subscribe_many<T>(&self, topics: T) -> Result<PkidPromise, ClientError>
+    pub fn subscribe_many<T>(&self, topics: T) -> Result<NoticeFuture, ClientError>
     where
         T: IntoIterator<Item = SubscribeFilter>,
     {
         let mut topics_iter = topics.into_iter();
         let is_valid_filters = topics_iter.all(|filter| valid_filter(&filter.path));
         let subscribe = Subscribe::new_many(topics_iter);
-
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-
-        let request = Request::Subscribe(Some(pkid_tx), subscribe);
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
+        let notice_tx = NoticeTx(notice_tx);
+        let request = Request::Subscribe(Some(notice_tx), subscribe);
         if !is_valid_filters {
             return Err(ClientError::Request(request));
         }
         self.client.request_tx.send(request)?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
-    pub fn try_subscribe_many<T>(&self, topics: T) -> Result<PkidPromise, ClientError>
+    pub fn try_subscribe_many<T>(&self, topics: T) -> Result<NoticeFuture, ClientError>
     where
         T: IntoIterator<Item = SubscribeFilter>,
     {
@@ -461,18 +442,18 @@ impl Client {
     }
 
     /// Sends a MQTT Unsubscribe to the `EventLoop`
-    pub fn unsubscribe<S: Into<String>>(&self, topic: S) -> Result<PkidPromise, ClientError> {
+    pub fn unsubscribe<S: Into<String>>(&self, topic: S) -> Result<NoticeFuture, ClientError> {
         let unsubscribe = Unsubscribe::new(topic.into());
 
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-
-        let request = Request::Unsubscribe(Some(pkid_tx), unsubscribe);
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
+        let notice_tx = NoticeTx(notice_tx);
+        let request = Request::Unsubscribe(Some(notice_tx), unsubscribe);
         self.client.request_tx.send(request)?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     /// Sends a MQTT Unsubscribe to the `EventLoop`
-    pub fn try_unsubscribe<S: Into<String>>(&self, topic: S) -> Result<PkidPromise, ClientError> {
+    pub fn try_unsubscribe<S: Into<String>>(&self, topic: S) -> Result<NoticeFuture, ClientError> {
         self.client.try_unsubscribe(topic)
     }
 

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -3,7 +3,9 @@
 use std::time::Duration;
 
 use crate::mqttbytes::{v4::*, QoS};
-use crate::{valid_filter, valid_topic, ConnectionError, Event, EventLoop, MqttOptions, Request};
+use crate::{
+    valid_filter, valid_topic, ConnectionError, Event, EventLoop, MqttOptions, PkidPromise, Request,
+};
 
 use bytes::Bytes;
 use flume::{SendError, Sender, TrySendError};
@@ -72,7 +74,7 @@ impl AsyncClient {
         qos: QoS,
         retain: bool,
         payload: V,
-    ) -> Result<(), ClientError>
+    ) -> Result<PkidPromise, ClientError>
     where
         S: Into<String>,
         V: Into<Vec<u8>>,
@@ -80,12 +82,16 @@ impl AsyncClient {
         let topic = topic.into();
         let mut publish = Publish::new(&topic, qos, payload);
         publish.retain = retain;
+
+        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
+        publish.place_pkid_tx(pkid_tx);
+
         let publish = Request::Publish(publish);
         if !valid_topic(&topic) {
             return Err(ClientError::Request(publish));
         }
         self.request_tx.send_async(publish).await?;
-        Ok(())
+        Ok(pkid_rx)
     }
 
     /// Attempts to send a MQTT Publish to the `EventLoop`.
@@ -95,7 +101,7 @@ impl AsyncClient {
         qos: QoS,
         retain: bool,
         payload: V,
-    ) -> Result<(), ClientError>
+    ) -> Result<PkidPromise, ClientError>
     where
         S: Into<String>,
         V: Into<Vec<u8>>,
@@ -103,12 +109,16 @@ impl AsyncClient {
         let topic = topic.into();
         let mut publish = Publish::new(&topic, qos, payload);
         publish.retain = retain;
+
+        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
+        publish.place_pkid_tx(pkid_tx);
+
         let publish = Request::Publish(publish);
         if !valid_topic(&topic) {
             return Err(ClientError::TryRequest(publish));
         }
         self.request_tx.try_send(publish)?;
-        Ok(())
+        Ok(pkid_rx)
     }
 
     /// Sends a MQTT PubAck to the `EventLoop`. Only needed in if `manual_acks` flag is set.
@@ -137,87 +147,123 @@ impl AsyncClient {
         qos: QoS,
         retain: bool,
         payload: Bytes,
-    ) -> Result<(), ClientError>
+    ) -> Result<PkidPromise, ClientError>
     where
         S: Into<String>,
     {
         let mut publish = Publish::from_bytes(topic, qos, payload);
         publish.retain = retain;
+
+        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
+        publish.place_pkid_tx(pkid_tx);
+
         let publish = Request::Publish(publish);
         self.request_tx.send_async(publish).await?;
-        Ok(())
+        Ok(pkid_rx)
     }
 
     /// Sends a MQTT Subscribe to the `EventLoop`
-    pub async fn subscribe<S: Into<String>>(&self, topic: S, qos: QoS) -> Result<(), ClientError> {
+    pub async fn subscribe<S: Into<String>>(
+        &self,
+        topic: S,
+        qos: QoS,
+    ) -> Result<PkidPromise, ClientError> {
         let topic = topic.into();
-        let subscribe = Subscribe::new(&topic, qos);
+        let mut subscribe = Subscribe::new(&topic, qos);
+
+        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
+        subscribe.place_pkid_tx(pkid_tx);
+
         let request = Request::Subscribe(subscribe);
         if !valid_filter(&topic) {
             return Err(ClientError::Request(request));
         }
         self.request_tx.send_async(request).await?;
-        Ok(())
+        Ok(pkid_rx)
     }
 
     /// Attempts to send a MQTT Subscribe to the `EventLoop`
-    pub fn try_subscribe<S: Into<String>>(&self, topic: S, qos: QoS) -> Result<(), ClientError> {
+    pub fn try_subscribe<S: Into<String>>(
+        &self,
+        topic: S,
+        qos: QoS,
+    ) -> Result<PkidPromise, ClientError> {
         let topic = topic.into();
-        let subscribe = Subscribe::new(&topic, qos);
+        let mut subscribe = Subscribe::new(&topic, qos);
+
+        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
+        subscribe.place_pkid_tx(pkid_tx);
+
         let request = Request::Subscribe(subscribe);
         if !valid_filter(&topic) {
             return Err(ClientError::TryRequest(request));
         }
         self.request_tx.try_send(request)?;
-        Ok(())
+        Ok(pkid_rx)
     }
 
     /// Sends a MQTT Subscribe for multiple topics to the `EventLoop`
-    pub async fn subscribe_many<T>(&self, topics: T) -> Result<(), ClientError>
+    pub async fn subscribe_many<T>(&self, topics: T) -> Result<PkidPromise, ClientError>
     where
         T: IntoIterator<Item = SubscribeFilter>,
     {
         let mut topics_iter = topics.into_iter();
         let is_valid_filters = topics_iter.all(|filter| valid_filter(&filter.path));
-        let subscribe = Subscribe::new_many(topics_iter);
+        let mut subscribe = Subscribe::new_many(topics_iter);
+
+        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
+        subscribe.place_pkid_tx(pkid_tx);
+
         let request = Request::Subscribe(subscribe);
         if !is_valid_filters {
             return Err(ClientError::Request(request));
         }
         self.request_tx.send_async(request).await?;
-        Ok(())
+        Ok(pkid_rx)
     }
 
     /// Attempts to send a MQTT Subscribe for multiple topics to the `EventLoop`
-    pub fn try_subscribe_many<T>(&self, topics: T) -> Result<(), ClientError>
+    pub fn try_subscribe_many<T>(&self, topics: T) -> Result<PkidPromise, ClientError>
     where
         T: IntoIterator<Item = SubscribeFilter>,
     {
         let mut topics_iter = topics.into_iter();
         let is_valid_filters = topics_iter.all(|filter| valid_filter(&filter.path));
-        let subscribe = Subscribe::new_many(topics_iter);
+        let mut subscribe = Subscribe::new_many(topics_iter);
+
+        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
+        subscribe.place_pkid_tx(pkid_tx);
+
         let request = Request::Subscribe(subscribe);
         if !is_valid_filters {
             return Err(ClientError::TryRequest(request));
         }
         self.request_tx.try_send(request)?;
-        Ok(())
+        Ok(pkid_rx)
     }
 
     /// Sends a MQTT Unsubscribe to the `EventLoop`
-    pub async fn unsubscribe<S: Into<String>>(&self, topic: S) -> Result<(), ClientError> {
-        let unsubscribe = Unsubscribe::new(topic.into());
+    pub async fn unsubscribe<S: Into<String>>(&self, topic: S) -> Result<PkidPromise, ClientError> {
+        let mut unsubscribe = Unsubscribe::new(topic.into());
+
+        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
+        unsubscribe.place_pkid_tx(pkid_tx);
+
         let request = Request::Unsubscribe(unsubscribe);
         self.request_tx.send_async(request).await?;
-        Ok(())
+        Ok(pkid_rx)
     }
 
     /// Attempts to send a MQTT Unsubscribe to the `EventLoop`
-    pub fn try_unsubscribe<S: Into<String>>(&self, topic: S) -> Result<(), ClientError> {
-        let unsubscribe = Unsubscribe::new(topic.into());
+    pub fn try_unsubscribe<S: Into<String>>(&self, topic: S) -> Result<PkidPromise, ClientError> {
+        let mut unsubscribe = Unsubscribe::new(topic.into());
+
+        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
+        unsubscribe.place_pkid_tx(pkid_tx);
+
         let request = Request::Unsubscribe(unsubscribe);
         self.request_tx.try_send(request)?;
-        Ok(())
+        Ok(pkid_rx)
     }
 
     /// Sends a MQTT disconnect to the `EventLoop`
@@ -292,7 +338,7 @@ impl Client {
         qos: QoS,
         retain: bool,
         payload: V,
-    ) -> Result<(), ClientError>
+    ) -> Result<PkidPromise, ClientError>
     where
         S: Into<String>,
         V: Into<Vec<u8>>,
@@ -300,12 +346,16 @@ impl Client {
         let topic = topic.into();
         let mut publish = Publish::new(&topic, qos, payload);
         publish.retain = retain;
+
+        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
+        publish.place_pkid_tx(pkid_tx);
+
         let publish = Request::Publish(publish);
         if !valid_topic(&topic) {
             return Err(ClientError::Request(publish));
         }
         self.client.request_tx.send(publish)?;
-        Ok(())
+        Ok(pkid_rx)
     }
 
     pub fn try_publish<S, V>(
@@ -314,13 +364,12 @@ impl Client {
         qos: QoS,
         retain: bool,
         payload: V,
-    ) -> Result<(), ClientError>
+    ) -> Result<PkidPromise, ClientError>
     where
         S: Into<String>,
         V: Into<Vec<u8>>,
     {
-        self.client.try_publish(topic, qos, retain, payload)?;
-        Ok(())
+        self.client.try_publish(topic, qos, retain, payload)
     }
 
     /// Sends a MQTT PubAck to the `EventLoop`. Only needed in if `manual_acks` flag is set.
@@ -340,40 +389,55 @@ impl Client {
     }
 
     /// Sends a MQTT Subscribe to the `EventLoop`
-    pub fn subscribe<S: Into<String>>(&self, topic: S, qos: QoS) -> Result<(), ClientError> {
+    pub fn subscribe<S: Into<String>>(
+        &self,
+        topic: S,
+        qos: QoS,
+    ) -> Result<PkidPromise, ClientError> {
         let topic = topic.into();
-        let subscribe = Subscribe::new(&topic, qos);
+        let mut subscribe = Subscribe::new(&topic, qos);
+
+        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
+        subscribe.place_pkid_tx(pkid_tx);
+
         let request = Request::Subscribe(subscribe);
         if !valid_filter(&topic) {
             return Err(ClientError::Request(request));
         }
         self.client.request_tx.send(request)?;
-        Ok(())
+        Ok(pkid_rx)
     }
 
     /// Sends a MQTT Subscribe to the `EventLoop`
-    pub fn try_subscribe<S: Into<String>>(&self, topic: S, qos: QoS) -> Result<(), ClientError> {
-        self.client.try_subscribe(topic, qos)?;
-        Ok(())
+    pub fn try_subscribe<S: Into<String>>(
+        &self,
+        topic: S,
+        qos: QoS,
+    ) -> Result<PkidPromise, ClientError> {
+        self.client.try_subscribe(topic, qos)
     }
 
     /// Sends a MQTT Subscribe for multiple topics to the `EventLoop`
-    pub fn subscribe_many<T>(&self, topics: T) -> Result<(), ClientError>
+    pub fn subscribe_many<T>(&self, topics: T) -> Result<PkidPromise, ClientError>
     where
         T: IntoIterator<Item = SubscribeFilter>,
     {
         let mut topics_iter = topics.into_iter();
         let is_valid_filters = topics_iter.all(|filter| valid_filter(&filter.path));
-        let subscribe = Subscribe::new_many(topics_iter);
+        let mut subscribe = Subscribe::new_many(topics_iter);
+
+        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
+        subscribe.place_pkid_tx(pkid_tx);
+
         let request = Request::Subscribe(subscribe);
         if !is_valid_filters {
             return Err(ClientError::Request(request));
         }
         self.client.request_tx.send(request)?;
-        Ok(())
+        Ok(pkid_rx)
     }
 
-    pub fn try_subscribe_many<T>(&self, topics: T) -> Result<(), ClientError>
+    pub fn try_subscribe_many<T>(&self, topics: T) -> Result<PkidPromise, ClientError>
     where
         T: IntoIterator<Item = SubscribeFilter>,
     {
@@ -381,17 +445,20 @@ impl Client {
     }
 
     /// Sends a MQTT Unsubscribe to the `EventLoop`
-    pub fn unsubscribe<S: Into<String>>(&self, topic: S) -> Result<(), ClientError> {
-        let unsubscribe = Unsubscribe::new(topic.into());
+    pub fn unsubscribe<S: Into<String>>(&self, topic: S) -> Result<PkidPromise, ClientError> {
+        let mut unsubscribe = Unsubscribe::new(topic.into());
+
+        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
+        unsubscribe.place_pkid_tx(pkid_tx);
+
         let request = Request::Unsubscribe(unsubscribe);
         self.client.request_tx.send(request)?;
-        Ok(())
+        Ok(pkid_rx)
     }
 
     /// Sends a MQTT Unsubscribe to the `EventLoop`
-    pub fn try_unsubscribe<S: Into<String>>(&self, topic: S) -> Result<(), ClientError> {
-        self.client.try_unsubscribe(topic)?;
-        Ok(())
+    pub fn try_unsubscribe<S: Into<String>>(&self, topic: S) -> Result<PkidPromise, ClientError> {
+        self.client.try_unsubscribe(topic)
     }
 
     /// Sends a MQTT disconnect to the `EventLoop`

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -96,7 +96,7 @@ impl AsyncClient {
             return Err(ClientError::Request(publish));
         }
         self.request_tx.send_async(publish).await?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     /// Attempts to send a MQTT Publish to the `EventLoop`.
@@ -127,7 +127,7 @@ impl AsyncClient {
             return Err(ClientError::TryRequest(publish));
         }
         self.request_tx.try_send(publish)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     /// Sends a MQTT PubAck to the `EventLoop`. Only needed in if `manual_acks` flag is set.
@@ -172,7 +172,7 @@ impl AsyncClient {
 
         let publish = Request::Publish(publish);
         self.request_tx.send_async(publish).await?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     /// Sends a MQTT Subscribe to the `EventLoop`
@@ -192,7 +192,7 @@ impl AsyncClient {
             return Err(ClientError::Request(request));
         }
         self.request_tx.send_async(request).await?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     /// Attempts to send a MQTT Subscribe to the `EventLoop`
@@ -212,7 +212,7 @@ impl AsyncClient {
             return Err(ClientError::TryRequest(request));
         }
         self.request_tx.try_send(request)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     /// Sends a MQTT Subscribe for multiple topics to the `EventLoop`
@@ -232,7 +232,7 @@ impl AsyncClient {
             return Err(ClientError::Request(request));
         }
         self.request_tx.send_async(request).await?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     /// Attempts to send a MQTT Subscribe for multiple topics to the `EventLoop`
@@ -252,7 +252,7 @@ impl AsyncClient {
             return Err(ClientError::TryRequest(request));
         }
         self.request_tx.try_send(request)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     /// Sends a MQTT Unsubscribe to the `EventLoop`
@@ -264,7 +264,7 @@ impl AsyncClient {
 
         let request = Request::Unsubscribe(unsubscribe);
         self.request_tx.send_async(request).await?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     /// Attempts to send a MQTT Unsubscribe to the `EventLoop`
@@ -276,7 +276,7 @@ impl AsyncClient {
 
         let request = Request::Unsubscribe(unsubscribe);
         self.request_tx.try_send(request)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     /// Sends a MQTT disconnect to the `EventLoop`
@@ -372,7 +372,7 @@ impl Client {
             return Err(ClientError::Request(publish));
         }
         self.client.request_tx.send(publish)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub fn try_publish<S, V>(
@@ -422,7 +422,7 @@ impl Client {
             return Err(ClientError::Request(request));
         }
         self.client.request_tx.send(request)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     /// Sends a MQTT Subscribe to the `EventLoop`
@@ -451,7 +451,7 @@ impl Client {
             return Err(ClientError::Request(request));
         }
         self.client.request_tx.send(request)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub fn try_subscribe_many<T>(&self, topics: T) -> Result<PkidPromise, ClientError>
@@ -470,7 +470,7 @@ impl Client {
 
         let request = Request::Unsubscribe(unsubscribe);
         self.client.request_tx.send(request)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     /// Sends a MQTT Unsubscribe to the `EventLoop`

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -76,11 +76,11 @@ pub struct EventLoop {
     /// Current state of the connection
     pub state: MqttState,
     /// Request stream
-    requests_rx: Receiver<(Option<NoticeTx>, Request)>,
+    requests_rx: Receiver<(NoticeTx, Request)>,
     /// Requests handle to send requests
-    pub(crate) requests_tx: Sender<(Option<NoticeTx>, Request)>,
+    pub(crate) requests_tx: Sender<(NoticeTx, Request)>,
     /// Pending packets from last session
-    pub pending: VecDeque<(Option<NoticeTx>, Request)>,
+    pub pending: VecDeque<(NoticeTx, Request)>,
     /// Network connection to the broker
     pub network: Option<Network>,
     /// Keep alive time
@@ -261,7 +261,8 @@ impl EventLoop {
                 let timeout = self.keepalive_timeout.as_mut().unwrap();
                 timeout.as_mut().reset(Instant::now() + self.mqtt_options.keep_alive);
 
-                if let Some(outgoing) = self.state.handle_outgoing_packet(None, Request::PingReq(PingReq))? {
+                let (tx, _) = NoticeTx::new();
+                if let Some(outgoing) = self.state.handle_outgoing_packet(tx, Request::PingReq(PingReq))? {
                     network.write(outgoing).await?;
                 }
                 match time::timeout(network_timeout, network.flush()).await {
@@ -283,10 +284,10 @@ impl EventLoop {
     }
 
     async fn next_request(
-        pending: &mut VecDeque<(Option<NoticeTx>, Request)>,
-        rx: &Receiver<(Option<NoticeTx>, Request)>,
+        pending: &mut VecDeque<(NoticeTx, Request)>,
+        rx: &Receiver<(NoticeTx, Request)>,
         pending_throttle: Duration,
-    ) -> Result<(Option<NoticeTx>, Request), ConnectionError> {
+    ) -> Result<(NoticeTx, Request), ConnectionError> {
         if !pending.is_empty() {
             time::sleep(pending_throttle).await;
             // We must call .pop_front() AFTER sleep() otherwise we would have

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -160,46 +160,57 @@ pub use proxy::{Proxy, ProxyAuth, ProxyType};
 
 pub type Incoming = Packet;
 
-pub type Pkid = u16;
-
-/// A token through which the user can access the assigned packet id of an associated request, once it
-/// is processed by the [`EventLoop`].
-pub struct PkidPromise {
-    inner: oneshot::Receiver<Pkid>,
-}
+use v5::mqttbytes::v5::{SubscribeReasonCode as V5SubscribeReasonCode, UnsubAckReason};
 
 #[derive(Debug, thiserror::Error)]
-pub enum PkidError {
+pub enum NoticeError {
     #[error("Eventloop dropped Sender")]
     Recv,
+    #[error(" v4 Subscription Failure Reason Code: {0:?}")]
+    V4Subscribe(SubscribeReasonCode),
+    #[error(" v5 Subscription Failure Reason Code: {0:?}")]
+    V5Subscribe(V5SubscribeReasonCode),
+    #[error(" v5 Unsubscription Failure Reason: {0:?}")]
+    V5Unsubscribe(UnsubAckReason),
 }
 
-impl From<oneshot::error::RecvError> for PkidError {
+impl From<oneshot::error::RecvError> for NoticeError {
     fn from(_: oneshot::error::RecvError) -> Self {
         Self::Recv
     }
 }
 
-impl PkidPromise {
-    pub fn new(inner: oneshot::Receiver<Pkid>) -> Self {
-        Self { inner }
-    }
+type NoticeResult = Result<(), NoticeError>;
 
-    /// Wait for the pkid to resolve by blocking the current thread
+/// A token through which the user is notified of the publish/subscribe/unsubscribe packet being acked by the broker.
+#[derive(Debug)]
+pub struct NoticeFuture(oneshot::Receiver<NoticeResult>);
+
+impl NoticeFuture {
+    /// Wait for broker to acknowledge by blocking the current thread
     ///
     /// # Panics
     /// Panics if called in an async context
-    pub fn wait(self) -> Result<Pkid, PkidError> {
-        let pkid = self.inner.blocking_recv()?;
-
-        Ok(pkid)
+    pub fn wait(self) -> NoticeResult {
+        self.0.blocking_recv()?
     }
 
-    /// Await pkid resolution without blocking the current thread
-    pub async fn wait_async(self) -> Result<Pkid, PkidError> {
-        let pkid = self.inner.await?;
+    /// Await the packet acknowledgement from broker, without blocking the current thread
+    pub async fn wait_async(self) -> NoticeResult {
+        self.0.await?
+    }
+}
 
-        Ok(pkid)
+#[derive(Debug)]
+pub struct NoticeTx(oneshot::Sender<NoticeResult>);
+
+impl NoticeTx {
+    fn success(self) {
+        _ = self.0.send(Ok(()));
+    }
+
+    fn error(self, e: NoticeError) {
+        _ = self.0.send(Err(e));
     }
 }
 
@@ -234,60 +245,19 @@ pub enum Outgoing {
 /// handled one by one.
 #[derive(Debug)]
 pub enum Request {
-    Publish(Option<oneshot::Sender<Pkid>>, Publish),
+    Publish(Option<NoticeTx>, Publish),
     PubAck(PubAck),
     PubRec(PubRec),
     PubComp(PubComp),
-    PubRel(PubRel),
+    PubRel(Option<NoticeTx>, PubRel),
     PingReq(PingReq),
     PingResp(PingResp),
-    Subscribe(Option<oneshot::Sender<Pkid>>, Subscribe),
+    Subscribe(Option<NoticeTx>, Subscribe),
     SubAck(SubAck),
-    Unsubscribe(Option<oneshot::Sender<Pkid>>, Unsubscribe),
+    Unsubscribe(Option<NoticeTx>, Unsubscribe),
     UnsubAck(UnsubAck),
     Disconnect(Disconnect),
 }
-
-impl Clone for Request {
-    fn clone(&self) -> Self {
-        match self {
-            Self::Publish(_, p) => Self::Publish(None, p.clone()),
-            Self::PubAck(p) => Self::PubAck(p.clone()),
-            Self::PubRec(p) => Self::PubRec(p.clone()),
-            Self::PubRel(p) => Self::PubRel(p.clone()),
-            Self::PubComp(p) => Self::PubComp(p.clone()),
-            Self::Subscribe(_, p) => Self::Subscribe(None, p.clone()),
-            Self::SubAck(p) => Self::SubAck(p.clone()),
-            Self::PingReq(p) => Self::PingReq(p.clone()),
-            Self::PingResp(p) => Self::PingResp(p.clone()),
-            Self::Disconnect(p) => Self::Disconnect(p.clone()),
-            Self::Unsubscribe(_, p) => Self::Unsubscribe(None, p.clone()),
-            Self::UnsubAck(p) => Self::UnsubAck(p.clone()),
-        }
-    }
-}
-
-impl PartialEq for Request {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Publish(_, p1), Self::Publish(_, p2)) => p1 == p2,
-            (Self::PubAck(p1), Self::PubAck(p2)) => p1 == p2,
-            (Self::PubRec(p1), Self::PubRec(p2)) => p1 == p2,
-            (Self::PubRel(p1), Self::PubRel(p2)) => p1 == p2,
-            (Self::PubComp(p1), Self::PubComp(p2)) => p1 == p2,
-            (Self::Subscribe(_, p1), Self::Subscribe(_, p2)) => p1 == p2,
-            (Self::SubAck(p1), Self::SubAck(p2)) => p1 == p2,
-            (Self::PingReq(p1), Self::PingReq(p2)) => p1 == p2,
-            (Self::PingResp(p1), Self::PingResp(p2)) => p1 == p2,
-            (Self::Unsubscribe(_, p1), Self::Unsubscribe(_, p2)) => p1 == p2,
-            (Self::UnsubAck(p1), Self::UnsubAck(p2)) => p1 == p2,
-            (Self::Disconnect(p1), Self::Disconnect(p2)) => p1 == p2,
-            _ => false,
-        }
-    }
-}
-
-impl Eq for Request {}
 
 impl Request {
     fn size(&self) -> usize {
@@ -296,7 +266,7 @@ impl Request {
             Request::PubAck(puback) => puback.size(),
             Request::PubRec(pubrec) => pubrec.size(),
             Request::PubComp(pubcomp) => pubcomp.size(),
-            Request::PubRel(pubrel) => pubrel.size(),
+            Request::PubRel(_, pubrel) => pubrel.size(),
             Request::PingReq(pingreq) => pingreq.size(),
             Request::PingResp(pingresp) => pingresp.size(),
             Request::Subscribe(_, subscribe) => subscribe.size(),

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -159,6 +159,9 @@ pub use proxy::{Proxy, ProxyAuth, ProxyType};
 
 pub type Incoming = Packet;
 
+pub type Pkid = u16;
+pub type PkidPromise = tokio::sync::oneshot::Receiver<Pkid>;
+
 /// Current outgoing activity on the eventloop
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Outgoing {

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -170,8 +170,14 @@ pub struct PkidPromise {
 
 #[derive(Debug, thiserror::Error)]
 pub enum PkidError {
-    #[error("Eventloop dropped Sender: {0}")]
-    Recv(#[from] oneshot::error::RecvError),
+    #[error("Eventloop dropped Sender")]
+    Recv,
+}
+
+impl From<oneshot::error::RecvError> for PkidError {
+    fn from(_: oneshot::error::RecvError) -> Self {
+        Self::Recv
+    }
 }
 
 impl PkidPromise {

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -145,6 +145,7 @@ use rustls_native_certs::load_native_certs;
 pub use state::{MqttState, StateError};
 #[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]
 pub use tls::Error as TlsError;
+use tokio::sync::oneshot;
 #[cfg(feature = "use-native-tls")]
 pub use tokio_native_tls;
 #[cfg(feature = "use-native-tls")]
@@ -160,7 +161,28 @@ pub use proxy::{Proxy, ProxyAuth, ProxyType};
 pub type Incoming = Packet;
 
 pub type Pkid = u16;
-pub type PkidPromise = tokio::sync::oneshot::Receiver<Pkid>;
+
+/// A token through which the user can access the assigned packet id of an associated request, once it
+/// is processed by the [`EventLoop`].
+pub struct PkidPromise {
+    inner: oneshot::Receiver<Pkid>,
+}
+
+impl PkidPromise {
+    pub fn new(inner: oneshot::Receiver<Pkid>) -> Self {
+        Self { inner }
+    }
+
+    /// Wait for the pkid to resolve by blocking the current thread
+    pub fn wait(self) -> Option<Pkid> {
+        self.inner.blocking_recv().ok()
+    }
+
+    /// Await pkid resolution without blocking the current thread
+    pub async fn wait_async(self) -> Option<Pkid> {
+        self.inner.await.ok()
+    }
+}
 
 /// Current outgoing activity on the eventloop
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -213,37 +213,97 @@ pub enum Outgoing {
 
 /// Requests by the client to mqtt event loop. Request are
 /// handled one by one.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum Request {
-    Publish(Publish),
+    Publish(Option<oneshot::Sender<Pkid>>, Publish),
     PubAck(PubAck),
     PubRec(PubRec),
     PubComp(PubComp),
     PubRel(PubRel),
     PingReq(PingReq),
     PingResp(PingResp),
-    Subscribe(Subscribe),
+    Subscribe(Option<oneshot::Sender<Pkid>>, Subscribe),
     SubAck(SubAck),
-    Unsubscribe(Unsubscribe),
+    Unsubscribe(Option<oneshot::Sender<Pkid>>, Unsubscribe),
     UnsubAck(UnsubAck),
     Disconnect(Disconnect),
 }
 
+impl Clone for Request {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Publish(_, p) => Self::Publish(None, p.clone()),
+            Self::PubAck(p) => Self::PubAck(p.clone()),
+            Self::PubRec(p) => Self::PubRec(p.clone()),
+            Self::PubRel(p) => Self::PubRel(p.clone()),
+            Self::PubComp(p) => Self::PubComp(p.clone()),
+            Self::Subscribe(_, p) => Self::Subscribe(None, p.clone()),
+            Self::SubAck(p) => Self::SubAck(p.clone()),
+            Self::PingReq(p) => Self::PingReq(p.clone()),
+            Self::PingResp(p) => Self::PingResp(p.clone()),
+            Self::Disconnect(p) => Self::Disconnect(p.clone()),
+            Self::Unsubscribe(_, p) => Self::Unsubscribe(None, p.clone()),
+            Self::UnsubAck(p) => Self::UnsubAck(p.clone()),
+        }
+    }
+}
+
+impl PartialEq for Request {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Publish(_, p1), Self::Publish(_, p2)) => p1 == p2,
+            (Self::PubAck(p1), Self::PubAck(p2)) => p1 == p2,
+            (Self::PubRec(p1), Self::PubRec(p2)) => p1 == p2,
+            (Self::PubRel(p1), Self::PubRel(p2)) => p1 == p2,
+            (Self::PubComp(p1), Self::PubComp(p2)) => p1 == p2,
+            (Self::Subscribe(_, p1), Self::Subscribe(_, p2)) => p1 == p2,
+            (Self::SubAck(p1), Self::SubAck(p2)) => p1 == p2,
+            (Self::PingReq(p1), Self::PingReq(p2)) => p1 == p2,
+            (Self::PingResp(p1), Self::PingResp(p2)) => p1 == p2,
+            (Self::Unsubscribe(_, p1), Self::Unsubscribe(_, p2)) => p1 == p2,
+            (Self::UnsubAck(p1), Self::UnsubAck(p2)) => p1 == p2,
+            (Self::Disconnect(p1), Self::Disconnect(p2)) => p1 == p2,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for Request {}
+
+impl Request {
+    fn size(&self) -> usize {
+        match &self {
+            Request::Publish(_, publish) => publish.size(),
+            Request::PubAck(puback) => puback.size(),
+            Request::PubRec(pubrec) => pubrec.size(),
+            Request::PubComp(pubcomp) => pubcomp.size(),
+            Request::PubRel(pubrel) => pubrel.size(),
+            Request::PingReq(pingreq) => pingreq.size(),
+            Request::PingResp(pingresp) => pingresp.size(),
+            Request::Subscribe(_, subscribe) => subscribe.size(),
+            Request::SubAck(suback) => suback.size(),
+            Request::Unsubscribe(_, unsubscribe) => unsubscribe.size(),
+            Request::UnsubAck(unsuback) => unsuback.size(),
+            Request::Disconnect(disconn) => disconn.size(),
+        }
+    }
+}
+
 impl From<Publish> for Request {
     fn from(publish: Publish) -> Request {
-        Request::Publish(publish)
+        Request::Publish(None, publish)
     }
 }
 
 impl From<Subscribe> for Request {
     fn from(subscribe: Subscribe) -> Request {
-        Request::Subscribe(subscribe)
+        Request::Subscribe(None, subscribe)
     }
 }
 
 impl From<Unsubscribe> for Request {
     fn from(unsubscribe: Unsubscribe) -> Request {
-        Request::Unsubscribe(unsubscribe)
+        Request::Unsubscribe(None, unsubscribe)
     }
 }
 

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -109,6 +109,7 @@ mod client;
 mod eventloop;
 mod framed;
 pub mod mqttbytes;
+mod notice;
 mod state;
 pub mod v5;
 
@@ -140,6 +141,8 @@ pub use client::{
 pub use eventloop::{ConnectionError, Event, EventLoop};
 pub use mqttbytes::v4::*;
 pub use mqttbytes::*;
+use notice::NoticeTx;
+pub use notice::{NoticeError, NoticeFuture};
 #[cfg(feature = "use-rustls")]
 use rustls_native_certs::load_native_certs;
 pub use state::{MqttState, StateError};
@@ -159,60 +162,6 @@ use tokio_rustls::rustls::{ClientConfig, RootCertStore};
 pub use proxy::{Proxy, ProxyAuth, ProxyType};
 
 pub type Incoming = Packet;
-
-use v5::mqttbytes::v5::{SubscribeReasonCode as V5SubscribeReasonCode, UnsubAckReason};
-
-#[derive(Debug, thiserror::Error)]
-pub enum NoticeError {
-    #[error("Eventloop dropped Sender")]
-    Recv,
-    #[error(" v4 Subscription Failure Reason Code: {0:?}")]
-    V4Subscribe(SubscribeReasonCode),
-    #[error(" v5 Subscription Failure Reason Code: {0:?}")]
-    V5Subscribe(V5SubscribeReasonCode),
-    #[error(" v5 Unsubscription Failure Reason: {0:?}")]
-    V5Unsubscribe(UnsubAckReason),
-}
-
-impl From<oneshot::error::RecvError> for NoticeError {
-    fn from(_: oneshot::error::RecvError) -> Self {
-        Self::Recv
-    }
-}
-
-type NoticeResult = Result<(), NoticeError>;
-
-/// A token through which the user is notified of the publish/subscribe/unsubscribe packet being acked by the broker.
-#[derive(Debug)]
-pub struct NoticeFuture(oneshot::Receiver<NoticeResult>);
-
-impl NoticeFuture {
-    /// Wait for broker to acknowledge by blocking the current thread
-    ///
-    /// # Panics
-    /// Panics if called in an async context
-    pub fn wait(self) -> NoticeResult {
-        self.0.blocking_recv()?
-    }
-
-    /// Await the packet acknowledgement from broker, without blocking the current thread
-    pub async fn wait_async(self) -> NoticeResult {
-        self.0.await?
-    }
-}
-
-#[derive(Debug)]
-pub struct NoticeTx(oneshot::Sender<NoticeResult>);
-
-impl NoticeTx {
-    fn success(self) {
-        _ = self.0.send(Ok(()));
-    }
-
-    fn error(self, e: NoticeError) {
-        _ = self.0.send(Err(e));
-    }
-}
 
 /// Current outgoing activity on the eventloop
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -243,18 +192,18 @@ pub enum Outgoing {
 
 /// Requests by the client to mqtt event loop. Request are
 /// handled one by one.
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Request {
-    Publish(Option<NoticeTx>, Publish),
+    Publish(Publish),
     PubAck(PubAck),
     PubRec(PubRec),
     PubComp(PubComp),
-    PubRel(Option<NoticeTx>, PubRel),
+    PubRel(PubRel),
     PingReq(PingReq),
     PingResp(PingResp),
-    Subscribe(Option<NoticeTx>, Subscribe),
+    Subscribe(Subscribe),
     SubAck(SubAck),
-    Unsubscribe(Option<NoticeTx>, Unsubscribe),
+    Unsubscribe(Unsubscribe),
     UnsubAck(UnsubAck),
     Disconnect(Disconnect),
 }
@@ -262,16 +211,16 @@ pub enum Request {
 impl Request {
     fn size(&self) -> usize {
         match &self {
-            Request::Publish(_, publish) => publish.size(),
+            Request::Publish(publish) => publish.size(),
             Request::PubAck(puback) => puback.size(),
             Request::PubRec(pubrec) => pubrec.size(),
             Request::PubComp(pubcomp) => pubcomp.size(),
-            Request::PubRel(_, pubrel) => pubrel.size(),
+            Request::PubRel(pubrel) => pubrel.size(),
             Request::PingReq(pingreq) => pingreq.size(),
             Request::PingResp(pingresp) => pingresp.size(),
-            Request::Subscribe(_, subscribe) => subscribe.size(),
+            Request::Subscribe(subscribe) => subscribe.size(),
             Request::SubAck(suback) => suback.size(),
-            Request::Unsubscribe(_, unsubscribe) => unsubscribe.size(),
+            Request::Unsubscribe(unsubscribe) => unsubscribe.size(),
             Request::UnsubAck(unsuback) => unsuback.size(),
             Request::Disconnect(disconn) => disconn.size(),
         }
@@ -280,19 +229,19 @@ impl Request {
 
 impl From<Publish> for Request {
     fn from(publish: Publish) -> Request {
-        Request::Publish(None, publish)
+        Request::Publish(publish)
     }
 }
 
 impl From<Subscribe> for Request {
     fn from(subscribe: Subscribe) -> Request {
-        Request::Subscribe(None, subscribe)
+        Request::Subscribe(subscribe)
     }
 }
 
 impl From<Unsubscribe> for Request {
     fn from(unsubscribe: Unsubscribe) -> Request {
-        Request::Unsubscribe(None, unsubscribe)
+        Request::Unsubscribe(unsubscribe)
     }
 }
 

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -168,19 +168,32 @@ pub struct PkidPromise {
     inner: oneshot::Receiver<Pkid>,
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum PkidError {
+    #[error("Eventloop dropped Sender: {0}")]
+    Recv(#[from] oneshot::error::RecvError),
+}
+
 impl PkidPromise {
     pub fn new(inner: oneshot::Receiver<Pkid>) -> Self {
         Self { inner }
     }
 
     /// Wait for the pkid to resolve by blocking the current thread
-    pub fn wait(self) -> Option<Pkid> {
-        self.inner.blocking_recv().ok()
+    ///
+    /// # Panics
+    /// Panics if called in an async context
+    pub fn wait(self) -> Result<Pkid, PkidError> {
+        let pkid = self.inner.blocking_recv()?;
+
+        Ok(pkid)
     }
 
     /// Await pkid resolution without blocking the current thread
-    pub async fn wait_async(self) -> Option<Pkid> {
-        self.inner.await.ok()
+    pub async fn wait_async(self) -> Result<Pkid, PkidError> {
+        let pkid = self.inner.await?;
+
+        Ok(pkid)
     }
 }
 

--- a/rumqttc/src/mqttbytes/v4/unsubscribe.rs
+++ b/rumqttc/src/mqttbytes/v4/unsubscribe.rs
@@ -1,42 +1,18 @@
-use bytes::{Buf, Bytes};
-use tokio::sync::oneshot::Sender;
-
 use super::*;
-use crate::Pkid;
+use bytes::{Buf, Bytes};
 
 /// Unsubscribe packet
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Unsubscribe {
     pub pkid: u16,
     pub topics: Vec<String>,
-    pub pkid_tx: Option<Sender<Pkid>>,
 }
-
-// TODO: figure out if this is even required
-impl Clone for Unsubscribe {
-    fn clone(&self) -> Self {
-        Self {
-            pkid: self.pkid,
-            topics: self.topics.clone(),
-            pkid_tx: None,
-        }
-    }
-}
-
-impl PartialEq for Unsubscribe {
-    fn eq(&self, other: &Self) -> bool {
-        self.pkid == other.pkid && self.topics == other.topics
-    }
-}
-
-impl Eq for Unsubscribe {}
 
 impl Unsubscribe {
     pub fn new<S: Into<String>>(topic: S) -> Unsubscribe {
         Unsubscribe {
             pkid: 0,
             topics: vec![topic.into()],
-            pkid_tx: None,
         }
     }
 
@@ -66,11 +42,7 @@ impl Unsubscribe {
             topics.push(topic_filter);
         }
 
-        let unsubscribe = Unsubscribe {
-            pkid,
-            topics,
-            pkid_tx: None,
-        };
+        let unsubscribe = Unsubscribe { pkid, topics };
         Ok(unsubscribe)
     }
 
@@ -85,9 +57,5 @@ impl Unsubscribe {
             write_mqtt_string(payload, topic.as_str());
         }
         Ok(1 + remaining_len_bytes + remaining_len)
-    }
-
-    pub fn place_pkid_tx(&mut self, pkid_tx: Sender<Pkid>) {
-        self.pkid_tx = Some(pkid_tx)
     }
 }

--- a/rumqttc/src/mqttbytes/v4/unsubscribe.rs
+++ b/rumqttc/src/mqttbytes/v4/unsubscribe.rs
@@ -1,18 +1,42 @@
-use super::*;
 use bytes::{Buf, Bytes};
+use tokio::sync::oneshot::Sender;
+
+use super::*;
+use crate::Pkid;
 
 /// Unsubscribe packet
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct Unsubscribe {
     pub pkid: u16,
     pub topics: Vec<String>,
+    pub pkid_tx: Option<Sender<Pkid>>,
 }
+
+// TODO: figure out if this is even required
+impl Clone for Unsubscribe {
+    fn clone(&self) -> Self {
+        Self {
+            pkid: self.pkid,
+            topics: self.topics.clone(),
+            pkid_tx: None,
+        }
+    }
+}
+
+impl PartialEq for Unsubscribe {
+    fn eq(&self, other: &Self) -> bool {
+        self.pkid == other.pkid && self.topics == other.topics
+    }
+}
+
+impl Eq for Unsubscribe {}
 
 impl Unsubscribe {
     pub fn new<S: Into<String>>(topic: S) -> Unsubscribe {
         Unsubscribe {
             pkid: 0,
             topics: vec![topic.into()],
+            pkid_tx: None,
         }
     }
 
@@ -42,7 +66,11 @@ impl Unsubscribe {
             topics.push(topic_filter);
         }
 
-        let unsubscribe = Unsubscribe { pkid, topics };
+        let unsubscribe = Unsubscribe {
+            pkid,
+            topics,
+            pkid_tx: None,
+        };
         Ok(unsubscribe)
     }
 
@@ -57,5 +85,9 @@ impl Unsubscribe {
             write_mqtt_string(payload, topic.as_str());
         }
         Ok(1 + remaining_len_bytes + remaining_len)
+    }
+
+    pub fn place_pkid_tx(&mut self, pkid_tx: Sender<Pkid>) {
+        self.pkid_tx = Some(pkid_tx)
     }
 }

--- a/rumqttc/src/notice.rs
+++ b/rumqttc/src/notice.rs
@@ -48,6 +48,12 @@ impl NoticeFuture {
 pub struct NoticeTx(pub(crate) oneshot::Sender<NoticeResult>);
 
 impl NoticeTx {
+    pub fn new() -> (Self, NoticeFuture) {
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
+
+        (NoticeTx(notice_tx), NoticeFuture(notice_rx))
+    }
+
     pub(crate) fn success(self) {
         _ = self.0.send(Ok(()));
     }

--- a/rumqttc/src/notice.rs
+++ b/rumqttc/src/notice.rs
@@ -1,0 +1,58 @@
+use tokio::sync::oneshot;
+
+use crate::{
+    v5::mqttbytes::v5::{SubscribeReasonCode as V5SubscribeReasonCode, UnsubAckReason},
+    SubscribeReasonCode,
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum NoticeError {
+    #[error("Eventloop dropped Sender")]
+    Recv,
+    #[error(" v4 Subscription Failure Reason Code: {0:?}")]
+    V4Subscribe(SubscribeReasonCode),
+    #[error(" v5 Subscription Failure Reason Code: {0:?}")]
+    V5Subscribe(V5SubscribeReasonCode),
+    #[error(" v5 Unsubscription Failure Reason: {0:?}")]
+    V5Unsubscribe(UnsubAckReason),
+}
+
+impl From<oneshot::error::RecvError> for NoticeError {
+    fn from(_: oneshot::error::RecvError) -> Self {
+        Self::Recv
+    }
+}
+
+type NoticeResult = Result<(), NoticeError>;
+
+/// A token through which the user is notified of the publish/subscribe/unsubscribe packet being acked by the broker.
+#[derive(Debug)]
+pub struct NoticeFuture(pub(crate) oneshot::Receiver<NoticeResult>);
+
+impl NoticeFuture {
+    /// Wait for broker to acknowledge by blocking the current thread
+    ///
+    /// # Panics
+    /// Panics if called in an async context
+    pub fn wait(self) -> NoticeResult {
+        self.0.blocking_recv()?
+    }
+
+    /// Await the packet acknowledgement from broker, without blocking the current thread
+    pub async fn wait_async(self) -> NoticeResult {
+        self.0.await?
+    }
+}
+
+#[derive(Debug)]
+pub struct NoticeTx(pub(crate) oneshot::Sender<NoticeResult>);
+
+impl NoticeTx {
+    pub(crate) fn success(self) {
+        _ = self.0.send(Ok(()));
+    }
+
+    pub(crate) fn error(self, e: NoticeError) {
+        _ = self.0.send(Err(e));
+    }
+}

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -64,17 +64,17 @@ pub struct MqttState {
     /// Maximum number of allowed inflight
     pub(crate) max_inflight: u16,
     /// Outgoing QoS 1, 2 publishes which aren't acked yet
-    pub(crate) outgoing_pub: HashMap<u16, (Publish, Option<NoticeTx>)>,
+    pub(crate) outgoing_pub: HashMap<u16, (Publish, NoticeTx)>,
     /// Packet ids of released QoS 2 publishes
-    pub(crate) outgoing_rel: HashMap<u16, Option<NoticeTx>>,
+    pub(crate) outgoing_rel: HashMap<u16, NoticeTx>,
     /// Packet ids on incoming QoS 2 publishes
     pub(crate) incoming_pub: FixedBitSet,
 
-    outgoing_sub: HashMap<u16, Option<NoticeTx>>,
-    outgoing_unsub: HashMap<u16, Option<NoticeTx>>,
+    outgoing_sub: HashMap<u16, NoticeTx>,
+    outgoing_unsub: HashMap<u16, NoticeTx>,
 
     /// Last collision due to broker not acking in order
-    pub(crate) collision: Option<(Publish, Option<NoticeTx>)>,
+    pub(crate) collision: Option<(Publish, NoticeTx)>,
     /// Buffered incoming packets
     pub events: VecDeque<Event>,
     /// Indicates if acknowledgements should be send immediately
@@ -109,7 +109,7 @@ impl MqttState {
     }
 
     /// Returns inflight outgoing packets and clears internal queues
-    pub fn clean(&mut self) -> Vec<(Option<NoticeTx>, Request)> {
+    pub fn clean(&mut self) -> Vec<(NoticeTx, Request)> {
         let mut pending = Vec::with_capacity(100);
 
         for (_, (publish, tx)) in self.outgoing_pub.drain() {
@@ -141,7 +141,7 @@ impl MqttState {
     /// be put on to the network by the eventloop
     pub fn handle_outgoing_packet(
         &mut self,
-        tx: Option<NoticeTx>,
+        tx: NoticeTx,
         request: Request,
     ) -> Result<Option<Packet>, StateError> {
         let packet = match request {
@@ -206,18 +206,12 @@ impl MqttState {
                     debug!("SubAck Pkid = {:?}, QoS = {:?}", suback.pkid, qos);
                 }
                 _ => {
-                    if let Some(tx) = tx {
-                        tx.error(NoticeError::V4Subscribe(*reason))
-                    }
-
+                    tx.error(NoticeError::V4Subscribe(*reason));
                     return Err(StateError::SubFail { reason: *reason });
                 }
             }
         }
-
-        if let Some(tx) = tx {
-            tx.success()
-        }
+        tx.success();
 
         Ok(None)
     }
@@ -230,14 +224,10 @@ impl MqttState {
             error!("Unsolicited unsuback packet: {:?}", unsuback.pkid);
             return Err(StateError::Unsolicited(unsuback.pkid));
         }
-
-        if let Some(tx) = self
-            .outgoing_sub
+        self.outgoing_sub
             .remove(&unsuback.pkid)
             .ok_or(StateError::Unsolicited(unsuback.pkid))?
-        {
-            tx.success()
-        }
+            .success();
 
         Ok(None)
     }
@@ -275,13 +265,11 @@ impl MqttState {
             return Err(StateError::Unsolicited(puback.pkid));
         }
 
-        if let (_, Some(tx)) = self
+        let (_, tx) = self
             .outgoing_pub
             .remove(&puback.pkid)
-            .ok_or(StateError::Unsolicited(puback.pkid))?
-        {
-            tx.success()
-        }
+            .ok_or(StateError::Unsolicited(puback.pkid))?;
+        tx.success();
 
         self.last_puback = puback.pkid;
 
@@ -340,13 +328,10 @@ impl MqttState {
             error!("Unsolicited pubcomp packet: {:?}", pubcomp.pkid);
             return Err(StateError::Unsolicited(pubcomp.pkid));
         }
-        if let Some(tx) = self
-            .outgoing_rel
+        self.outgoing_rel
             .remove(&pubcomp.pkid)
             .ok_or(StateError::Unsolicited(pubcomp.pkid))?
-        {
-            tx.success()
-        }
+            .success();
 
         self.inflight -= 1;
         let packet = self.check_collision(pubcomp.pkid).map(|(publish, tx)| {
@@ -373,7 +358,7 @@ impl MqttState {
     fn outgoing_publish(
         &mut self,
         mut publish: Publish,
-        notice_tx: Option<NoticeTx>,
+        notice_tx: NoticeTx,
     ) -> Result<Option<Packet>, StateError> {
         if publish.qos != QoS::AtMostOnce {
             if publish.pkid == 0 {
@@ -394,8 +379,8 @@ impl MqttState {
             // packet yet. This error is possible only when broker isn't acking sequentially
             self.outgoing_pub.insert(pkid, (publish.clone(), notice_tx));
             self.inflight += 1;
-        } else if let Some(tx) = notice_tx {
-            tx.success()
+        } else {
+            notice_tx.success()
         }
 
         debug!(
@@ -414,7 +399,7 @@ impl MqttState {
     fn outgoing_pubrel(
         &mut self,
         pubrel: PubRel,
-        notice_tx: Option<NoticeTx>,
+        notice_tx: NoticeTx,
     ) -> Result<Option<Packet>, StateError> {
         let pubrel = self.save_pubrel(pubrel, notice_tx)?;
 
@@ -477,7 +462,7 @@ impl MqttState {
     fn outgoing_subscribe(
         &mut self,
         mut subscription: Subscribe,
-        notice_tx: Option<NoticeTx>,
+        notice_tx: NoticeTx,
     ) -> Result<Option<Packet>, StateError> {
         if subscription.filters.is_empty() {
             return Err(StateError::EmptySubscription);
@@ -501,7 +486,7 @@ impl MqttState {
     fn outgoing_unsubscribe(
         &mut self,
         mut unsub: Unsubscribe,
-        notice_tx: Option<NoticeTx>,
+        notice_tx: NoticeTx,
     ) -> Result<Option<Packet>, StateError> {
         let pkid = self.next_pkid();
         unsub.pkid = pkid;
@@ -527,7 +512,7 @@ impl MqttState {
         Ok(Some(Packet::Disconnect))
     }
 
-    fn check_collision(&mut self, pkid: u16) -> Option<(Publish, Option<NoticeTx>)> {
+    fn check_collision(&mut self, pkid: u16) -> Option<(Publish, NoticeTx)> {
         if let Some((publish, _)) = &self.collision {
             if publish.pkid == pkid {
                 return self.collision.take();
@@ -540,7 +525,7 @@ impl MqttState {
     fn save_pubrel(
         &mut self,
         mut pubrel: PubRel,
-        notice_tx: Option<NoticeTx>,
+        notice_tx: NoticeTx,
     ) -> Result<PubRel, StateError> {
         let pubrel = match pubrel.pkid {
             // consider PacketIdentifier(0) as uninitialized packets
@@ -633,7 +618,8 @@ mod test {
         let publish = build_outgoing_publish(QoS::AtMostOnce);
 
         // QoS 0 publish shouldn't be saved in queue
-        mqtt.outgoing_publish(publish, None).unwrap();
+        let (tx, _) = NoticeTx::new();
+        mqtt.outgoing_publish(publish, tx).unwrap();
         assert_eq!(mqtt.last_pkid, 0);
         assert_eq!(mqtt.inflight, 0);
 
@@ -641,12 +627,14 @@ mod test {
         let publish = build_outgoing_publish(QoS::AtLeastOnce);
 
         // Packet id should be set and publish should be saved in queue
-        mqtt.outgoing_publish(publish.clone(), None).unwrap();
+        let (tx, _) = NoticeTx::new();
+        mqtt.outgoing_publish(publish.clone(), tx).unwrap();
         assert_eq!(mqtt.last_pkid, 1);
         assert_eq!(mqtt.inflight, 1);
 
         // Packet id should be incremented and publish should be saved in queue
-        mqtt.outgoing_publish(publish, None).unwrap();
+        let (tx, _) = NoticeTx::new();
+        mqtt.outgoing_publish(publish, tx).unwrap();
         assert_eq!(mqtt.last_pkid, 2);
         assert_eq!(mqtt.inflight, 2);
 
@@ -654,12 +642,14 @@ mod test {
         let publish = build_outgoing_publish(QoS::ExactlyOnce);
 
         // Packet id should be set and publish should be saved in queue
-        mqtt.outgoing_publish(publish.clone(), None).unwrap();
+        let (tx, _) = NoticeTx::new();
+        mqtt.outgoing_publish(publish.clone(), tx).unwrap();
         assert_eq!(mqtt.last_pkid, 3);
         assert_eq!(mqtt.inflight, 3);
 
         // Packet id should be incremented and publish should be saved in queue
-        mqtt.outgoing_publish(publish, None).unwrap();
+        let (tx, _) = NoticeTx::new();
+        mqtt.outgoing_publish(publish, tx).unwrap();
         assert_eq!(mqtt.last_pkid, 4);
         assert_eq!(mqtt.inflight, 4);
     }
@@ -745,8 +735,10 @@ mod test {
         let publish1 = build_outgoing_publish(QoS::AtLeastOnce);
         let publish2 = build_outgoing_publish(QoS::ExactlyOnce);
 
-        mqtt.outgoing_publish(publish1, None).unwrap();
-        mqtt.outgoing_publish(publish2, None).unwrap();
+        let (tx, _) = NoticeTx::new();
+        mqtt.outgoing_publish(publish1, tx).unwrap();
+        let (tx, _) = NoticeTx::new();
+        mqtt.outgoing_publish(publish2, tx).unwrap();
         assert_eq!(mqtt.inflight, 2);
 
         mqtt.handle_incoming_puback(&PubAck::new(1)).unwrap();
@@ -778,8 +770,10 @@ mod test {
         let publish1 = build_outgoing_publish(QoS::AtLeastOnce);
         let publish2 = build_outgoing_publish(QoS::ExactlyOnce);
 
-        let _publish_out = mqtt.outgoing_publish(publish1, None);
-        let _publish_out = mqtt.outgoing_publish(publish2, None);
+        let (tx, _) = NoticeTx::new();
+        let _publish_out = mqtt.outgoing_publish(publish1, tx);
+        let (tx, _) = NoticeTx::new();
+        let _publish_out = mqtt.outgoing_publish(publish2, tx);
 
         mqtt.handle_incoming_pubrec(&PubRec::new(2)).unwrap();
         assert_eq!(mqtt.inflight, 2);
@@ -797,7 +791,8 @@ mod test {
         let mut mqtt = build_mqttstate();
 
         let publish = build_outgoing_publish(QoS::ExactlyOnce);
-        let packet = mqtt.outgoing_publish(publish, None).unwrap().unwrap();
+        let (tx, _) = NoticeTx::new();
+        let packet = mqtt.outgoing_publish(publish, tx).unwrap().unwrap();
         match packet {
             Packet::Publish(publish) => assert_eq!(publish.pkid, 1),
             packet => panic!("Invalid network request: {:?}", packet),
@@ -839,7 +834,8 @@ mod test {
         let mut mqtt = build_mqttstate();
         let publish = build_outgoing_publish(QoS::ExactlyOnce);
 
-        mqtt.outgoing_publish(publish, None).unwrap();
+        let (tx, _) = NoticeTx::new();
+        mqtt.outgoing_publish(publish, tx).unwrap();
         mqtt.handle_incoming_pubrec(&PubRec::new(1)).unwrap();
 
         mqtt.handle_incoming_pubcomp(&PubComp::new(1)).unwrap();
@@ -853,7 +849,8 @@ mod test {
 
         // network activity other than pingresp
         let publish = build_outgoing_publish(QoS::AtLeastOnce);
-        mqtt.handle_outgoing_packet(None, Request::Publish(publish))
+        let (tx, _) = NoticeTx::new();
+        mqtt.handle_outgoing_packet(tx, Request::Publish(publish))
             .unwrap();
         mqtt.handle_incoming_packet(Incoming::PubAck(PubAck::new(1)))
             .unwrap();
@@ -882,8 +879,9 @@ mod test {
     fn clean_is_calculating_pending_correctly() {
         let mut mqtt = build_mqttstate();
 
-        fn build_outgoing_pub() -> HashMap<u16, (Publish, Option<NoticeTx>)> {
+        fn build_outgoing_pub() -> HashMap<u16, (Publish, NoticeTx)> {
             let mut outgoing_pub = HashMap::new();
+            let (tx, _) = NoticeTx::new();
             outgoing_pub.insert(
                 2,
                 (
@@ -895,9 +893,10 @@ mod test {
                         pkid: 1,
                         payload: "".into(),
                     },
-                    None,
+                    tx,
                 ),
             );
+            let (tx, _) = NoticeTx::new();
             outgoing_pub.insert(
                 3,
                 (
@@ -909,9 +908,10 @@ mod test {
                         pkid: 2,
                         payload: "".into(),
                     },
-                    None,
+                    tx,
                 ),
             );
+            let (tx, _) = NoticeTx::new();
             outgoing_pub.insert(
                 4,
                 (
@@ -923,10 +923,10 @@ mod test {
                         pkid: 3,
                         payload: "".into(),
                     },
-                    None,
+                    tx,
                 ),
             );
-
+            let (tx, _) = NoticeTx::new();
             outgoing_pub.insert(
                 7,
                 (
@@ -938,7 +938,7 @@ mod test {
                         pkid: 6,
                         payload: "".into(),
                     },
-                    None,
+                    tx,
                 ),
             );
 

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -1,10 +1,11 @@
-use crate::{Event, Incoming, Outgoing, Request};
+use crate::{Event, Incoming, Outgoing, Pkid, Request};
 
 use crate::mqttbytes::v4::*;
 use crate::mqttbytes::{self, *};
 use fixedbitset::FixedBitSet;
 use std::collections::VecDeque;
 use std::{io, time::Instant};
+use tokio::sync::oneshot;
 
 /// Errors during state handling
 #[derive(Debug, thiserror::Error)]
@@ -108,7 +109,7 @@ impl MqttState {
 
         for publish in second_half.iter_mut().chain(first_half) {
             if let Some(publish) = publish.take() {
-                let request = Request::Publish(publish);
+                let request = Request::Publish(None, publish);
                 pending.push(request);
             }
         }
@@ -140,10 +141,10 @@ impl MqttState {
         request: Request,
     ) -> Result<Option<Packet>, StateError> {
         let packet = match request {
-            Request::Publish(publish) => self.outgoing_publish(publish)?,
+            Request::Publish(tx, publish) => self.outgoing_publish(publish, tx)?,
             Request::PubRel(pubrel) => self.outgoing_pubrel(pubrel)?,
-            Request::Subscribe(subscribe) => self.outgoing_subscribe(subscribe)?,
-            Request::Unsubscribe(unsubscribe) => self.outgoing_unsubscribe(unsubscribe)?,
+            Request::Subscribe(tx, subscribe) => self.outgoing_subscribe(subscribe, tx)?,
+            Request::Unsubscribe(tx, unsubscribe) => self.outgoing_unsubscribe(unsubscribe, tx)?,
             Request::PingReq(_) => self.outgoing_ping()?,
             Request::Disconnect(_) => self.outgoing_disconnect()?,
             Request::PubAck(puback) => self.outgoing_puback(puback)?,
@@ -308,7 +309,11 @@ impl MqttState {
 
     /// Adds next packet identifier to QoS 1 and 2 publish packets and returns
     /// it buy wrapping publish in packet
-    fn outgoing_publish(&mut self, mut publish: Publish) -> Result<Option<Packet>, StateError> {
+    fn outgoing_publish(
+        &mut self,
+        mut publish: Publish,
+        pkid_tx: Option<oneshot::Sender<Pkid>>,
+    ) -> Result<Option<Packet>, StateError> {
         // NOTE: pkid promise need not be fulfilled for QoS 0,
         // user should know this but still handled in Client.
         if publish.qos != QoS::AtMostOnce {
@@ -318,7 +323,7 @@ impl MqttState {
 
             let pkid = publish.pkid;
             // Fulfill the pkid promise
-            if let Some(pkid_tx) = publish.pkid_tx.take() {
+            if let Some(pkid_tx) = pkid_tx {
                 _ = pkid_tx.send(pkid);
             }
 
@@ -416,6 +421,7 @@ impl MqttState {
     fn outgoing_subscribe(
         &mut self,
         mut subscription: Subscribe,
+        pkid_tx: Option<oneshot::Sender<Pkid>>,
     ) -> Result<Option<Packet>, StateError> {
         if subscription.filters.is_empty() {
             return Err(StateError::EmptySubscription);
@@ -424,7 +430,7 @@ impl MqttState {
         let pkid = self.next_pkid();
         subscription.pkid = pkid;
         // Fulfill the pkid promise
-        if let Some(pkid_tx) = subscription.pkid_tx.take() {
+        if let Some(pkid_tx) = pkid_tx {
             _ = pkid_tx.send(pkid);
         }
 
@@ -442,12 +448,13 @@ impl MqttState {
     fn outgoing_unsubscribe(
         &mut self,
         mut unsub: Unsubscribe,
+        pkid_tx: Option<oneshot::Sender<Pkid>>,
     ) -> Result<Option<Packet>, StateError> {
         let pkid = self.next_pkid();
         unsub.pkid = pkid;
 
         // Fulfill the pkid promise
-        if let Some(pkid_tx) = unsub.pkid_tx.take() {
+        if let Some(pkid_tx) = pkid_tx {
             _ = pkid_tx.send(pkid);
         }
 
@@ -571,7 +578,7 @@ mod test {
         let publish = build_outgoing_publish(QoS::AtMostOnce);
 
         // QoS 0 publish shouldn't be saved in queue
-        mqtt.outgoing_publish(publish).unwrap();
+        mqtt.outgoing_publish(publish, None).unwrap();
         assert_eq!(mqtt.last_pkid, 0);
         assert_eq!(mqtt.inflight, 0);
 
@@ -579,12 +586,12 @@ mod test {
         let publish = build_outgoing_publish(QoS::AtLeastOnce);
 
         // Packet id should be set and publish should be saved in queue
-        mqtt.outgoing_publish(publish.clone()).unwrap();
+        mqtt.outgoing_publish(publish.clone(), None).unwrap();
         assert_eq!(mqtt.last_pkid, 1);
         assert_eq!(mqtt.inflight, 1);
 
         // Packet id should be incremented and publish should be saved in queue
-        mqtt.outgoing_publish(publish).unwrap();
+        mqtt.outgoing_publish(publish, None).unwrap();
         assert_eq!(mqtt.last_pkid, 2);
         assert_eq!(mqtt.inflight, 2);
 
@@ -592,12 +599,12 @@ mod test {
         let publish = build_outgoing_publish(QoS::ExactlyOnce);
 
         // Packet id should be set and publish should be saved in queue
-        mqtt.outgoing_publish(publish.clone()).unwrap();
+        mqtt.outgoing_publish(publish.clone(), None).unwrap();
         assert_eq!(mqtt.last_pkid, 3);
         assert_eq!(mqtt.inflight, 3);
 
         // Packet id should be incremented and publish should be saved in queue
-        mqtt.outgoing_publish(publish).unwrap();
+        mqtt.outgoing_publish(publish, None).unwrap();
         assert_eq!(mqtt.last_pkid, 4);
         assert_eq!(mqtt.inflight, 4);
     }
@@ -683,8 +690,8 @@ mod test {
         let publish1 = build_outgoing_publish(QoS::AtLeastOnce);
         let publish2 = build_outgoing_publish(QoS::ExactlyOnce);
 
-        mqtt.outgoing_publish(publish1).unwrap();
-        mqtt.outgoing_publish(publish2).unwrap();
+        mqtt.outgoing_publish(publish1, None).unwrap();
+        mqtt.outgoing_publish(publish2, None).unwrap();
         assert_eq!(mqtt.inflight, 2);
 
         mqtt.handle_incoming_puback(&PubAck::new(1)).unwrap();
@@ -716,8 +723,8 @@ mod test {
         let publish1 = build_outgoing_publish(QoS::AtLeastOnce);
         let publish2 = build_outgoing_publish(QoS::ExactlyOnce);
 
-        let _publish_out = mqtt.outgoing_publish(publish1);
-        let _publish_out = mqtt.outgoing_publish(publish2);
+        let _publish_out = mqtt.outgoing_publish(publish1, None);
+        let _publish_out = mqtt.outgoing_publish(publish2, None);
 
         mqtt.handle_incoming_pubrec(&PubRec::new(2)).unwrap();
         assert_eq!(mqtt.inflight, 2);
@@ -735,7 +742,7 @@ mod test {
         let mut mqtt = build_mqttstate();
 
         let publish = build_outgoing_publish(QoS::ExactlyOnce);
-        let packet = mqtt.outgoing_publish(publish).unwrap().unwrap();
+        let packet = mqtt.outgoing_publish(publish, None).unwrap().unwrap();
         match packet {
             Packet::Publish(publish) => assert_eq!(publish.pkid, 1),
             packet => panic!("Invalid network request: {:?}", packet),
@@ -777,7 +784,7 @@ mod test {
         let mut mqtt = build_mqttstate();
         let publish = build_outgoing_publish(QoS::ExactlyOnce);
 
-        mqtt.outgoing_publish(publish).unwrap();
+        mqtt.outgoing_publish(publish, None).unwrap();
         mqtt.handle_incoming_pubrec(&PubRec::new(1)).unwrap();
 
         mqtt.handle_incoming_pubcomp(&PubComp::new(1)).unwrap();
@@ -791,7 +798,7 @@ mod test {
 
         // network activity other than pingresp
         let publish = build_outgoing_publish(QoS::AtLeastOnce);
-        mqtt.handle_outgoing_packet(Request::Publish(publish))
+        mqtt.handle_outgoing_packet(Request::Publish(None, publish))
             .unwrap();
         mqtt.handle_incoming_packet(Incoming::PubAck(PubAck::new(1)))
             .unwrap();
@@ -830,7 +837,6 @@ mod test {
                     topic: "test".to_string(),
                     pkid: 1,
                     payload: "".into(),
-                    pkid_tx: None,
                 }),
                 Some(Publish {
                     dup: false,
@@ -839,7 +845,6 @@ mod test {
                     topic: "test".to_string(),
                     pkid: 2,
                     payload: "".into(),
-                    pkid_tx: None,
                 }),
                 Some(Publish {
                     dup: false,
@@ -848,7 +853,6 @@ mod test {
                     topic: "test".to_string(),
                     pkid: 3,
                     payload: "".into(),
-                    pkid_tx: None,
                 }),
                 None,
                 None,
@@ -859,7 +863,6 @@ mod test {
                     topic: "test".to_string(),
                     pkid: 6,
                     payload: "".into(),
-                    pkid_tx: None,
                 }),
             ]
         }
@@ -869,7 +872,7 @@ mod test {
         let requests = mqtt.clean();
         let res = vec![6, 1, 2, 3];
         for (req, idx) in requests.iter().zip(res) {
-            if let Request::Publish(publish) = req {
+            if let Request::Publish(_, publish) = req {
                 assert_eq!(publish.pkid, idx);
             } else {
                 unreachable!()
@@ -881,7 +884,7 @@ mod test {
         let requests = mqtt.clean();
         let res = vec![1, 2, 3, 6];
         for (req, idx) in requests.iter().zip(res) {
-            if let Request::Publish(publish) = req {
+            if let Request::Publish(_, publish) = req {
                 assert_eq!(publish.pkid, idx);
             } else {
                 unreachable!()
@@ -893,7 +896,7 @@ mod test {
         let requests = mqtt.clean();
         let res = vec![1, 2, 3, 6];
         for (req, idx) in requests.iter().zip(res) {
-            if let Request::Publish(publish) = req {
+            if let Request::Publish(_, publish) = req {
                 assert_eq!(publish.pkid, idx);
             } else {
                 unreachable!()

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -814,6 +814,7 @@ mod test {
                     topic: "test".to_string(),
                     pkid: 1,
                     payload: "".into(),
+                    pkid_tx: None,
                 }),
                 Some(Publish {
                     dup: false,
@@ -822,6 +823,7 @@ mod test {
                     topic: "test".to_string(),
                     pkid: 2,
                     payload: "".into(),
+                    pkid_tx: None,
                 }),
                 Some(Publish {
                     dup: false,
@@ -830,6 +832,7 @@ mod test {
                     topic: "test".to_string(),
                     pkid: 3,
                     payload: "".into(),
+                    pkid_tx: None,
                 }),
                 None,
                 None,
@@ -840,6 +843,7 @@ mod test {
                     topic: "test".to_string(),
                     pkid: 6,
                     payload: "".into(),
+                    pkid_tx: None,
                 }),
             ]
         }

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -1,11 +1,10 @@
-use crate::{Event, Incoming, Outgoing, Pkid, Request};
+use crate::{Event, Incoming, NoticeError, NoticeTx, Outgoing, Request};
 
 use crate::mqttbytes::v4::*;
 use crate::mqttbytes::{self, *};
 use fixedbitset::FixedBitSet;
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::{io, time::Instant};
-use tokio::sync::oneshot;
 
 /// Errors during state handling
 #[derive(Debug, thiserror::Error)]
@@ -33,6 +32,8 @@ pub enum StateError {
     Deserialization(#[from] mqttbytes::Error),
     #[error("Connection closed by peer abruptly")]
     ConnectionAborted,
+    #[error("Subscribe failed with reason '{reason:?}' ")]
+    SubFail { reason: SubscribeReasonCode },
 }
 
 /// State of the mqtt connection.
@@ -41,7 +42,7 @@ pub enum StateError {
 // This is done for 2 reasons
 // Bad acks or out of order acks aren't O(n) causing cpu spikes
 // Any missing acks from the broker are detected during the next recycled use of packet ids
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct MqttState {
     /// Status of last ping
     pub await_pingresp: bool,
@@ -62,13 +63,17 @@ pub struct MqttState {
     /// Maximum number of allowed inflight
     pub(crate) max_inflight: u16,
     /// Outgoing QoS 1, 2 publishes which aren't acked yet
-    pub(crate) outgoing_pub: Vec<Option<Publish>>,
+    pub(crate) outgoing_pub: HashMap<u16, (Publish, Option<NoticeTx>)>,
     /// Packet ids of released QoS 2 publishes
-    pub(crate) outgoing_rel: FixedBitSet,
+    pub(crate) outgoing_rel: HashMap<u16, Option<NoticeTx>>,
     /// Packet ids on incoming QoS 2 publishes
     pub(crate) incoming_pub: FixedBitSet,
+
+    outgoing_sub: HashMap<u16, Option<NoticeTx>>,
+    outgoing_unsub: HashMap<u16, Option<NoticeTx>>,
+
     /// Last collision due to broker not acking in order
-    pub collision: Option<Publish>,
+    pub collision: Option<(Publish, Option<NoticeTx>)>,
     /// Buffered incoming packets
     pub events: VecDeque<Event>,
     /// Indicates if acknowledgements should be send immediately
@@ -89,10 +94,12 @@ impl MqttState {
             last_puback: 0,
             inflight: 0,
             max_inflight,
+            outgoing_pub: HashMap::new(),
+            outgoing_rel: HashMap::new(),
             // index 0 is wasted as 0 is not a valid packet id
-            outgoing_pub: vec![None; max_inflight as usize + 1],
-            outgoing_rel: FixedBitSet::with_capacity(max_inflight as usize + 1),
             incoming_pub: FixedBitSet::with_capacity(u16::MAX as usize + 1),
+            outgoing_sub: HashMap::new(),
+            outgoing_unsub: HashMap::new(),
             collision: None,
             // TODO: Optimize these sizes later
             events: VecDeque::with_capacity(100),
@@ -103,20 +110,15 @@ impl MqttState {
     /// Returns inflight outgoing packets and clears internal queues
     pub fn clean(&mut self) -> Vec<Request> {
         let mut pending = Vec::with_capacity(100);
-        let (first_half, second_half) = self
-            .outgoing_pub
-            .split_at_mut(self.last_puback as usize + 1);
 
-        for publish in second_half.iter_mut().chain(first_half) {
-            if let Some(publish) = publish.take() {
-                let request = Request::Publish(None, publish);
-                pending.push(request);
-            }
+        for (_, (publish, tx)) in self.outgoing_pub.drain() {
+            let request = Request::Publish(tx, publish);
+            pending.push(request);
         }
 
         // remove and collect pending releases
-        for pkid in self.outgoing_rel.ones() {
-            let request = Request::PubRel(PubRel::new(pkid as u16));
+        for (pkid, tx) in self.outgoing_rel.drain() {
+            let request = Request::PubRel(tx, PubRel::new(pkid));
             pending.push(request);
         }
         self.outgoing_rel.clear();
@@ -142,7 +144,7 @@ impl MqttState {
     ) -> Result<Option<Packet>, StateError> {
         let packet = match request {
             Request::Publish(tx, publish) => self.outgoing_publish(publish, tx)?,
-            Request::PubRel(pubrel) => self.outgoing_pubrel(pubrel)?,
+            Request::PubRel(tx, pubrel) => self.outgoing_pubrel(pubrel, tx)?,
             Request::Subscribe(tx, subscribe) => self.outgoing_subscribe(subscribe, tx)?,
             Request::Unsubscribe(tx, unsubscribe) => self.outgoing_unsubscribe(unsubscribe, tx)?,
             Request::PingReq(_) => self.outgoing_ping()?,
@@ -169,8 +171,8 @@ impl MqttState {
         let outgoing = match &packet {
             Incoming::PingResp => self.handle_incoming_pingresp()?,
             Incoming::Publish(publish) => self.handle_incoming_publish(publish)?,
-            Incoming::SubAck(_suback) => self.handle_incoming_suback()?,
-            Incoming::UnsubAck(_unsuback) => self.handle_incoming_unsuback()?,
+            Incoming::SubAck(suback) => self.handle_incoming_suback(suback)?,
+            Incoming::UnsubAck(unsuback) => self.handle_incoming_unsuback(unsuback)?,
             Incoming::PubAck(puback) => self.handle_incoming_puback(puback)?,
             Incoming::PubRec(pubrec) => self.handle_incoming_pubrec(pubrec)?,
             Incoming::PubRel(pubrel) => self.handle_incoming_pubrel(pubrel)?,
@@ -185,11 +187,56 @@ impl MqttState {
         Ok(outgoing)
     }
 
-    fn handle_incoming_suback(&mut self) -> Result<Option<Packet>, StateError> {
+    fn handle_incoming_suback(&mut self, suback: &SubAck) -> Result<Option<Packet>, StateError> {
+        if suback.pkid > self.max_inflight {
+            error!("Unsolicited suback packet: {:?}", suback.pkid);
+            return Err(StateError::Unsolicited(suback.pkid));
+        }
+
+        let tx = self
+            .outgoing_sub
+            .remove(&suback.pkid)
+            .ok_or(StateError::Unsolicited(suback.pkid))?;
+
+        for reason in suback.return_codes.iter() {
+            match reason {
+                SubscribeReasonCode::Success(qos) => {
+                    debug!("SubAck Pkid = {:?}, QoS = {:?}", suback.pkid, qos);
+                }
+                _ => {
+                    if let Some(tx) = tx {
+                        tx.error(NoticeError::V4Subscribe(*reason))
+                    }
+
+                    return Err(StateError::SubFail { reason: *reason });
+                }
+            }
+        }
+
+        if let Some(tx) = tx {
+            tx.success()
+        }
+
         Ok(None)
     }
 
-    fn handle_incoming_unsuback(&mut self) -> Result<Option<Packet>, StateError> {
+    fn handle_incoming_unsuback(
+        &mut self,
+        unsuback: &UnsubAck,
+    ) -> Result<Option<Packet>, StateError> {
+        if unsuback.pkid > self.max_inflight {
+            error!("Unsolicited unsuback packet: {:?}", unsuback.pkid);
+            return Err(StateError::Unsolicited(unsuback.pkid));
+        }
+
+        if let Some(tx) = self
+            .outgoing_sub
+            .remove(&unsuback.pkid)
+            .ok_or(StateError::Unsolicited(unsuback.pkid))?
+        {
+            tx.success()
+        }
+
         Ok(None)
     }
 
@@ -221,21 +268,25 @@ impl MqttState {
     }
 
     fn handle_incoming_puback(&mut self, puback: &PubAck) -> Result<Option<Packet>, StateError> {
-        let publish = self
-            .outgoing_pub
-            .get_mut(puback.pkid as usize)
-            .ok_or(StateError::Unsolicited(puback.pkid))?;
-
-        self.last_puback = puback.pkid;
-
-        if publish.take().is_none() {
+        if puback.pkid > self.max_inflight {
             error!("Unsolicited puback packet: {:?}", puback.pkid);
             return Err(StateError::Unsolicited(puback.pkid));
         }
 
+        if let (_, Some(tx)) = self
+            .outgoing_pub
+            .remove(&puback.pkid)
+            .ok_or(StateError::Unsolicited(puback.pkid))?
+        {
+            tx.success()
+        }
+
+        self.last_puback = puback.pkid;
+
         self.inflight -= 1;
-        let packet = self.check_collision(puback.pkid).map(|publish| {
-            self.outgoing_pub[publish.pkid as usize] = Some(publish.clone());
+        let packet = self.check_collision(puback.pkid).map(|(publish, tx)| {
+            self.outgoing_pub
+                .insert(publish.pkid, (publish.clone(), tx));
             self.inflight += 1;
 
             let event = Event::Outgoing(Outgoing::Publish(publish.pkid));
@@ -249,18 +300,18 @@ impl MqttState {
     }
 
     fn handle_incoming_pubrec(&mut self, pubrec: &PubRec) -> Result<Option<Packet>, StateError> {
-        let publish = self
-            .outgoing_pub
-            .get_mut(pubrec.pkid as usize)
-            .ok_or(StateError::Unsolicited(pubrec.pkid))?;
-
-        if publish.take().is_none() {
+        if pubrec.pkid > self.max_inflight {
             error!("Unsolicited pubrec packet: {:?}", pubrec.pkid);
             return Err(StateError::Unsolicited(pubrec.pkid));
         }
 
+        let (_, tx) = self
+            .outgoing_pub
+            .remove(&pubrec.pkid)
+            .ok_or(StateError::Unsolicited(pubrec.pkid))?;
+
         // NOTE: Inflight - 1 for qos2 in comp
-        self.outgoing_rel.insert(pubrec.pkid as usize);
+        self.outgoing_rel.insert(pubrec.pkid, tx);
         let pubrel = PubRel { pkid: pubrec.pkid };
         let event = Event::Outgoing(Outgoing::PubRel(pubrec.pkid));
         self.events.push_back(event);
@@ -283,14 +334,22 @@ impl MqttState {
     }
 
     fn handle_incoming_pubcomp(&mut self, pubcomp: &PubComp) -> Result<Option<Packet>, StateError> {
-        if !self.outgoing_rel.contains(pubcomp.pkid as usize) {
+        if pubcomp.pkid > self.max_inflight {
             error!("Unsolicited pubcomp packet: {:?}", pubcomp.pkid);
             return Err(StateError::Unsolicited(pubcomp.pkid));
         }
+        if let Some(tx) = self
+            .outgoing_rel
+            .remove(&pubcomp.pkid)
+            .ok_or(StateError::Unsolicited(pubcomp.pkid))?
+        {
+            tx.success()
+        }
 
-        self.outgoing_rel.set(pubcomp.pkid as usize, false);
         self.inflight -= 1;
-        let packet = self.check_collision(pubcomp.pkid).map(|publish| {
+        let packet = self.check_collision(pubcomp.pkid).map(|(publish, tx)| {
+            self.outgoing_pub
+                .insert(pubcomp.pkid, (publish.clone(), tx));
             let event = Event::Outgoing(Outgoing::Publish(publish.pkid));
             self.events.push_back(event);
             self.collision_ping_count = 0;
@@ -312,29 +371,18 @@ impl MqttState {
     fn outgoing_publish(
         &mut self,
         mut publish: Publish,
-        pkid_tx: Option<oneshot::Sender<Pkid>>,
+        notice_tx: Option<NoticeTx>,
     ) -> Result<Option<Packet>, StateError> {
-        // NOTE: pkid promise need not be fulfilled for QoS 0,
-        // user should know this but still handled in Client.
         if publish.qos != QoS::AtMostOnce {
             if publish.pkid == 0 {
                 publish.pkid = self.next_pkid();
             }
 
             let pkid = publish.pkid;
-            // Fulfill the pkid promise
-            if let Some(pkid_tx) = pkid_tx {
-                _ = pkid_tx.send(pkid);
-            }
 
-            if self
-                .outgoing_pub
-                .get(publish.pkid as usize)
-                .ok_or(StateError::Unsolicited(publish.pkid))?
-                .is_some()
-            {
+            if self.outgoing_pub.get(&publish.pkid).is_some() {
                 info!("Collision on packet id = {:?}", publish.pkid);
-                self.collision = Some(publish);
+                self.collision = Some((publish, notice_tx));
                 let event = Event::Outgoing(Outgoing::AwaitAck(pkid));
                 self.events.push_back(event);
                 return Ok(None);
@@ -342,9 +390,11 @@ impl MqttState {
 
             // if there is an existing publish at this pkid, this implies that broker hasn't acked this
             // packet yet. This error is possible only when broker isn't acking sequentially
-            self.outgoing_pub[pkid as usize] = Some(publish.clone());
+            self.outgoing_pub.insert(pkid, (publish.clone(), notice_tx));
             self.inflight += 1;
-        };
+        } else if let Some(tx) = notice_tx {
+            tx.success()
+        }
 
         debug!(
             "Publish. Topic = {}, Pkid = {:?}, Payload Size = {:?}",
@@ -359,8 +409,12 @@ impl MqttState {
         Ok(Some(Packet::Publish(publish)))
     }
 
-    fn outgoing_pubrel(&mut self, pubrel: PubRel) -> Result<Option<Packet>, StateError> {
-        let pubrel = self.save_pubrel(pubrel)?;
+    fn outgoing_pubrel(
+        &mut self,
+        pubrel: PubRel,
+        notice_tx: Option<NoticeTx>,
+    ) -> Result<Option<Packet>, StateError> {
+        let pubrel = self.save_pubrel(pubrel, notice_tx)?;
 
         debug!("Pubrel. Pkid = {}", pubrel.pkid);
         let event = Event::Outgoing(Outgoing::PubRel(pubrel.pkid));
@@ -421,7 +475,7 @@ impl MqttState {
     fn outgoing_subscribe(
         &mut self,
         mut subscription: Subscribe,
-        pkid_tx: Option<oneshot::Sender<Pkid>>,
+        notice_tx: Option<NoticeTx>,
     ) -> Result<Option<Packet>, StateError> {
         if subscription.filters.is_empty() {
             return Err(StateError::EmptySubscription);
@@ -429,16 +483,13 @@ impl MqttState {
 
         let pkid = self.next_pkid();
         subscription.pkid = pkid;
-        // Fulfill the pkid promise
-        if let Some(pkid_tx) = pkid_tx {
-            _ = pkid_tx.send(pkid);
-        }
 
         debug!(
             "Subscribe. Topics = {:?}, Pkid = {:?}",
             subscription.filters, subscription.pkid
         );
 
+        self.outgoing_sub.insert(pkid, notice_tx);
         let event = Event::Outgoing(Outgoing::Subscribe(subscription.pkid));
         self.events.push_back(event);
 
@@ -448,21 +499,17 @@ impl MqttState {
     fn outgoing_unsubscribe(
         &mut self,
         mut unsub: Unsubscribe,
-        pkid_tx: Option<oneshot::Sender<Pkid>>,
+        notice_tx: Option<NoticeTx>,
     ) -> Result<Option<Packet>, StateError> {
         let pkid = self.next_pkid();
         unsub.pkid = pkid;
-
-        // Fulfill the pkid promise
-        if let Some(pkid_tx) = pkid_tx {
-            _ = pkid_tx.send(pkid);
-        }
 
         debug!(
             "Unsubscribe. Topics = {:?}, Pkid = {:?}",
             unsub.topics, unsub.pkid
         );
 
+        self.outgoing_unsub.insert(pkid, notice_tx);
         let event = Event::Outgoing(Outgoing::Unsubscribe(unsub.pkid));
         self.events.push_back(event);
 
@@ -478,8 +525,8 @@ impl MqttState {
         Ok(Some(Packet::Disconnect))
     }
 
-    fn check_collision(&mut self, pkid: u16) -> Option<Publish> {
-        if let Some(publish) = &self.collision {
+    fn check_collision(&mut self, pkid: u16) -> Option<(Publish, Option<NoticeTx>)> {
+        if let Some((publish, _)) = &self.collision {
             if publish.pkid == pkid {
                 return self.collision.take();
             }
@@ -488,7 +535,11 @@ impl MqttState {
         None
     }
 
-    fn save_pubrel(&mut self, mut pubrel: PubRel) -> Result<PubRel, StateError> {
+    fn save_pubrel(
+        &mut self,
+        mut pubrel: PubRel,
+        notice_tx: Option<NoticeTx>,
+    ) -> Result<PubRel, StateError> {
         let pubrel = match pubrel.pkid {
             // consider PacketIdentifier(0) as uninitialized packets
             0 => {
@@ -498,7 +549,7 @@ impl MqttState {
             _ => pubrel,
         };
 
-        self.outgoing_rel.insert(pubrel.pkid as usize);
+        self.outgoing_rel.insert(pubrel.pkid, notice_tx);
         self.inflight += 1;
         Ok(pubrel)
     }
@@ -525,9 +576,11 @@ impl MqttState {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashMap;
+
     use super::{MqttState, StateError};
     use crate::mqttbytes::v4::*;
-    use crate::mqttbytes::*;
+    use crate::{mqttbytes::*, NoticeTx};
     use crate::{Event, Incoming, Outgoing, Request};
 
     fn build_outgoing_publish(qos: QoS) -> Publish {
@@ -700,8 +753,8 @@ mod test {
         mqtt.handle_incoming_puback(&PubAck::new(2)).unwrap();
         assert_eq!(mqtt.inflight, 0);
 
-        assert!(mqtt.outgoing_pub[1].is_none());
-        assert!(mqtt.outgoing_pub[2].is_none());
+        assert!(mqtt.outgoing_pub.get(&1).is_none());
+        assert!(mqtt.outgoing_pub.get(&2).is_none());
     }
 
     #[test]
@@ -730,11 +783,11 @@ mod test {
         assert_eq!(mqtt.inflight, 2);
 
         // check if the remaining element's pkid is 1
-        let backup = mqtt.outgoing_pub[1].clone();
-        assert_eq!(backup.unwrap().pkid, 1);
+        let (backup, _) = mqtt.outgoing_pub.get(&1).unwrap();
+        assert_eq!(backup.pkid, 1);
 
-        // check if the qos2 element's release pkid is 2
-        assert!(mqtt.outgoing_rel.contains(2));
+        // check if the qos2 element's release pkik has been set
+        assert!(mqtt.outgoing_rel.get(&2).is_some());
     }
 
     #[test]
@@ -827,44 +880,67 @@ mod test {
     fn clean_is_calculating_pending_correctly() {
         let mut mqtt = build_mqttstate();
 
-        fn build_outgoing_pub() -> Vec<Option<Publish>> {
-            vec![
-                None,
-                Some(Publish {
-                    dup: false,
-                    qos: QoS::AtMostOnce,
-                    retain: false,
-                    topic: "test".to_string(),
-                    pkid: 1,
-                    payload: "".into(),
-                }),
-                Some(Publish {
-                    dup: false,
-                    qos: QoS::AtMostOnce,
-                    retain: false,
-                    topic: "test".to_string(),
-                    pkid: 2,
-                    payload: "".into(),
-                }),
-                Some(Publish {
-                    dup: false,
-                    qos: QoS::AtMostOnce,
-                    retain: false,
-                    topic: "test".to_string(),
-                    pkid: 3,
-                    payload: "".into(),
-                }),
-                None,
-                None,
-                Some(Publish {
-                    dup: false,
-                    qos: QoS::AtMostOnce,
-                    retain: false,
-                    topic: "test".to_string(),
-                    pkid: 6,
-                    payload: "".into(),
-                }),
-            ]
+        fn build_outgoing_pub() -> HashMap<u16, (Publish, Option<NoticeTx>)> {
+            let mut outgoing_pub = HashMap::new();
+            outgoing_pub.insert(
+                2,
+                (
+                    Publish {
+                        dup: false,
+                        qos: QoS::AtMostOnce,
+                        retain: false,
+                        topic: "test".to_string(),
+                        pkid: 1,
+                        payload: "".into(),
+                    },
+                    None,
+                ),
+            );
+            outgoing_pub.insert(
+                3,
+                (
+                    Publish {
+                        dup: false,
+                        qos: QoS::AtMostOnce,
+                        retain: false,
+                        topic: "test".to_string(),
+                        pkid: 2,
+                        payload: "".into(),
+                    },
+                    None,
+                ),
+            );
+            outgoing_pub.insert(
+                4,
+                (
+                    Publish {
+                        dup: false,
+                        qos: QoS::AtMostOnce,
+                        retain: false,
+                        topic: "test".to_string(),
+                        pkid: 3,
+                        payload: "".into(),
+                    },
+                    None,
+                ),
+            );
+
+            outgoing_pub.insert(
+                7,
+                (
+                    Publish {
+                        dup: false,
+                        qos: QoS::AtMostOnce,
+                        retain: false,
+                        topic: "test".to_string(),
+                        pkid: 6,
+                        payload: "".into(),
+                    },
+                    None,
+                ),
+            );
+
+            outgoing_pub
         }
 
         mqtt.outgoing_pub = build_outgoing_pub();

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -1,4 +1,5 @@
-use crate::{Event, Incoming, NoticeError, NoticeTx, Outgoing, Request};
+use crate::notice::NoticeTx;
+use crate::{Event, Incoming, NoticeError, Outgoing, Request};
 
 use crate::mqttbytes::v4::*;
 use crate::mqttbytes::{self, *};
@@ -73,7 +74,7 @@ pub struct MqttState {
     outgoing_unsub: HashMap<u16, Option<NoticeTx>>,
 
     /// Last collision due to broker not acking in order
-    pub collision: Option<(Publish, Option<NoticeTx>)>,
+    pub(crate) collision: Option<(Publish, Option<NoticeTx>)>,
     /// Buffered incoming packets
     pub events: VecDeque<Event>,
     /// Indicates if acknowledgements should be send immediately
@@ -108,18 +109,18 @@ impl MqttState {
     }
 
     /// Returns inflight outgoing packets and clears internal queues
-    pub fn clean(&mut self) -> Vec<Request> {
+    pub fn clean(&mut self) -> Vec<(Option<NoticeTx>, Request)> {
         let mut pending = Vec::with_capacity(100);
 
         for (_, (publish, tx)) in self.outgoing_pub.drain() {
-            let request = Request::Publish(tx, publish);
-            pending.push(request);
+            let request = Request::Publish(publish);
+            pending.push((tx, request));
         }
 
         // remove and collect pending releases
         for (pkid, tx) in self.outgoing_rel.drain() {
-            let request = Request::PubRel(tx, PubRel::new(pkid));
-            pending.push(request);
+            let request = Request::PubRel(PubRel::new(pkid));
+            pending.push((tx, request));
         }
         self.outgoing_rel.clear();
 
@@ -140,13 +141,14 @@ impl MqttState {
     /// be put on to the network by the eventloop
     pub fn handle_outgoing_packet(
         &mut self,
+        tx: Option<NoticeTx>,
         request: Request,
     ) -> Result<Option<Packet>, StateError> {
         let packet = match request {
-            Request::Publish(tx, publish) => self.outgoing_publish(publish, tx)?,
-            Request::PubRel(tx, pubrel) => self.outgoing_pubrel(pubrel, tx)?,
-            Request::Subscribe(tx, subscribe) => self.outgoing_subscribe(subscribe, tx)?,
-            Request::Unsubscribe(tx, unsubscribe) => self.outgoing_unsubscribe(unsubscribe, tx)?,
+            Request::Publish(publish) => self.outgoing_publish(publish, tx)?,
+            Request::PubRel(pubrel) => self.outgoing_pubrel(pubrel, tx)?,
+            Request::Subscribe(subscribe) => self.outgoing_subscribe(subscribe, tx)?,
+            Request::Unsubscribe(unsubscribe) => self.outgoing_unsubscribe(unsubscribe, tx)?,
             Request::PingReq(_) => self.outgoing_ping()?,
             Request::Disconnect(_) => self.outgoing_disconnect()?,
             Request::PubAck(puback) => self.outgoing_puback(puback)?,
@@ -851,7 +853,7 @@ mod test {
 
         // network activity other than pingresp
         let publish = build_outgoing_publish(QoS::AtLeastOnce);
-        mqtt.handle_outgoing_packet(Request::Publish(None, publish))
+        mqtt.handle_outgoing_packet(None, Request::Publish(publish))
             .unwrap();
         mqtt.handle_incoming_packet(Incoming::PubAck(PubAck::new(1)))
             .unwrap();
@@ -947,8 +949,8 @@ mod test {
         mqtt.last_puback = 3;
         let requests = mqtt.clean();
         let res = vec![6, 1, 2, 3];
-        for (req, idx) in requests.iter().zip(res) {
-            if let Request::Publish(_, publish) = req {
+        for ((_, req), idx) in requests.iter().zip(res) {
+            if let Request::Publish(publish) = req {
                 assert_eq!(publish.pkid, idx);
             } else {
                 unreachable!()
@@ -959,8 +961,8 @@ mod test {
         mqtt.last_puback = 0;
         let requests = mqtt.clean();
         let res = vec![1, 2, 3, 6];
-        for (req, idx) in requests.iter().zip(res) {
-            if let Request::Publish(_, publish) = req {
+        for ((_, req), idx) in requests.iter().zip(res) {
+            if let Request::Publish(publish) = req {
                 assert_eq!(publish.pkid, idx);
             } else {
                 unreachable!()
@@ -971,8 +973,8 @@ mod test {
         mqtt.last_puback = 6;
         let requests = mqtt.clean();
         let res = vec![1, 2, 3, 6];
-        for (req, idx) in requests.iter().zip(res) {
-            if let Request::Publish(_, publish) = req {
+        for ((_, req), idx) in requests.iter().zip(res) {
+            if let Request::Publish(publish) = req {
                 assert_eq!(publish.pkid, idx);
             } else {
                 unreachable!()

--- a/rumqttc/src/v5/client.rs
+++ b/rumqttc/src/v5/client.rs
@@ -8,7 +8,7 @@ use super::mqttbytes::v5::{
 };
 use super::mqttbytes::{valid_filter, QoS};
 use super::{ConnectionError, Event, EventLoop, MqttOptions, Request};
-use crate::{valid_topic, PkidPromise};
+use crate::{valid_topic, NoticeFuture, NoticeTx};
 
 use bytes::Bytes;
 use flume::{SendError, Sender, TrySendError};
@@ -78,7 +78,7 @@ impl AsyncClient {
         retain: bool,
         payload: P,
         properties: Option<PublishProperties>,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         S: Into<String>,
         P: Into<Bytes>,
@@ -87,21 +87,16 @@ impl AsyncClient {
         let mut publish = Publish::new(&topic, qos, payload, properties);
         publish.retain = retain;
 
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
         // Fulfill instantly for QoS 0
-        let pkid_tx = if qos == QoS::AtMostOnce {
-            _ = pkid_tx.send(0);
-            None
-        } else {
-            Some(pkid_tx)
-        };
+        let notice_tx = Some(NoticeTx(notice_tx));
 
-        let publish = Request::Publish(pkid_tx, publish);
+        let publish = Request::Publish(notice_tx, publish);
         if !valid_topic(&topic) {
             return Err(ClientError::Request(publish));
         }
         self.request_tx.send_async(publish).await?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     pub async fn publish_with_properties<S, P>(
@@ -111,7 +106,7 @@ impl AsyncClient {
         retain: bool,
         payload: P,
         properties: PublishProperties,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         S: Into<String>,
         P: Into<Bytes>,
@@ -126,7 +121,7 @@ impl AsyncClient {
         qos: QoS,
         retain: bool,
         payload: P,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         S: Into<String>,
         P: Into<Bytes>,
@@ -142,7 +137,7 @@ impl AsyncClient {
         retain: bool,
         payload: P,
         properties: Option<PublishProperties>,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         S: Into<String>,
         P: Into<Bytes>,
@@ -151,21 +146,16 @@ impl AsyncClient {
         let mut publish = Publish::new(&topic, qos, payload, properties);
         publish.retain = retain;
 
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
         // Fulfill instantly for QoS 0
-        let pkid_tx = if qos == QoS::AtMostOnce {
-            _ = pkid_tx.send(0);
-            None
-        } else {
-            Some(pkid_tx)
-        };
+        let notice_tx = Some(NoticeTx(notice_tx));
 
-        let publish = Request::Publish(pkid_tx, publish);
+        let publish = Request::Publish(notice_tx, publish);
         if !valid_topic(&topic) {
             return Err(ClientError::TryRequest(publish));
         }
         self.request_tx.try_send(publish)?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     pub fn try_publish_with_properties<S, P>(
@@ -175,7 +165,7 @@ impl AsyncClient {
         retain: bool,
         payload: P,
         properties: PublishProperties,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         S: Into<String>,
         P: Into<Bytes>,
@@ -189,7 +179,7 @@ impl AsyncClient {
         qos: QoS,
         retain: bool,
         payload: P,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         S: Into<String>,
         P: Into<Bytes>,
@@ -224,7 +214,7 @@ impl AsyncClient {
         retain: bool,
         payload: Bytes,
         properties: Option<PublishProperties>,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         S: Into<String>,
     {
@@ -232,21 +222,16 @@ impl AsyncClient {
         let mut publish = Publish::new(&topic, qos, payload, properties);
         publish.retain = retain;
 
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
         // Fulfill instantly for QoS 0
-        let pkid_tx = if qos == QoS::AtMostOnce {
-            _ = pkid_tx.send(0);
-            None
-        } else {
-            Some(pkid_tx)
-        };
+        let notice_tx = Some(NoticeTx(notice_tx));
 
-        let publish = Request::Publish(pkid_tx, publish);
+        let publish = Request::Publish(notice_tx, publish);
         if !valid_topic(&topic) {
             return Err(ClientError::TryRequest(publish));
         }
         self.request_tx.send_async(publish).await?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     pub async fn publish_bytes_with_properties<S>(
@@ -256,7 +241,7 @@ impl AsyncClient {
         retain: bool,
         payload: Bytes,
         properties: PublishProperties,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         S: Into<String>,
     {
@@ -270,7 +255,7 @@ impl AsyncClient {
         qos: QoS,
         retain: bool,
         payload: Bytes,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         S: Into<String>,
     {
@@ -284,19 +269,17 @@ impl AsyncClient {
         topic: S,
         qos: QoS,
         properties: Option<SubscribeProperties>,
-    ) -> Result<PkidPromise, ClientError> {
+    ) -> Result<NoticeFuture, ClientError> {
         let filter = Filter::new(topic, qos);
         let is_filter_valid = valid_filter(&filter.path);
         let subscribe = Subscribe::new(filter, properties);
-
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-
-        let request: Request = Request::Subscribe(Some(pkid_tx), subscribe);
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
+        let request = Request::Subscribe(Some(NoticeTx(notice_tx)), subscribe);
         if !is_filter_valid {
             return Err(ClientError::Request(request));
         }
         self.request_tx.send_async(request).await?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     pub async fn subscribe_with_properties<S: Into<String>>(
@@ -304,7 +287,7 @@ impl AsyncClient {
         topic: S,
         qos: QoS,
         properties: SubscribeProperties,
-    ) -> Result<PkidPromise, ClientError> {
+    ) -> Result<NoticeFuture, ClientError> {
         self.handle_subscribe(topic, qos, Some(properties)).await
     }
 
@@ -312,7 +295,7 @@ impl AsyncClient {
         &self,
         topic: S,
         qos: QoS,
-    ) -> Result<PkidPromise, ClientError> {
+    ) -> Result<NoticeFuture, ClientError> {
         self.handle_subscribe(topic, qos, None).await
     }
 
@@ -322,19 +305,17 @@ impl AsyncClient {
         topic: S,
         qos: QoS,
         properties: Option<SubscribeProperties>,
-    ) -> Result<PkidPromise, ClientError> {
+    ) -> Result<NoticeFuture, ClientError> {
         let filter = Filter::new(topic, qos);
         let is_filter_valid = valid_filter(&filter.path);
         let subscribe = Subscribe::new(filter, properties);
-
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-
-        let request = Request::Subscribe(Some(pkid_tx), subscribe);
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
+        let request = Request::Subscribe(Some(NoticeTx(notice_tx)), subscribe);
         if !is_filter_valid {
             return Err(ClientError::TryRequest(request));
         }
         self.request_tx.try_send(request)?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     pub fn try_subscribe_with_properties<S: Into<String>>(
@@ -342,7 +323,7 @@ impl AsyncClient {
         topic: S,
         qos: QoS,
         properties: SubscribeProperties,
-    ) -> Result<PkidPromise, ClientError> {
+    ) -> Result<NoticeFuture, ClientError> {
         self.handle_try_subscribe(topic, qos, Some(properties))
     }
 
@@ -350,7 +331,7 @@ impl AsyncClient {
         &self,
         topic: S,
         qos: QoS,
-    ) -> Result<PkidPromise, ClientError> {
+    ) -> Result<NoticeFuture, ClientError> {
         self.handle_try_subscribe(topic, qos, None)
     }
 
@@ -359,37 +340,35 @@ impl AsyncClient {
         &self,
         topics: T,
         properties: Option<SubscribeProperties>,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         T: IntoIterator<Item = Filter>,
     {
         let mut topics_iter = topics.into_iter();
         let is_valid_filters = topics_iter.all(|filter| valid_filter(&filter.path));
         let subscribe = Subscribe::new_many(topics_iter, properties);
-
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-
-        let request = Request::Subscribe(Some(pkid_tx), subscribe);
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
+        let request = Request::Subscribe(Some(NoticeTx(notice_tx)), subscribe);
         if !is_valid_filters {
             return Err(ClientError::Request(request));
         }
 
         self.request_tx.send_async(request).await?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     pub async fn subscribe_many_with_properties<T>(
         &self,
         topics: T,
         properties: SubscribeProperties,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         T: IntoIterator<Item = Filter>,
     {
         self.handle_subscribe_many(topics, Some(properties)).await
     }
 
-    pub async fn subscribe_many<T>(&self, topics: T) -> Result<PkidPromise, ClientError>
+    pub async fn subscribe_many<T>(&self, topics: T) -> Result<NoticeFuture, ClientError>
     where
         T: IntoIterator<Item = Filter>,
     {
@@ -401,36 +380,34 @@ impl AsyncClient {
         &self,
         topics: T,
         properties: Option<SubscribeProperties>,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         T: IntoIterator<Item = Filter>,
     {
         let mut topics_iter = topics.into_iter();
         let is_valid_filters = topics_iter.all(|filter| valid_filter(&filter.path));
         let subscribe = Subscribe::new_many(topics_iter, properties);
-
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-
-        let request = Request::Subscribe(Some(pkid_tx), subscribe);
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
+        let request = Request::Subscribe(Some(NoticeTx(notice_tx)), subscribe);
         if !is_valid_filters {
             return Err(ClientError::TryRequest(request));
         }
         self.request_tx.try_send(request)?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     pub fn try_subscribe_many_with_properties<T>(
         &self,
         topics: T,
         properties: SubscribeProperties,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         T: IntoIterator<Item = Filter>,
     {
         self.handle_try_subscribe_many(topics, Some(properties))
     }
 
-    pub fn try_subscribe_many<T>(&self, topics: T) -> Result<PkidPromise, ClientError>
+    pub fn try_subscribe_many<T>(&self, topics: T) -> Result<NoticeFuture, ClientError>
     where
         T: IntoIterator<Item = Filter>,
     {
@@ -442,25 +419,28 @@ impl AsyncClient {
         &self,
         topic: S,
         properties: Option<UnsubscribeProperties>,
-    ) -> Result<PkidPromise, ClientError> {
+    ) -> Result<NoticeFuture, ClientError> {
         let unsubscribe = Unsubscribe::new(topic, properties);
 
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
 
-        let request = Request::Unsubscribe(Some(pkid_tx), unsubscribe);
+        let request = Request::Unsubscribe(Some(NoticeTx(notice_tx)), unsubscribe);
         self.request_tx.send_async(request).await?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     pub async fn unsubscribe_with_properties<S: Into<String>>(
         &self,
         topic: S,
         properties: UnsubscribeProperties,
-    ) -> Result<PkidPromise, ClientError> {
+    ) -> Result<NoticeFuture, ClientError> {
         self.handle_unsubscribe(topic, Some(properties)).await
     }
 
-    pub async fn unsubscribe<S: Into<String>>(&self, topic: S) -> Result<PkidPromise, ClientError> {
+    pub async fn unsubscribe<S: Into<String>>(
+        &self,
+        topic: S,
+    ) -> Result<NoticeFuture, ClientError> {
         self.handle_unsubscribe(topic, None).await
     }
 
@@ -469,25 +449,25 @@ impl AsyncClient {
         &self,
         topic: S,
         properties: Option<UnsubscribeProperties>,
-    ) -> Result<PkidPromise, ClientError> {
+    ) -> Result<NoticeFuture, ClientError> {
         let unsubscribe = Unsubscribe::new(topic, properties);
 
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
 
-        let request = Request::Unsubscribe(Some(pkid_tx), unsubscribe);
+        let request = Request::Unsubscribe(Some(NoticeTx(notice_tx)), unsubscribe);
         self.request_tx.try_send(request)?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     pub fn try_unsubscribe_with_properties<S: Into<String>>(
         &self,
         topic: S,
         properties: UnsubscribeProperties,
-    ) -> Result<PkidPromise, ClientError> {
+    ) -> Result<NoticeFuture, ClientError> {
         self.handle_try_unsubscribe(topic, Some(properties))
     }
 
-    pub fn try_unsubscribe<S: Into<String>>(&self, topic: S) -> Result<PkidPromise, ClientError> {
+    pub fn try_unsubscribe<S: Into<String>>(&self, topic: S) -> Result<NoticeFuture, ClientError> {
         self.handle_try_unsubscribe(topic, None)
     }
 
@@ -565,7 +545,7 @@ impl Client {
         retain: bool,
         payload: P,
         properties: Option<PublishProperties>,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         S: Into<String>,
         P: Into<Bytes>,
@@ -574,21 +554,16 @@ impl Client {
         let mut publish = Publish::new(&topic, qos, payload, properties);
         publish.retain = retain;
 
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
         // Fulfill instantly for QoS 0
-        let pkid_tx = if qos == QoS::AtMostOnce {
-            _ = pkid_tx.send(0);
-            None
-        } else {
-            Some(pkid_tx)
-        };
+        let notice_tx = Some(NoticeTx(notice_tx));
 
-        let publish = Request::Publish(pkid_tx, publish);
+        let publish = Request::Publish(notice_tx, publish);
         if !valid_topic(&topic) {
             return Err(ClientError::Request(publish));
         }
         self.client.request_tx.send(publish)?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     pub fn publish_with_properties<S, P>(
@@ -598,7 +573,7 @@ impl Client {
         retain: bool,
         payload: P,
         properties: PublishProperties,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         S: Into<String>,
         P: Into<Bytes>,
@@ -612,7 +587,7 @@ impl Client {
         qos: QoS,
         retain: bool,
         payload: P,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         S: Into<String>,
         P: Into<Bytes>,
@@ -627,7 +602,7 @@ impl Client {
         retain: bool,
         payload: P,
         properties: PublishProperties,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         S: Into<String>,
         P: Into<Bytes>,
@@ -642,7 +617,7 @@ impl Client {
         qos: QoS,
         retain: bool,
         payload: P,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         S: Into<String>,
         P: Into<Bytes>,
@@ -672,19 +647,17 @@ impl Client {
         topic: S,
         qos: QoS,
         properties: Option<SubscribeProperties>,
-    ) -> Result<PkidPromise, ClientError> {
+    ) -> Result<NoticeFuture, ClientError> {
         let filter = Filter::new(topic, qos);
         let is_filter_valid = valid_filter(&filter.path);
         let subscribe = Subscribe::new(filter, properties);
-
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-
-        let request = Request::Subscribe(Some(pkid_tx), subscribe);
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
+        let request = Request::Subscribe(Some(NoticeTx(notice_tx)), subscribe);
         if !is_filter_valid {
             return Err(ClientError::Request(request));
         }
         self.client.request_tx.send(request)?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     pub fn subscribe_with_properties<S: Into<String>>(
@@ -692,7 +665,7 @@ impl Client {
         topic: S,
         qos: QoS,
         properties: SubscribeProperties,
-    ) -> Result<PkidPromise, ClientError> {
+    ) -> Result<NoticeFuture, ClientError> {
         self.handle_subscribe(topic, qos, Some(properties))
     }
 
@@ -700,7 +673,7 @@ impl Client {
         &self,
         topic: S,
         qos: QoS,
-    ) -> Result<PkidPromise, ClientError> {
+    ) -> Result<NoticeFuture, ClientError> {
         self.handle_subscribe(topic, qos, None)
     }
 
@@ -710,7 +683,7 @@ impl Client {
         topic: S,
         qos: QoS,
         properties: SubscribeProperties,
-    ) -> Result<PkidPromise, ClientError> {
+    ) -> Result<NoticeFuture, ClientError> {
         self.client
             .try_subscribe_with_properties(topic, qos, properties)
     }
@@ -719,7 +692,7 @@ impl Client {
         &self,
         topic: S,
         qos: QoS,
-    ) -> Result<PkidPromise, ClientError> {
+    ) -> Result<NoticeFuture, ClientError> {
         self.client.try_subscribe(topic, qos)
     }
 
@@ -728,36 +701,34 @@ impl Client {
         &self,
         topics: T,
         properties: Option<SubscribeProperties>,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         T: IntoIterator<Item = Filter>,
     {
         let mut topics_iter = topics.into_iter();
         let is_valid_filters = topics_iter.all(|filter| valid_filter(&filter.path));
         let subscribe = Subscribe::new_many(topics_iter, properties);
-
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
-
-        let request = Request::Subscribe(Some(pkid_tx), subscribe);
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
+        let request = Request::Subscribe(Some(NoticeTx(notice_tx)), subscribe);
         if !is_valid_filters {
             return Err(ClientError::Request(request));
         }
         self.client.request_tx.send(request)?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     pub fn subscribe_many_with_properties<T>(
         &self,
         topics: T,
         properties: SubscribeProperties,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         T: IntoIterator<Item = Filter>,
     {
         self.handle_subscribe_many(topics, Some(properties))
     }
 
-    pub fn subscribe_many<T>(&self, topics: T) -> Result<PkidPromise, ClientError>
+    pub fn subscribe_many<T>(&self, topics: T) -> Result<NoticeFuture, ClientError>
     where
         T: IntoIterator<Item = Filter>,
     {
@@ -768,7 +739,7 @@ impl Client {
         &self,
         topics: T,
         properties: SubscribeProperties,
-    ) -> Result<PkidPromise, ClientError>
+    ) -> Result<NoticeFuture, ClientError>
     where
         T: IntoIterator<Item = Filter>,
     {
@@ -776,7 +747,7 @@ impl Client {
             .try_subscribe_many_with_properties(topics, properties)
     }
 
-    pub fn try_subscribe_many<T>(&self, topics: T) -> Result<PkidPromise, ClientError>
+    pub fn try_subscribe_many<T>(&self, topics: T) -> Result<NoticeFuture, ClientError>
     where
         T: IntoIterator<Item = Filter>,
     {
@@ -788,25 +759,25 @@ impl Client {
         &self,
         topic: S,
         properties: Option<UnsubscribeProperties>,
-    ) -> Result<PkidPromise, ClientError> {
+    ) -> Result<NoticeFuture, ClientError> {
         let unsubscribe = Unsubscribe::new(topic, properties);
 
-        let (pkid_tx, pkid_rx) = tokio::sync::oneshot::channel();
+        let (notice_tx, notice_rx) = tokio::sync::oneshot::channel();
 
-        let request = Request::Unsubscribe(Some(pkid_tx), unsubscribe);
+        let request = Request::Unsubscribe(Some(NoticeTx(notice_tx)), unsubscribe);
         self.client.request_tx.send(request)?;
-        Ok(PkidPromise::new(pkid_rx))
+        Ok(NoticeFuture(notice_rx))
     }
 
     pub fn unsubscribe_with_properties<S: Into<String>>(
         &self,
         topic: S,
         properties: UnsubscribeProperties,
-    ) -> Result<PkidPromise, ClientError> {
+    ) -> Result<NoticeFuture, ClientError> {
         self.handle_unsubscribe(topic, Some(properties))
     }
 
-    pub fn unsubscribe<S: Into<String>>(&self, topic: S) -> Result<PkidPromise, ClientError> {
+    pub fn unsubscribe<S: Into<String>>(&self, topic: S) -> Result<NoticeFuture, ClientError> {
         self.handle_unsubscribe(topic, None)
     }
 
@@ -815,12 +786,12 @@ impl Client {
         &self,
         topic: S,
         properties: UnsubscribeProperties,
-    ) -> Result<PkidPromise, ClientError> {
+    ) -> Result<NoticeFuture, ClientError> {
         self.client
             .try_unsubscribe_with_properties(topic, properties)
     }
 
-    pub fn try_unsubscribe<S: Into<String>>(&self, topic: S) -> Result<PkidPromise, ClientError> {
+    pub fn try_unsubscribe<S: Into<String>>(&self, topic: S) -> Result<NoticeFuture, ClientError> {
         self.client.try_unsubscribe(topic)
     }
 

--- a/rumqttc/src/v5/client.rs
+++ b/rumqttc/src/v5/client.rs
@@ -100,7 +100,7 @@ impl AsyncClient {
             return Err(ClientError::Request(publish));
         }
         self.request_tx.send_async(publish).await?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub async fn publish_with_properties<S, P>(
@@ -163,7 +163,7 @@ impl AsyncClient {
             return Err(ClientError::TryRequest(publish));
         }
         self.request_tx.try_send(publish)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub fn try_publish_with_properties<S, P>(
@@ -243,7 +243,7 @@ impl AsyncClient {
             return Err(ClientError::TryRequest(publish));
         }
         self.request_tx.send_async(publish).await?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub async fn publish_bytes_with_properties<S>(
@@ -295,7 +295,7 @@ impl AsyncClient {
             return Err(ClientError::Request(request));
         }
         self.request_tx.send_async(request).await?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub async fn subscribe_with_properties<S: Into<String>>(
@@ -334,7 +334,7 @@ impl AsyncClient {
             return Err(ClientError::TryRequest(request));
         }
         self.request_tx.try_send(request)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub fn try_subscribe_with_properties<S: Into<String>>(
@@ -376,7 +376,7 @@ impl AsyncClient {
         }
 
         self.request_tx.send_async(request).await?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub async fn subscribe_many_with_properties<T>(
@@ -418,7 +418,7 @@ impl AsyncClient {
             return Err(ClientError::TryRequest(request));
         }
         self.request_tx.try_send(request)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub fn try_subscribe_many_with_properties<T>(
@@ -452,7 +452,7 @@ impl AsyncClient {
 
         let request = Request::Unsubscribe(unsubscribe);
         self.request_tx.send_async(request).await?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub async fn unsubscribe_with_properties<S: Into<String>>(
@@ -480,7 +480,7 @@ impl AsyncClient {
 
         let request = Request::Unsubscribe(unsubscribe);
         self.request_tx.try_send(request)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub fn try_unsubscribe_with_properties<S: Into<String>>(
@@ -591,7 +591,7 @@ impl Client {
             return Err(ClientError::Request(publish));
         }
         self.client.request_tx.send(publish)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub fn publish_with_properties<S, P>(
@@ -688,7 +688,7 @@ impl Client {
             return Err(ClientError::Request(request));
         }
         self.client.request_tx.send(request)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub fn subscribe_with_properties<S: Into<String>>(
@@ -748,7 +748,7 @@ impl Client {
             return Err(ClientError::Request(request));
         }
         self.client.request_tx.send(request)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub fn subscribe_many_with_properties<T>(
@@ -801,7 +801,7 @@ impl Client {
 
         let request = Request::Unsubscribe(unsubscribe);
         self.client.request_tx.send(request)?;
-        Ok(pkid_rx)
+        Ok(PkidPromise::new(pkid_rx))
     }
 
     pub fn unsubscribe_with_properties<S: Into<String>>(

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -74,11 +74,11 @@ pub struct EventLoop {
     /// Current state of the connection
     pub state: MqttState,
     /// Request stream
-    requests_rx: Receiver<(Option<NoticeTx>, Request)>,
+    requests_rx: Receiver<(NoticeTx, Request)>,
     /// Requests handle to send requests
-    pub(crate) requests_tx: Sender<(Option<NoticeTx>, Request)>,
+    pub(crate) requests_tx: Sender<(NoticeTx, Request)>,
     /// Pending packets from last session
-    pub(crate) pending: VecDeque<(Option<NoticeTx>, Request)>,
+    pub(crate) pending: VecDeque<(NoticeTx, Request)>,
     /// Network connection to the broker
     network: Option<Network>,
     /// Keep alive time
@@ -246,7 +246,8 @@ impl EventLoop {
                 let timeout = self.keepalive_timeout.as_mut().unwrap();
                 timeout.as_mut().reset(Instant::now() + self.options.keep_alive);
 
-                if let Some(outgoing) = self.state.handle_outgoing_packet(None, Request::PingReq)? {
+                let (tx, _) = NoticeTx::new();
+                if let Some(outgoing) = self.state.handle_outgoing_packet(tx, Request::PingReq)? {
                     network.write(outgoing).await?;
                 }
                 network.flush().await?;
@@ -256,10 +257,10 @@ impl EventLoop {
     }
 
     async fn next_request(
-        pending: &mut VecDeque<(Option<NoticeTx>, Request)>,
-        rx: &Receiver<(Option<NoticeTx>, Request)>,
+        pending: &mut VecDeque<(NoticeTx, Request)>,
+        rx: &Receiver<(NoticeTx, Request)>,
         pending_throttle: Duration,
-    ) -> Result<(Option<NoticeTx>, Request), ConnectionError> {
+    ) -> Result<(NoticeTx, Request), ConnectionError> {
         if !pending.is_empty() {
             time::sleep(pending_throttle).await;
             // We must call .next() AFTER sleep() otherwise .next() would

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -77,7 +77,7 @@ pub struct EventLoop {
     /// Requests handle to send requests
     pub(crate) requests_tx: Sender<Request>,
     /// Pending packets from last session
-    pub pending: VecDeque<Request>,
+    pub(crate) pending: VecDeque<Request>,
     /// Network connection to the broker
     network: Option<Network>,
     /// Keep alive time

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -3,6 +3,7 @@ use super::mqttbytes::v5::*;
 use super::{Incoming, MqttOptions, MqttState, Outgoing, Request, StateError, Transport};
 use crate::eventloop::socket_connect;
 use crate::framed::AsyncReadWrite;
+use crate::notice::NoticeTx;
 
 use flume::{bounded, Receiver, Sender};
 use tokio::select;
@@ -73,11 +74,11 @@ pub struct EventLoop {
     /// Current state of the connection
     pub state: MqttState,
     /// Request stream
-    requests_rx: Receiver<Request>,
+    requests_rx: Receiver<(Option<NoticeTx>, Request)>,
     /// Requests handle to send requests
-    pub(crate) requests_tx: Sender<Request>,
+    pub(crate) requests_tx: Sender<(Option<NoticeTx>, Request)>,
     /// Pending packets from last session
-    pub(crate) pending: VecDeque<Request>,
+    pub(crate) pending: VecDeque<(Option<NoticeTx>, Request)>,
     /// Network connection to the broker
     network: Option<Network>,
     /// Keep alive time
@@ -128,7 +129,7 @@ impl EventLoop {
         // drain requests from channel which weren't yet received
         let mut requests_in_channel: Vec<_> = self.requests_rx.drain().collect();
 
-        requests_in_channel.retain(|request| {
+        requests_in_channel.retain(|(_, request)| {
             match request {
                 Request::PubAck(_) => false, // Wait for publish retransmission, else the broker could be confused by an unexpected ack
                 _ => true,
@@ -223,8 +224,8 @@ impl EventLoop {
                 &self.requests_rx,
                 self.options.pending_throttle
             ), if !self.pending.is_empty() || (!inflight_full && !collision) => match o {
-                Ok(request) => {
-                    if let Some(outgoing) = self.state.handle_outgoing_packet(request)? {
+                Ok((tx, request)) => {
+                    if let Some(outgoing) = self.state.handle_outgoing_packet(tx, request)? {
                         network.write(outgoing).await?;
                     }
                     network.flush().await?;
@@ -245,7 +246,7 @@ impl EventLoop {
                 let timeout = self.keepalive_timeout.as_mut().unwrap();
                 timeout.as_mut().reset(Instant::now() + self.options.keep_alive);
 
-                if let Some(outgoing) = self.state.handle_outgoing_packet(Request::PingReq)? {
+                if let Some(outgoing) = self.state.handle_outgoing_packet(None, Request::PingReq)? {
                     network.write(outgoing).await?;
                 }
                 network.flush().await?;
@@ -255,10 +256,10 @@ impl EventLoop {
     }
 
     async fn next_request(
-        pending: &mut VecDeque<Request>,
-        rx: &Receiver<Request>,
+        pending: &mut VecDeque<(Option<NoticeTx>, Request)>,
+        rx: &Receiver<(Option<NoticeTx>, Request)>,
         pending_throttle: Duration,
-    ) -> Result<Request, ConnectionError> {
+    ) -> Result<(Option<NoticeTx>, Request), ConnectionError> {
         if !pending.is_empty() {
             time::sleep(pending_throttle).await;
             // We must call .next() AFTER sleep() otherwise .next() would

--- a/rumqttc/src/v5/mod.rs
+++ b/rumqttc/src/v5/mod.rs
@@ -14,8 +14,8 @@ mod framed;
 pub mod mqttbytes;
 mod state;
 
+use crate::Outgoing;
 use crate::{NetworkOptions, Transport};
-use crate::{NoticeTx, Outgoing};
 
 use mqttbytes::v5::*;
 
@@ -33,62 +33,21 @@ pub type Incoming = Packet;
 
 /// Requests by the client to mqtt event loop. Request are
 /// handled one by one.
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Request {
-    Publish(Option<NoticeTx>, Publish),
+    Publish(Publish),
     PubAck(PubAck),
     PubRec(PubRec),
     PubComp(PubComp),
-    PubRel(Option<NoticeTx>, PubRel),
+    PubRel(PubRel),
     PingReq,
     PingResp,
-    Subscribe(Option<NoticeTx>, Subscribe),
+    Subscribe(Subscribe),
     SubAck(SubAck),
-    Unsubscribe(Option<NoticeTx>, Unsubscribe),
+    Unsubscribe(Unsubscribe),
     UnsubAck(UnsubAck),
     Disconnect,
 }
-
-impl Clone for Request {
-    fn clone(&self) -> Self {
-        match self {
-            Self::Publish(_, p) => Self::Publish(None, p.clone()),
-            Self::PubAck(p) => Self::PubAck(p.clone()),
-            Self::PubRec(p) => Self::PubRec(p.clone()),
-            Self::PubRel(_, p) => Self::PubRel(None, p.clone()),
-            Self::PubComp(p) => Self::PubComp(p.clone()),
-            Self::Subscribe(_, p) => Self::Subscribe(None, p.clone()),
-            Self::SubAck(p) => Self::SubAck(p.clone()),
-            Self::PingReq => Self::PingReq,
-            Self::PingResp => Self::PingResp,
-            Self::Disconnect => Self::Disconnect,
-            Self::Unsubscribe(_, p) => Self::Unsubscribe(None, p.clone()),
-            Self::UnsubAck(p) => Self::UnsubAck(p.clone()),
-        }
-    }
-}
-
-impl PartialEq for Request {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Publish(_, p1), Self::Publish(_, p2)) => p1 == p2,
-            (Self::PubAck(p1), Self::PubAck(p2)) => p1 == p2,
-            (Self::PubRec(p1), Self::PubRec(p2)) => p1 == p2,
-            (Self::PubRel(_, p1), Self::PubRel(_, p2)) => p1 == p2,
-            (Self::PubComp(p1), Self::PubComp(p2)) => p1 == p2,
-            (Self::Subscribe(_, p1), Self::Subscribe(_, p2)) => p1 == p2,
-            (Self::SubAck(p1), Self::SubAck(p2)) => p1 == p2,
-            (Self::PingReq, Self::PingReq)
-            | (Self::PingResp, Self::PingResp)
-            | (Self::Disconnect, Self::Disconnect) => true,
-            (Self::Unsubscribe(_, p1), Self::Unsubscribe(_, p2)) => p1 == p2,
-            (Self::UnsubAck(p1), Self::UnsubAck(p2)) => p1 == p2,
-            _ => false,
-        }
-    }
-}
-
-impl Eq for Request {}
 
 #[cfg(feature = "websocket")]
 type RequestModifierFn = Arc<

--- a/rumqttc/src/v5/mod.rs
+++ b/rumqttc/src/v5/mod.rs
@@ -7,6 +7,7 @@ use std::{
     pin::Pin,
     sync::Arc,
 };
+use tokio::sync::oneshot;
 
 mod client;
 mod eventloop;
@@ -14,8 +15,8 @@ mod framed;
 pub mod mqttbytes;
 mod state;
 
-use crate::Outgoing;
 use crate::{NetworkOptions, Transport};
+use crate::{Outgoing, Pkid};
 
 use mqttbytes::v5::*;
 
@@ -33,21 +34,62 @@ pub type Incoming = Packet;
 
 /// Requests by the client to mqtt event loop. Request are
 /// handled one by one.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum Request {
-    Publish(Publish),
+    Publish(Option<oneshot::Sender<Pkid>>, Publish),
     PubAck(PubAck),
     PubRec(PubRec),
     PubComp(PubComp),
     PubRel(PubRel),
     PingReq,
     PingResp,
-    Subscribe(Subscribe),
+    Subscribe(Option<oneshot::Sender<Pkid>>, Subscribe),
     SubAck(SubAck),
-    Unsubscribe(Unsubscribe),
+    Unsubscribe(Option<oneshot::Sender<Pkid>>, Unsubscribe),
     UnsubAck(UnsubAck),
     Disconnect,
 }
+
+impl Clone for Request {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Publish(_, p) => Self::Publish(None, p.clone()),
+            Self::PubAck(p) => Self::PubAck(p.clone()),
+            Self::PubRec(p) => Self::PubRec(p.clone()),
+            Self::PubRel(p) => Self::PubRel(p.clone()),
+            Self::PubComp(p) => Self::PubComp(p.clone()),
+            Self::Subscribe(_, p) => Self::Subscribe(None, p.clone()),
+            Self::SubAck(p) => Self::SubAck(p.clone()),
+            Self::PingReq => Self::PingReq,
+            Self::PingResp => Self::PingResp,
+            Self::Disconnect => Self::Disconnect,
+            Self::Unsubscribe(_, p) => Self::Unsubscribe(None, p.clone()),
+            Self::UnsubAck(p) => Self::UnsubAck(p.clone()),
+        }
+    }
+}
+
+impl PartialEq for Request {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Publish(_, p1), Self::Publish(_, p2)) => p1 == p2,
+            (Self::PubAck(p1), Self::PubAck(p2)) => p1 == p2,
+            (Self::PubRec(p1), Self::PubRec(p2)) => p1 == p2,
+            (Self::PubRel(p1), Self::PubRel(p2)) => p1 == p2,
+            (Self::PubComp(p1), Self::PubComp(p2)) => p1 == p2,
+            (Self::Subscribe(_, p1), Self::Subscribe(_, p2)) => p1 == p2,
+            (Self::SubAck(p1), Self::SubAck(p2)) => p1 == p2,
+            (Self::PingReq, Self::PingReq)
+            | (Self::PingResp, Self::PingResp)
+            | (Self::Disconnect, Self::Disconnect) => true,
+            (Self::Unsubscribe(_, p1), Self::Unsubscribe(_, p2)) => p1 == p2,
+            (Self::UnsubAck(p1), Self::UnsubAck(p2)) => p1 == p2,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for Request {}
 
 #[cfg(feature = "websocket")]
 type RequestModifierFn = Arc<

--- a/rumqttc/src/v5/mqttbytes/v5/publish.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/publish.rs
@@ -1,11 +1,8 @@
-use bytes::{Buf, Bytes};
-use tokio::sync::oneshot::Sender;
-
 use super::*;
-use crate::Pkid;
+use bytes::{Buf, Bytes};
 
 /// Publish packet
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Publish {
     pub dup: bool,
     pub qos: QoS,
@@ -14,38 +11,7 @@ pub struct Publish {
     pub pkid: u16,
     pub payload: Bytes,
     pub properties: Option<PublishProperties>,
-    pub pkid_tx: Option<Sender<Pkid>>,
 }
-
-// TODO: figure out if this is even required
-impl Clone for Publish {
-    fn clone(&self) -> Self {
-        Self {
-            dup: self.dup,
-            qos: self.qos,
-            retain: self.retain,
-            topic: self.topic.clone(),
-            payload: self.payload.clone(),
-            pkid: self.pkid,
-            properties: self.properties.clone(),
-            pkid_tx: None,
-        }
-    }
-}
-
-impl PartialEq for Publish {
-    fn eq(&self, other: &Self) -> bool {
-        self.dup == other.dup
-            && self.qos == other.qos
-            && self.retain == other.retain
-            && self.topic == other.topic
-            && self.payload == other.payload
-            && self.pkid == other.pkid
-            && self.properties == other.properties
-    }
-}
-
-impl Eq for Publish {}
 
 impl Publish {
     pub fn new<T: Into<String>, P: Into<Bytes>>(
@@ -119,7 +85,6 @@ impl Publish {
             topic,
             payload: bytes,
             properties,
-            pkid_tx: None,
         };
 
         Ok(publish)
@@ -154,10 +119,6 @@ impl Publish {
         buffer.extend_from_slice(&self.payload);
 
         Ok(1 + count + len)
-    }
-
-    pub fn place_pkid_tx(&mut self, pkid_tx: Sender<Pkid>) {
-        self.pkid_tx = Some(pkid_tx)
     }
 }
 

--- a/rumqttc/src/v5/mqttbytes/v5/subscribe.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/subscribe.rs
@@ -1,39 +1,13 @@
-use bytes::{Buf, Bytes};
-use tokio::sync::oneshot::Sender;
-
 use super::*;
-use crate::Pkid;
+use bytes::{Buf, Bytes};
 
 /// Subscription packet
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Subscribe {
     pub pkid: u16,
     pub filters: Vec<Filter>,
     pub properties: Option<SubscribeProperties>,
-    pub pkid_tx: Option<Sender<Pkid>>,
 }
-
-// TODO: figure out if this is even required
-impl Clone for Subscribe {
-    fn clone(&self) -> Self {
-        Self {
-            pkid: self.pkid,
-            filters: self.filters.clone(),
-            properties: self.properties.clone(),
-            pkid_tx: None,
-        }
-    }
-}
-
-impl PartialEq for Subscribe {
-    fn eq(&self, other: &Self) -> bool {
-        self.pkid == other.pkid
-            && self.filters == other.filters
-            && self.properties == other.properties
-    }
-}
-
-impl Eq for Subscribe {}
 
 impl Subscribe {
     pub fn new(filter: Filter, properties: Option<SubscribeProperties>) -> Self {
@@ -93,7 +67,6 @@ impl Subscribe {
                 pkid,
                 filters,
                 properties,
-                pkid_tx: None,
             }),
         }
     }
@@ -121,10 +94,6 @@ impl Subscribe {
         }
 
         Ok(1 + remaining_len_bytes + remaining_len)
-    }
-
-    pub fn place_pkid_tx(&mut self, pkid_tx: Sender<Pkid>) {
-        self.pkid_tx = Some(pkid_tx)
     }
 }
 

--- a/rumqttc/src/v5/mqttbytes/v5/subscribe.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/subscribe.rs
@@ -1,13 +1,39 @@
-use super::*;
 use bytes::{Buf, Bytes};
+use tokio::sync::oneshot::Sender;
+
+use super::*;
+use crate::Pkid;
 
 /// Subscription packet
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[derive(Debug, Default)]
 pub struct Subscribe {
     pub pkid: u16,
     pub filters: Vec<Filter>,
     pub properties: Option<SubscribeProperties>,
+    pub pkid_tx: Option<Sender<Pkid>>,
 }
+
+// TODO: figure out if this is even required
+impl Clone for Subscribe {
+    fn clone(&self) -> Self {
+        Self {
+            pkid: self.pkid,
+            filters: self.filters.clone(),
+            properties: self.properties.clone(),
+            pkid_tx: None,
+        }
+    }
+}
+
+impl PartialEq for Subscribe {
+    fn eq(&self, other: &Self) -> bool {
+        self.pkid == other.pkid
+            && self.filters == other.filters
+            && self.properties == other.properties
+    }
+}
+
+impl Eq for Subscribe {}
 
 impl Subscribe {
     pub fn new(filter: Filter, properties: Option<SubscribeProperties>) -> Self {
@@ -67,6 +93,7 @@ impl Subscribe {
                 pkid,
                 filters,
                 properties,
+                pkid_tx: None,
             }),
         }
     }
@@ -94,6 +121,10 @@ impl Subscribe {
         }
 
         Ok(1 + remaining_len_bytes + remaining_len)
+    }
+
+    pub fn place_pkid_tx(&mut self, pkid_tx: Sender<Pkid>) {
+        self.pkid_tx = Some(pkid_tx)
     }
 }
 

--- a/rumqttc/src/v5/mqttbytes/v5/unsubscribe.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/unsubscribe.rs
@@ -1,13 +1,37 @@
-use super::*;
 use bytes::{Buf, Bytes};
+use tokio::sync::oneshot::Sender;
+
+use super::*;
+use crate::Pkid;
 
 /// Unsubscribe packet
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Default)]
 pub struct Unsubscribe {
     pub pkid: u16,
     pub filters: Vec<String>,
     pub properties: Option<UnsubscribeProperties>,
+    pub pkid_tx: Option<Sender<Pkid>>,
 }
+
+// TODO: figure out if this is even required
+impl Clone for Unsubscribe {
+    fn clone(&self) -> Self {
+        Self {
+            pkid: self.pkid,
+            filters: self.filters.clone(),
+            properties: self.properties.clone(),
+            pkid_tx: None,
+        }
+    }
+}
+
+impl PartialEq for Unsubscribe {
+    fn eq(&self, other: &Self) -> bool {
+        self.pkid == other.pkid && self.filters == other.filters
+    }
+}
+
+impl Eq for Unsubscribe {}
 
 impl Unsubscribe {
     pub fn new<S: Into<String>>(filter: S, properties: Option<UnsubscribeProperties>) -> Self {
@@ -59,6 +83,7 @@ impl Unsubscribe {
             pkid,
             filters,
             properties,
+            pkid_tx: None,
         };
         Ok(unsubscribe)
     }
@@ -85,6 +110,10 @@ impl Unsubscribe {
         }
 
         Ok(1 + remaining_len_bytes + remaining_len)
+    }
+
+    pub fn place_pkid_tx(&mut self, pkid_tx: Sender<Pkid>) {
+        self.pkid_tx = Some(pkid_tx)
     }
 }
 

--- a/rumqttc/src/v5/mqttbytes/v5/unsubscribe.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/unsubscribe.rs
@@ -1,37 +1,14 @@
 use bytes::{Buf, Bytes};
-use tokio::sync::oneshot::Sender;
 
 use super::*;
-use crate::Pkid;
 
 /// Unsubscribe packet
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Unsubscribe {
     pub pkid: u16,
     pub filters: Vec<String>,
     pub properties: Option<UnsubscribeProperties>,
-    pub pkid_tx: Option<Sender<Pkid>>,
 }
-
-// TODO: figure out if this is even required
-impl Clone for Unsubscribe {
-    fn clone(&self) -> Self {
-        Self {
-            pkid: self.pkid,
-            filters: self.filters.clone(),
-            properties: self.properties.clone(),
-            pkid_tx: None,
-        }
-    }
-}
-
-impl PartialEq for Unsubscribe {
-    fn eq(&self, other: &Self) -> bool {
-        self.pkid == other.pkid && self.filters == other.filters
-    }
-}
-
-impl Eq for Unsubscribe {}
 
 impl Unsubscribe {
     pub fn new<S: Into<String>>(filter: S, properties: Option<UnsubscribeProperties>) -> Self {
@@ -83,7 +60,6 @@ impl Unsubscribe {
             pkid,
             filters,
             properties,
-            pkid_tx: None,
         };
         Ok(unsubscribe)
     }
@@ -110,10 +86,6 @@ impl Unsubscribe {
         }
 
         Ok(1 + remaining_len_bytes + remaining_len)
-    }
-
-    pub fn place_pkid_tx(&mut self, pkid_tx: Sender<Pkid>) {
-        self.pkid_tx = Some(pkid_tx)
     }
 }
 

--- a/rumqttc/src/v5/state.rs
+++ b/rumqttc/src/v5/state.rs
@@ -161,18 +161,18 @@ impl MqttState {
     }
 
     /// Returns inflight outgoing packets and clears internal queues
-    pub fn clean(&mut self) -> Vec<Request> {
+    pub fn clean(&mut self) -> Vec<(Option<NoticeTx>, Request)> {
         let mut pending = Vec::with_capacity(100);
         // remove and collect pending publishes
         for (_, (publish, tx)) in self.outgoing_pub.drain() {
-            let request = Request::Publish(tx, publish);
-            pending.push(request);
+            let request = Request::Publish(publish);
+            pending.push((tx, request));
         }
 
         // remove and collect pending releases
         for (pkid, tx) in self.outgoing_rel.drain() {
-            let request = Request::PubRel(tx, PubRel::new(pkid, None));
-            pending.push(request);
+            let request = Request::PubRel(PubRel::new(pkid, None));
+            pending.push((tx, request));
         }
         self.outgoing_rel.clear();
 
@@ -193,13 +193,14 @@ impl MqttState {
     /// be put on to the network by the eventloop
     pub fn handle_outgoing_packet(
         &mut self,
+        tx: Option<NoticeTx>,
         request: Request,
     ) -> Result<Option<Packet>, StateError> {
         let packet = match request {
-            Request::Publish(tx, publish) => self.outgoing_publish(publish, tx)?,
-            Request::PubRel(tx, pubrel) => self.outgoing_pubrel(pubrel, tx)?,
-            Request::Subscribe(tx, subscribe) => self.outgoing_subscribe(subscribe, tx)?,
-            Request::Unsubscribe(tx, unsubscribe) => self.outgoing_unsubscribe(unsubscribe, tx)?,
+            Request::Publish(publish) => self.outgoing_publish(publish, tx)?,
+            Request::PubRel(pubrel) => self.outgoing_pubrel(pubrel, tx)?,
+            Request::Subscribe(subscribe) => self.outgoing_subscribe(subscribe, tx)?,
+            Request::Unsubscribe(unsubscribe) => self.outgoing_unsubscribe(unsubscribe, tx)?,
             Request::PingReq => self.outgoing_ping()?,
             Request::Disconnect => {
                 self.outgoing_disconnect(DisconnectReasonCode::NormalDisconnection)?
@@ -1052,7 +1053,7 @@ mod test {
 
         // network activity other than pingresp
         let publish = build_outgoing_publish(QoS::AtLeastOnce);
-        mqtt.handle_outgoing_packet(Request::Publish(None, publish))
+        mqtt.handle_outgoing_packet(None, Request::Publish(publish))
             .unwrap();
         mqtt.handle_incoming_packet(Incoming::PubAck(PubAck::new(1, None)))
             .unwrap();

--- a/rumqttc/src/v5/state.rs
+++ b/rumqttc/src/v5/state.rs
@@ -105,17 +105,17 @@ pub struct MqttState {
     /// Number of outgoing inflight publishes
     pub(crate) inflight: u16,
     /// Outgoing QoS 1, 2 publishes which aren't acked yet
-    pub(crate) outgoing_pub: HashMap<u16, (Publish, Option<NoticeTx>)>,
+    pub(crate) outgoing_pub: HashMap<u16, (Publish, NoticeTx)>,
     /// Packet ids of released QoS 2 publishes
-    pub(crate) outgoing_rel: HashMap<u16, Option<NoticeTx>>,
+    pub(crate) outgoing_rel: HashMap<u16, NoticeTx>,
     /// Packet ids on incoming QoS 2 publishes
     pub(crate) incoming_pub: FixedBitSet,
 
-    outgoing_sub: HashMap<u16, Option<NoticeTx>>,
-    outgoing_unsub: HashMap<u16, Option<NoticeTx>>,
+    outgoing_sub: HashMap<u16, NoticeTx>,
+    outgoing_unsub: HashMap<u16, NoticeTx>,
 
     /// Last collision due to broker not acking in order
-    pub(crate) collision: Option<(Publish, Option<NoticeTx>)>,
+    pub(crate) collision: Option<(Publish, NoticeTx)>,
     /// Buffered incoming packets
     pub events: VecDeque<Event>,
     /// Indicates if acknowledgements should be send immediately
@@ -161,7 +161,7 @@ impl MqttState {
     }
 
     /// Returns inflight outgoing packets and clears internal queues
-    pub fn clean(&mut self) -> Vec<(Option<NoticeTx>, Request)> {
+    pub fn clean(&mut self) -> Vec<(NoticeTx, Request)> {
         let mut pending = Vec::with_capacity(100);
         // remove and collect pending publishes
         for (_, (publish, tx)) in self.outgoing_pub.drain() {
@@ -193,7 +193,7 @@ impl MqttState {
     /// be put on to the network by the eventloop
     pub fn handle_outgoing_packet(
         &mut self,
-        tx: Option<NoticeTx>,
+        tx: NoticeTx,
         request: Request,
     ) -> Result<Option<Packet>, StateError> {
         let packet = match request {
@@ -270,18 +270,12 @@ impl MqttState {
                     debug!("SubAck Pkid = {:?}, QoS = {:?}", suback.pkid, qos);
                 }
                 _ => {
-                    if let Some(tx) = tx {
-                        tx.error(NoticeError::V5Subscribe(*reason))
-                    }
-
+                    tx.error(NoticeError::V5Subscribe(*reason));
                     return Err(StateError::SubFail { reason: *reason });
                 }
             }
         }
-
-        if let Some(tx) = tx {
-            tx.success()
-        }
+        tx.success();
 
         Ok(None)
     }
@@ -302,17 +296,11 @@ impl MqttState {
 
         for reason in unsuback.reasons.iter() {
             if reason != &UnsubAckReason::Success {
-                if let Some(tx) = tx {
-                    tx.error(NoticeError::V5Unsubscribe(*reason))
-                }
-
+                tx.error(NoticeError::V5Unsubscribe(*reason));
                 return Err(StateError::UnsubFail { reason: *reason });
             }
         }
-
-        if let Some(tx) = tx {
-            tx.success()
-        }
+        tx.success();
 
         Ok(None)
     }
@@ -411,13 +399,11 @@ impl MqttState {
             return Err(StateError::Unsolicited(puback.pkid));
         }
 
-        if let (_, Some(tx)) = self
+        let (_, tx) = self
             .outgoing_pub
             .remove(&puback.pkid)
-            .ok_or(StateError::Unsolicited(puback.pkid))?
-        {
-            tx.success()
-        }
+            .ok_or(StateError::Unsolicited(puback.pkid))?;
+        tx.success();
 
         self.inflight -= 1;
 
@@ -495,13 +481,10 @@ impl MqttState {
             error!("Unsolicited pubcomp packet: {:?}", pubcomp.pkid);
             return Err(StateError::Unsolicited(pubcomp.pkid));
         }
-        if let Some(tx) = self
-            .outgoing_rel
+        self.outgoing_rel
             .remove(&pubcomp.pkid)
             .ok_or(StateError::Unsolicited(pubcomp.pkid))?
-        {
-            tx.success()
-        }
+            .success();
 
         self.inflight -= 1;
         let packet = self.check_collision(pubcomp.pkid).map(|(publish, tx)| {
@@ -527,7 +510,7 @@ impl MqttState {
     fn outgoing_publish(
         &mut self,
         mut publish: Publish,
-        notice_tx: Option<NoticeTx>,
+        notice_tx: NoticeTx,
     ) -> Result<Option<Packet>, StateError> {
         if publish.qos != QoS::AtMostOnce {
             if publish.pkid == 0 {
@@ -548,8 +531,8 @@ impl MqttState {
             // packet yet. This error is possible only when broker isn't acking sequentially
             self.outgoing_pub.insert(pkid, (publish.clone(), notice_tx));
             self.inflight += 1;
-        } else if let Some(tx) = notice_tx {
-            tx.success()
+        } else {
+            notice_tx.success()
         }
 
         debug!(
@@ -560,7 +543,6 @@ impl MqttState {
         );
 
         let pkid = publish.pkid;
-
         if let Some(props) = &publish.properties {
             if let Some(alias) = props.topic_alias {
                 if alias > self.broker_topic_alias_max {
@@ -583,7 +565,7 @@ impl MqttState {
     fn outgoing_pubrel(
         &mut self,
         pubrel: PubRel,
-        notice_tx: Option<NoticeTx>,
+        notice_tx: NoticeTx,
     ) -> Result<Option<Packet>, StateError> {
         let pubrel = self.save_pubrel(pubrel, notice_tx)?;
 
@@ -646,7 +628,7 @@ impl MqttState {
     fn outgoing_subscribe(
         &mut self,
         mut subscription: Subscribe,
-        notice_tx: Option<NoticeTx>,
+        notice_tx: NoticeTx,
     ) -> Result<Option<Packet>, StateError> {
         if subscription.filters.is_empty() {
             return Err(StateError::EmptySubscription);
@@ -670,7 +652,7 @@ impl MqttState {
     fn outgoing_unsubscribe(
         &mut self,
         mut unsub: Unsubscribe,
-        notice_tx: Option<NoticeTx>,
+        notice_tx: NoticeTx,
     ) -> Result<Option<Packet>, StateError> {
         let pkid = self.next_pkid();
         unsub.pkid = pkid;
@@ -698,7 +680,7 @@ impl MqttState {
         Ok(Some(Packet::Disconnect(Disconnect::new(reason))))
     }
 
-    fn check_collision(&mut self, pkid: u16) -> Option<(Publish, Option<NoticeTx>)> {
+    fn check_collision(&mut self, pkid: u16) -> Option<(Publish, NoticeTx)> {
         if let Some((publish, _)) = &self.collision {
             if publish.pkid == pkid {
                 return self.collision.take();
@@ -711,7 +693,7 @@ impl MqttState {
     fn save_pubrel(
         &mut self,
         mut pubrel: PubRel,
-        notice_tx: Option<NoticeTx>,
+        notice_tx: NoticeTx,
     ) -> Result<PubRel, StateError> {
         let pubrel = match pubrel.pkid {
             // consider PacketIdentifier(0) as uninitialized packets
@@ -749,6 +731,8 @@ impl MqttState {
 
 #[cfg(test)]
 mod test {
+    use crate::notice::NoticeTx;
+
     use super::mqttbytes::v5::*;
     use super::mqttbytes::*;
     use super::{Event, Incoming, Outgoing, Request};
@@ -802,7 +786,8 @@ mod test {
         let publish = build_outgoing_publish(QoS::AtMostOnce);
 
         // QoS 0 publish shouldn't be saved in queue
-        mqtt.outgoing_publish(publish, None).unwrap();
+        let (tx, _) = NoticeTx::new();
+        mqtt.outgoing_publish(publish, tx).unwrap();
         assert_eq!(mqtt.last_pkid, 0);
         assert_eq!(mqtt.inflight, 0);
 
@@ -810,12 +795,14 @@ mod test {
         let publish = build_outgoing_publish(QoS::AtLeastOnce);
 
         // Packet id should be set and publish should be saved in queue
-        mqtt.outgoing_publish(publish.clone(), None).unwrap();
+        let (tx, _) = NoticeTx::new();
+        mqtt.outgoing_publish(publish.clone(), tx).unwrap();
         assert_eq!(mqtt.last_pkid, 1);
         assert_eq!(mqtt.inflight, 1);
 
         // Packet id should be incremented and publish should be saved in queue
-        mqtt.outgoing_publish(publish, None).unwrap();
+        let (tx, _) = NoticeTx::new();
+        mqtt.outgoing_publish(publish, tx).unwrap();
         assert_eq!(mqtt.last_pkid, 2);
         assert_eq!(mqtt.inflight, 2);
 
@@ -823,12 +810,14 @@ mod test {
         let publish = build_outgoing_publish(QoS::ExactlyOnce);
 
         // Packet id should be set and publish should be saved in queue
-        mqtt.outgoing_publish(publish.clone(), None).unwrap();
+        let (tx, _) = NoticeTx::new();
+        mqtt.outgoing_publish(publish.clone(), tx).unwrap();
         assert_eq!(mqtt.last_pkid, 3);
         assert_eq!(mqtt.inflight, 3);
 
         // Packet id should be incremented and publish should be saved in queue
-        mqtt.outgoing_publish(publish, None).unwrap();
+        let (tx, _) = NoticeTx::new();
+        mqtt.outgoing_publish(publish, tx).unwrap();
         assert_eq!(mqtt.last_pkid, 4);
         assert_eq!(mqtt.inflight, 4);
     }
@@ -840,17 +829,20 @@ mod test {
         // QoS2 publish
         let publish = build_outgoing_publish(QoS::ExactlyOnce);
 
-        mqtt.outgoing_publish(publish.clone(), None).unwrap();
+        let (tx, _) = NoticeTx::new();
+        mqtt.outgoing_publish(publish.clone(), tx).unwrap();
         assert_eq!(mqtt.last_pkid, 1);
         assert_eq!(mqtt.inflight, 1);
 
         // Packet id should be set back down to 0, since we hit the limit
-        mqtt.outgoing_publish(publish.clone(), None).unwrap();
+        let (tx, _) = NoticeTx::new();
+        mqtt.outgoing_publish(publish.clone(), tx).unwrap();
         assert_eq!(mqtt.last_pkid, 0);
         assert_eq!(mqtt.inflight, 2);
 
         // This should cause a collition
-        mqtt.outgoing_publish(publish.clone(), None).unwrap();
+        let (tx, _) = NoticeTx::new();
+        mqtt.outgoing_publish(publish.clone(), tx).unwrap();
         assert_eq!(mqtt.last_pkid, 1);
         assert_eq!(mqtt.inflight, 2);
         assert!(mqtt.collision.is_some());
@@ -860,7 +852,8 @@ mod test {
         assert_eq!(mqtt.inflight, 1);
 
         // Now there should be space in the outgoing queue
-        mqtt.outgoing_publish(publish.clone(), None).unwrap();
+        let (tx, _) = NoticeTx::new();
+        mqtt.outgoing_publish(publish.clone(), tx).unwrap();
         assert_eq!(mqtt.last_pkid, 0);
         assert_eq!(mqtt.inflight, 2);
     }
@@ -944,8 +937,10 @@ mod test {
         let publish1 = build_outgoing_publish(QoS::AtLeastOnce);
         let publish2 = build_outgoing_publish(QoS::ExactlyOnce);
 
-        mqtt.outgoing_publish(publish1, None).unwrap();
-        mqtt.outgoing_publish(publish2, None).unwrap();
+        let (tx, _) = NoticeTx::new();
+        mqtt.outgoing_publish(publish1, tx).unwrap();
+        let (tx, _) = NoticeTx::new();
+        mqtt.outgoing_publish(publish2, tx).unwrap();
         assert_eq!(mqtt.inflight, 2);
 
         mqtt.handle_incoming_puback(&PubAck::new(1, None)).unwrap();
@@ -979,8 +974,10 @@ mod test {
         let publish1 = build_outgoing_publish(QoS::AtLeastOnce);
         let publish2 = build_outgoing_publish(QoS::ExactlyOnce);
 
-        let _publish_out = mqtt.outgoing_publish(publish1, None);
-        let _publish_out = mqtt.outgoing_publish(publish2, None);
+        let (tx, _) = NoticeTx::new();
+        let _publish_out = mqtt.outgoing_publish(publish1, tx);
+        let (tx, _) = NoticeTx::new();
+        let _publish_out = mqtt.outgoing_publish(publish2, tx);
 
         mqtt.handle_incoming_pubrec(&PubRec::new(2, None)).unwrap();
         assert_eq!(mqtt.inflight, 2);
@@ -998,7 +995,8 @@ mod test {
         let mut mqtt = build_mqttstate();
 
         let publish = build_outgoing_publish(QoS::ExactlyOnce);
-        match mqtt.outgoing_publish(publish, None).unwrap().unwrap() {
+        let (tx, _) = NoticeTx::new();
+        match mqtt.outgoing_publish(publish, tx).unwrap().unwrap() {
             Packet::Publish(publish) => assert_eq!(publish.pkid, 1),
             packet => panic!("Invalid network request: {:?}", packet),
         }
@@ -1038,7 +1036,8 @@ mod test {
         let mut mqtt = build_mqttstate();
         let publish = build_outgoing_publish(QoS::ExactlyOnce);
 
-        mqtt.outgoing_publish(publish, None).unwrap();
+        let (tx, _) = NoticeTx::new();
+        mqtt.outgoing_publish(publish, tx).unwrap();
         mqtt.handle_incoming_pubrec(&PubRec::new(1, None)).unwrap();
 
         mqtt.handle_incoming_pubcomp(&PubComp::new(1, None))
@@ -1053,7 +1052,8 @@ mod test {
 
         // network activity other than pingresp
         let publish = build_outgoing_publish(QoS::AtLeastOnce);
-        mqtt.handle_outgoing_packet(None, Request::Publish(publish))
+        let (tx, _) = NoticeTx::new();
+        mqtt.handle_outgoing_packet(tx, Request::Publish(publish))
             .unwrap();
         mqtt.handle_incoming_packet(Incoming::PubAck(PubAck::new(1, None)))
             .unwrap();

--- a/rumqttc/src/v5/state.rs
+++ b/rumqttc/src/v5/state.rs
@@ -1,4 +1,4 @@
-use crate::Pkid;
+use crate::{NoticeError, NoticeTx};
 
 use super::mqttbytes::v5::{
     ConnAck, ConnectReturnCode, Disconnect, DisconnectReasonCode, Packet, PingReq, PubAck,
@@ -13,7 +13,6 @@ use bytes::Bytes;
 use fixedbitset::FixedBitSet;
 use std::collections::{HashMap, VecDeque};
 use std::{io, time::Instant};
-use tokio::sync::oneshot;
 
 /// Errors during state handling
 #[derive(Debug, thiserror::Error)]
@@ -89,7 +88,7 @@ impl From<mqttbytes::Error> for StateError {
 // This is done for 2 reasons
 // Bad acks or out of order acks aren't O(n) causing cpu spikes
 // Any missing acks from the broker are detected during the next recycled use of packet ids
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct MqttState {
     /// Status of last ping
     pub await_pingresp: bool,
@@ -106,13 +105,17 @@ pub struct MqttState {
     /// Number of outgoing inflight publishes
     pub(crate) inflight: u16,
     /// Outgoing QoS 1, 2 publishes which aren't acked yet
-    pub(crate) outgoing_pub: Vec<Option<Publish>>,
+    pub(crate) outgoing_pub: HashMap<u16, (Publish, Option<NoticeTx>)>,
     /// Packet ids of released QoS 2 publishes
-    pub(crate) outgoing_rel: FixedBitSet,
+    pub(crate) outgoing_rel: HashMap<u16, Option<NoticeTx>>,
     /// Packet ids on incoming QoS 2 publishes
     pub(crate) incoming_pub: FixedBitSet,
+
+    outgoing_sub: HashMap<u16, Option<NoticeTx>>,
+    outgoing_unsub: HashMap<u16, Option<NoticeTx>>,
+
     /// Last collision due to broker not acking in order
-    pub collision: Option<Publish>,
+    pub(crate) collision: Option<(Publish, Option<NoticeTx>)>,
     /// Buffered incoming packets
     pub events: VecDeque<Event>,
     /// Indicates if acknowledgements should be send immediately
@@ -139,10 +142,12 @@ impl MqttState {
             last_outgoing: Instant::now(),
             last_pkid: 0,
             inflight: 0,
+            outgoing_pub: HashMap::new(),
+            outgoing_rel: HashMap::new(),
             // index 0 is wasted as 0 is not a valid packet id
-            outgoing_pub: vec![None; max_inflight as usize + 1],
-            outgoing_rel: FixedBitSet::with_capacity(max_inflight as usize + 1),
             incoming_pub: FixedBitSet::with_capacity(u16::MAX as usize + 1),
+            outgoing_sub: HashMap::new(),
+            outgoing_unsub: HashMap::new(),
             collision: None,
             // TODO: Optimize these sizes later
             events: VecDeque::with_capacity(100),
@@ -159,16 +164,14 @@ impl MqttState {
     pub fn clean(&mut self) -> Vec<Request> {
         let mut pending = Vec::with_capacity(100);
         // remove and collect pending publishes
-        for publish in self.outgoing_pub.iter_mut() {
-            if let Some(publish) = publish.take() {
-                let request = Request::Publish(None, publish);
-                pending.push(request);
-            }
+        for (_, (publish, tx)) in self.outgoing_pub.drain() {
+            let request = Request::Publish(tx, publish);
+            pending.push(request);
         }
 
         // remove and collect pending releases
-        for pkid in self.outgoing_rel.ones() {
-            let request = Request::PubRel(PubRel::new(pkid as u16, None));
+        for (pkid, tx) in self.outgoing_rel.drain() {
+            let request = Request::PubRel(tx, PubRel::new(pkid, None));
             pending.push(request);
         }
         self.outgoing_rel.clear();
@@ -194,7 +197,7 @@ impl MqttState {
     ) -> Result<Option<Packet>, StateError> {
         let packet = match request {
             Request::Publish(tx, publish) => self.outgoing_publish(publish, tx)?,
-            Request::PubRel(pubrel) => self.outgoing_pubrel(pubrel)?,
+            Request::PubRel(tx, pubrel) => self.outgoing_pubrel(pubrel, tx)?,
             Request::Subscribe(tx, subscribe) => self.outgoing_subscribe(subscribe, tx)?,
             Request::Unsubscribe(tx, unsubscribe) => self.outgoing_unsubscribe(unsubscribe, tx)?,
             Request::PingReq => self.outgoing_ping()?,
@@ -250,14 +253,35 @@ impl MqttState {
         &mut self,
         suback: &mut SubAck,
     ) -> Result<Option<Packet>, StateError> {
+        if suback.pkid > self.max_outgoing_inflight {
+            error!("Unsolicited suback packet: {:?}", suback.pkid);
+            return Err(StateError::Unsolicited(suback.pkid));
+        }
+
+        let tx = self
+            .outgoing_sub
+            .remove(&suback.pkid)
+            .ok_or(StateError::Unsolicited(suback.pkid))?;
+
         for reason in suback.return_codes.iter() {
             match reason {
                 SubscribeReasonCode::Success(qos) => {
                     debug!("SubAck Pkid = {:?}, QoS = {:?}", suback.pkid, qos);
                 }
-                _ => return Err(StateError::SubFail { reason: *reason }),
+                _ => {
+                    if let Some(tx) = tx {
+                        tx.error(NoticeError::V5Subscribe(*reason))
+                    }
+
+                    return Err(StateError::SubFail { reason: *reason });
+                }
             }
         }
+
+        if let Some(tx) = tx {
+            tx.success()
+        }
+
         Ok(None)
     }
 
@@ -265,11 +289,30 @@ impl MqttState {
         &mut self,
         unsuback: &mut UnsubAck,
     ) -> Result<Option<Packet>, StateError> {
+        if unsuback.pkid > self.max_outgoing_inflight {
+            error!("Unsolicited unsuback packet: {:?}", unsuback.pkid);
+            return Err(StateError::Unsolicited(unsuback.pkid));
+        }
+
+        let tx = self
+            .outgoing_unsub
+            .remove(&unsuback.pkid)
+            .ok_or(StateError::Unsolicited(unsuback.pkid))?;
+
         for reason in unsuback.reasons.iter() {
             if reason != &UnsubAckReason::Success {
+                if let Some(tx) = tx {
+                    tx.error(NoticeError::V5Unsubscribe(*reason))
+                }
+
                 return Err(StateError::UnsubFail { reason: *reason });
             }
         }
+
+        if let Some(tx) = tx {
+            tx.success()
+        }
+
         Ok(None)
     }
 
@@ -362,14 +405,17 @@ impl MqttState {
     }
 
     fn handle_incoming_puback(&mut self, puback: &PubAck) -> Result<Option<Packet>, StateError> {
-        let publish = self
-            .outgoing_pub
-            .get_mut(puback.pkid as usize)
-            .ok_or(StateError::Unsolicited(puback.pkid))?;
-
-        if publish.take().is_none() {
+        if puback.pkid > self.max_outgoing_inflight {
             error!("Unsolicited puback packet: {:?}", puback.pkid);
             return Err(StateError::Unsolicited(puback.pkid));
+        }
+
+        if let (_, Some(tx)) = self
+            .outgoing_pub
+            .remove(&puback.pkid)
+            .ok_or(StateError::Unsolicited(puback.pkid))?
+        {
+            tx.success()
         }
 
         self.inflight -= 1;
@@ -382,31 +428,31 @@ impl MqttState {
             });
         }
 
-        if let Some(publish) = self.check_collision(puback.pkid) {
-            self.outgoing_pub[publish.pkid as usize] = Some(publish.clone());
+        let packet = self.check_collision(puback.pkid).map(|(publish, tx)| {
+            self.outgoing_pub
+                .insert(publish.pkid, (publish.clone(), tx));
             self.inflight += 1;
 
-            let pkid = publish.pkid;
-            let event = Event::Outgoing(Outgoing::Publish(pkid));
+            let event = Event::Outgoing(Outgoing::Publish(publish.pkid));
             self.events.push_back(event);
             self.collision_ping_count = 0;
 
-            return Ok(Some(Packet::Publish(publish)));
-        }
+            Packet::Publish(publish)
+        });
 
-        Ok(None)
+        Ok(packet)
     }
 
     fn handle_incoming_pubrec(&mut self, pubrec: &PubRec) -> Result<Option<Packet>, StateError> {
-        let publish = self
-            .outgoing_pub
-            .get_mut(pubrec.pkid as usize)
-            .ok_or(StateError::Unsolicited(pubrec.pkid))?;
-
-        if publish.take().is_none() {
+        if pubrec.pkid > self.max_outgoing_inflight {
             error!("Unsolicited pubrec packet: {:?}", pubrec.pkid);
             return Err(StateError::Unsolicited(pubrec.pkid));
         }
+
+        let (_, tx) = self
+            .outgoing_pub
+            .remove(&pubrec.pkid)
+            .ok_or(StateError::Unsolicited(pubrec.pkid))?;
 
         if pubrec.reason != PubRecReason::Success
             && pubrec.reason != PubRecReason::NoMatchingSubscribers
@@ -417,7 +463,7 @@ impl MqttState {
         }
 
         // NOTE: Inflight - 1 for qos2 in comp
-        self.outgoing_rel.insert(pubrec.pkid as usize);
+        self.outgoing_rel.insert(pubrec.pkid, tx);
         let event = Event::Outgoing(Outgoing::PubRel(pubrec.pkid));
         self.events.push_back(event);
 
@@ -444,29 +490,30 @@ impl MqttState {
     }
 
     fn handle_incoming_pubcomp(&mut self, pubcomp: &PubComp) -> Result<Option<Packet>, StateError> {
-        let outgoing = self.check_collision(pubcomp.pkid).map(|publish| {
-            let pkid = publish.pkid;
-            let event = Event::Outgoing(Outgoing::Publish(pkid));
+        if pubcomp.pkid > self.max_outgoing_inflight {
+            error!("Unsolicited pubcomp packet: {:?}", pubcomp.pkid);
+            return Err(StateError::Unsolicited(pubcomp.pkid));
+        }
+        if let Some(tx) = self
+            .outgoing_rel
+            .remove(&pubcomp.pkid)
+            .ok_or(StateError::Unsolicited(pubcomp.pkid))?
+        {
+            tx.success()
+        }
+
+        self.inflight -= 1;
+        let packet = self.check_collision(pubcomp.pkid).map(|(publish, tx)| {
+            self.outgoing_pub
+                .insert(pubcomp.pkid, (publish.clone(), tx));
+            let event = Event::Outgoing(Outgoing::Publish(publish.pkid));
             self.events.push_back(event);
             self.collision_ping_count = 0;
 
             Packet::Publish(publish)
         });
 
-        if !self.outgoing_rel.contains(pubcomp.pkid as usize) {
-            error!("Unsolicited pubcomp packet: {:?}", pubcomp.pkid);
-            return Err(StateError::Unsolicited(pubcomp.pkid));
-        }
-        self.outgoing_rel.set(pubcomp.pkid as usize, false);
-
-        if pubcomp.reason != PubCompReason::Success {
-            return Err(StateError::PubCompFail {
-                reason: pubcomp.reason,
-            });
-        }
-
-        self.inflight -= 1;
-        Ok(outgoing)
+        Ok(packet)
     }
 
     fn handle_incoming_pingresp(&mut self) -> Result<Option<Packet>, StateError> {
@@ -479,29 +526,18 @@ impl MqttState {
     fn outgoing_publish(
         &mut self,
         mut publish: Publish,
-        pkid_tx: Option<oneshot::Sender<Pkid>>,
+        notice_tx: Option<NoticeTx>,
     ) -> Result<Option<Packet>, StateError> {
-        // NOTE: pkid promise need not be fulfilled for QoS 0,
-        // user should know this but still handled in Client.
         if publish.qos != QoS::AtMostOnce {
             if publish.pkid == 0 {
                 publish.pkid = self.next_pkid();
             }
 
             let pkid = publish.pkid;
-            // Fulfill the pkid promise
-            if let Some(pkid_tx) = pkid_tx {
-                _ = pkid_tx.send(pkid);
-            }
 
-            if self
-                .outgoing_pub
-                .get(publish.pkid as usize)
-                .ok_or(StateError::Unsolicited(publish.pkid))?
-                .is_some()
-            {
+            if self.outgoing_pub.get(&publish.pkid).is_some() {
                 info!("Collision on packet id = {:?}", publish.pkid);
-                self.collision = Some(publish);
+                self.collision = Some((publish, notice_tx));
                 let event = Event::Outgoing(Outgoing::AwaitAck(pkid));
                 self.events.push_back(event);
                 return Ok(None);
@@ -509,9 +545,11 @@ impl MqttState {
 
             // if there is an existing publish at this pkid, this implies that broker hasn't acked this
             // packet yet. This error is possible only when broker isn't acking sequentially
-            self.outgoing_pub[pkid as usize] = Some(publish.clone());
+            self.outgoing_pub.insert(pkid, (publish.clone(), notice_tx));
             self.inflight += 1;
-        };
+        } else if let Some(tx) = notice_tx {
+            tx.success()
+        }
 
         debug!(
             "Publish. Topic = {}, Pkid = {:?}, Payload Size = {:?}",
@@ -541,8 +579,12 @@ impl MqttState {
         Ok(Some(Packet::Publish(publish)))
     }
 
-    fn outgoing_pubrel(&mut self, pubrel: PubRel) -> Result<Option<Packet>, StateError> {
-        let pubrel = self.save_pubrel(pubrel)?;
+    fn outgoing_pubrel(
+        &mut self,
+        pubrel: PubRel,
+        notice_tx: Option<NoticeTx>,
+    ) -> Result<Option<Packet>, StateError> {
+        let pubrel = self.save_pubrel(pubrel, notice_tx)?;
 
         debug!("Pubrel. Pkid = {}", pubrel.pkid);
 
@@ -603,7 +645,7 @@ impl MqttState {
     fn outgoing_subscribe(
         &mut self,
         mut subscription: Subscribe,
-        pkid_tx: Option<oneshot::Sender<Pkid>>,
+        notice_tx: Option<NoticeTx>,
     ) -> Result<Option<Packet>, StateError> {
         if subscription.filters.is_empty() {
             return Err(StateError::EmptySubscription);
@@ -611,17 +653,13 @@ impl MqttState {
 
         let pkid = self.next_pkid();
         subscription.pkid = pkid;
-        // Fulfill the pkid promise
-        if let Some(pkid_tx) = pkid_tx {
-            _ = pkid_tx.send(pkid);
-        }
 
         debug!(
             "Subscribe. Topics = {:?}, Pkid = {:?}",
             subscription.filters, subscription.pkid
         );
 
-        let pkid = subscription.pkid;
+        self.outgoing_sub.insert(pkid, notice_tx);
         let event = Event::Outgoing(Outgoing::Subscribe(pkid));
         self.events.push_back(event);
 
@@ -631,21 +669,17 @@ impl MqttState {
     fn outgoing_unsubscribe(
         &mut self,
         mut unsub: Unsubscribe,
-        pkid_tx: Option<oneshot::Sender<Pkid>>,
+        notice_tx: Option<NoticeTx>,
     ) -> Result<Option<Packet>, StateError> {
         let pkid = self.next_pkid();
         unsub.pkid = pkid;
-        // Fulfill the pkid promise
-        if let Some(pkid_tx) = pkid_tx {
-            _ = pkid_tx.send(pkid);
-        }
 
         debug!(
             "Unsubscribe. Topics = {:?}, Pkid = {:?}",
             unsub.filters, unsub.pkid
         );
 
-        let pkid = unsub.pkid;
+        self.outgoing_unsub.insert(pkid, notice_tx);
         let event = Event::Outgoing(Outgoing::Unsubscribe(pkid));
         self.events.push_back(event);
 
@@ -663,8 +697,8 @@ impl MqttState {
         Ok(Some(Packet::Disconnect(Disconnect::new(reason))))
     }
 
-    fn check_collision(&mut self, pkid: u16) -> Option<Publish> {
-        if let Some(publish) = &self.collision {
+    fn check_collision(&mut self, pkid: u16) -> Option<(Publish, Option<NoticeTx>)> {
+        if let Some((publish, _)) = &self.collision {
             if publish.pkid == pkid {
                 return self.collision.take();
             }
@@ -673,7 +707,11 @@ impl MqttState {
         None
     }
 
-    fn save_pubrel(&mut self, mut pubrel: PubRel) -> Result<PubRel, StateError> {
+    fn save_pubrel(
+        &mut self,
+        mut pubrel: PubRel,
+        notice_tx: Option<NoticeTx>,
+    ) -> Result<PubRel, StateError> {
         let pubrel = match pubrel.pkid {
             // consider PacketIdentifier(0) as uninitialized packets
             0 => {
@@ -683,7 +721,7 @@ impl MqttState {
             _ => pubrel,
         };
 
-        self.outgoing_rel.insert(pubrel.pkid as usize);
+        self.outgoing_rel.insert(pubrel.pkid, notice_tx);
         self.inflight += 1;
         Ok(pubrel)
     }
@@ -915,8 +953,8 @@ mod test {
         mqtt.handle_incoming_puback(&PubAck::new(2, None)).unwrap();
         assert_eq!(mqtt.inflight, 0);
 
-        assert!(mqtt.outgoing_pub[1].is_none());
-        assert!(mqtt.outgoing_pub[2].is_none());
+        assert!(mqtt.outgoing_pub.get(&1).is_none());
+        assert!(mqtt.outgoing_pub.get(&2).is_none());
     }
 
     #[test]
@@ -947,11 +985,11 @@ mod test {
         assert_eq!(mqtt.inflight, 2);
 
         // check if the remaining element's pkid is 1
-        let backup = mqtt.outgoing_pub[1].clone();
-        assert_eq!(backup.unwrap().pkid, 1);
+        let (backup, _) = mqtt.outgoing_pub.get(&1).unwrap();
+        assert_eq!(backup.pkid, 1);
 
-        // check if the qos2 element's release pkid is 2
-        assert!(mqtt.outgoing_rel.contains(2));
+        // check if the qos2 element's release pkik has been set
+        assert!(mqtt.outgoing_rel.get(&2).is_some());
     }
 
     #[test]

--- a/rumqttc/src/v5/state.rs
+++ b/rumqttc/src/v5/state.rs
@@ -474,12 +474,19 @@ impl MqttState {
     /// Adds next packet identifier to QoS 1 and 2 publish packets and returns
     /// it buy wrapping publish in packet
     fn outgoing_publish(&mut self, mut publish: Publish) -> Result<Option<Packet>, StateError> {
+        // NOTE: pkid promise need not be fulfilled for QoS 0,
+        // user should know this but still handled in Client.
         if publish.qos != QoS::AtMostOnce {
             if publish.pkid == 0 {
                 publish.pkid = self.next_pkid();
             }
 
             let pkid = publish.pkid;
+            // Fulfill the pkid promise
+            if let Some(pkid_tx) = publish.pkid_tx.take() {
+                _ = pkid_tx.send(pkid);
+            }
+
             if self
                 .outgoing_pub
                 .get(publish.pkid as usize)
@@ -596,6 +603,10 @@ impl MqttState {
 
         let pkid = self.next_pkid();
         subscription.pkid = pkid;
+        // Fulfill the pkid promise
+        if let Some(pkid_tx) = subscription.pkid_tx.take() {
+            _ = pkid_tx.send(pkid);
+        }
 
         debug!(
             "Subscribe. Topics = {:?}, Pkid = {:?}",
@@ -615,6 +626,10 @@ impl MqttState {
     ) -> Result<Option<Packet>, StateError> {
         let pkid = self.next_pkid();
         unsub.pkid = pkid;
+        // Fulfill the pkid promise
+        if let Some(pkid_tx) = unsub.pkid_tx.take() {
+            _ = pkid_tx.send(pkid);
+        }
 
         debug!(
             "Unsubscribe. Topics = {:?}, Pkid = {:?}",

--- a/rumqttc/src/v5/state.rs
+++ b/rumqttc/src/v5/state.rs
@@ -1,3 +1,5 @@
+use crate::Pkid;
+
 use super::mqttbytes::v5::{
     ConnAck, ConnectReturnCode, Disconnect, DisconnectReasonCode, Packet, PingReq, PubAck,
     PubAckReason, PubComp, PubCompReason, PubRec, PubRecReason, PubRel, PubRelReason, Publish,
@@ -11,6 +13,7 @@ use bytes::Bytes;
 use fixedbitset::FixedBitSet;
 use std::collections::{HashMap, VecDeque};
 use std::{io, time::Instant};
+use tokio::sync::oneshot;
 
 /// Errors during state handling
 #[derive(Debug, thiserror::Error)]
@@ -158,7 +161,7 @@ impl MqttState {
         // remove and collect pending publishes
         for publish in self.outgoing_pub.iter_mut() {
             if let Some(publish) = publish.take() {
-                let request = Request::Publish(publish);
+                let request = Request::Publish(None, publish);
                 pending.push(request);
             }
         }
@@ -190,10 +193,10 @@ impl MqttState {
         request: Request,
     ) -> Result<Option<Packet>, StateError> {
         let packet = match request {
-            Request::Publish(publish) => self.outgoing_publish(publish)?,
+            Request::Publish(tx, publish) => self.outgoing_publish(publish, tx)?,
             Request::PubRel(pubrel) => self.outgoing_pubrel(pubrel)?,
-            Request::Subscribe(subscribe) => self.outgoing_subscribe(subscribe)?,
-            Request::Unsubscribe(unsubscribe) => self.outgoing_unsubscribe(unsubscribe)?,
+            Request::Subscribe(tx, subscribe) => self.outgoing_subscribe(subscribe, tx)?,
+            Request::Unsubscribe(tx, unsubscribe) => self.outgoing_unsubscribe(unsubscribe, tx)?,
             Request::PingReq => self.outgoing_ping()?,
             Request::Disconnect => {
                 self.outgoing_disconnect(DisconnectReasonCode::NormalDisconnection)?
@@ -473,7 +476,11 @@ impl MqttState {
 
     /// Adds next packet identifier to QoS 1 and 2 publish packets and returns
     /// it buy wrapping publish in packet
-    fn outgoing_publish(&mut self, mut publish: Publish) -> Result<Option<Packet>, StateError> {
+    fn outgoing_publish(
+        &mut self,
+        mut publish: Publish,
+        pkid_tx: Option<oneshot::Sender<Pkid>>,
+    ) -> Result<Option<Packet>, StateError> {
         // NOTE: pkid promise need not be fulfilled for QoS 0,
         // user should know this but still handled in Client.
         if publish.qos != QoS::AtMostOnce {
@@ -483,7 +490,7 @@ impl MqttState {
 
             let pkid = publish.pkid;
             // Fulfill the pkid promise
-            if let Some(pkid_tx) = publish.pkid_tx.take() {
+            if let Some(pkid_tx) = pkid_tx {
                 _ = pkid_tx.send(pkid);
             }
 
@@ -596,6 +603,7 @@ impl MqttState {
     fn outgoing_subscribe(
         &mut self,
         mut subscription: Subscribe,
+        pkid_tx: Option<oneshot::Sender<Pkid>>,
     ) -> Result<Option<Packet>, StateError> {
         if subscription.filters.is_empty() {
             return Err(StateError::EmptySubscription);
@@ -604,7 +612,7 @@ impl MqttState {
         let pkid = self.next_pkid();
         subscription.pkid = pkid;
         // Fulfill the pkid promise
-        if let Some(pkid_tx) = subscription.pkid_tx.take() {
+        if let Some(pkid_tx) = pkid_tx {
             _ = pkid_tx.send(pkid);
         }
 
@@ -623,11 +631,12 @@ impl MqttState {
     fn outgoing_unsubscribe(
         &mut self,
         mut unsub: Unsubscribe,
+        pkid_tx: Option<oneshot::Sender<Pkid>>,
     ) -> Result<Option<Packet>, StateError> {
         let pkid = self.next_pkid();
         unsub.pkid = pkid;
         // Fulfill the pkid promise
-        if let Some(pkid_tx) = unsub.pkid_tx.take() {
+        if let Some(pkid_tx) = pkid_tx {
             _ = pkid_tx.send(pkid);
         }
 
@@ -754,7 +763,7 @@ mod test {
         let publish = build_outgoing_publish(QoS::AtMostOnce);
 
         // QoS 0 publish shouldn't be saved in queue
-        mqtt.outgoing_publish(publish).unwrap();
+        mqtt.outgoing_publish(publish, None).unwrap();
         assert_eq!(mqtt.last_pkid, 0);
         assert_eq!(mqtt.inflight, 0);
 
@@ -762,12 +771,12 @@ mod test {
         let publish = build_outgoing_publish(QoS::AtLeastOnce);
 
         // Packet id should be set and publish should be saved in queue
-        mqtt.outgoing_publish(publish.clone()).unwrap();
+        mqtt.outgoing_publish(publish.clone(), None).unwrap();
         assert_eq!(mqtt.last_pkid, 1);
         assert_eq!(mqtt.inflight, 1);
 
         // Packet id should be incremented and publish should be saved in queue
-        mqtt.outgoing_publish(publish).unwrap();
+        mqtt.outgoing_publish(publish, None).unwrap();
         assert_eq!(mqtt.last_pkid, 2);
         assert_eq!(mqtt.inflight, 2);
 
@@ -775,12 +784,12 @@ mod test {
         let publish = build_outgoing_publish(QoS::ExactlyOnce);
 
         // Packet id should be set and publish should be saved in queue
-        mqtt.outgoing_publish(publish.clone()).unwrap();
+        mqtt.outgoing_publish(publish.clone(), None).unwrap();
         assert_eq!(mqtt.last_pkid, 3);
         assert_eq!(mqtt.inflight, 3);
 
         // Packet id should be incremented and publish should be saved in queue
-        mqtt.outgoing_publish(publish).unwrap();
+        mqtt.outgoing_publish(publish, None).unwrap();
         assert_eq!(mqtt.last_pkid, 4);
         assert_eq!(mqtt.inflight, 4);
     }
@@ -792,17 +801,17 @@ mod test {
         // QoS2 publish
         let publish = build_outgoing_publish(QoS::ExactlyOnce);
 
-        mqtt.outgoing_publish(publish.clone()).unwrap();
+        mqtt.outgoing_publish(publish.clone(), None).unwrap();
         assert_eq!(mqtt.last_pkid, 1);
         assert_eq!(mqtt.inflight, 1);
 
         // Packet id should be set back down to 0, since we hit the limit
-        mqtt.outgoing_publish(publish.clone()).unwrap();
+        mqtt.outgoing_publish(publish.clone(), None).unwrap();
         assert_eq!(mqtt.last_pkid, 0);
         assert_eq!(mqtt.inflight, 2);
 
         // This should cause a collition
-        mqtt.outgoing_publish(publish.clone()).unwrap();
+        mqtt.outgoing_publish(publish.clone(), None).unwrap();
         assert_eq!(mqtt.last_pkid, 1);
         assert_eq!(mqtt.inflight, 2);
         assert!(mqtt.collision.is_some());
@@ -812,7 +821,7 @@ mod test {
         assert_eq!(mqtt.inflight, 1);
 
         // Now there should be space in the outgoing queue
-        mqtt.outgoing_publish(publish.clone()).unwrap();
+        mqtt.outgoing_publish(publish.clone(), None).unwrap();
         assert_eq!(mqtt.last_pkid, 0);
         assert_eq!(mqtt.inflight, 2);
     }
@@ -896,8 +905,8 @@ mod test {
         let publish1 = build_outgoing_publish(QoS::AtLeastOnce);
         let publish2 = build_outgoing_publish(QoS::ExactlyOnce);
 
-        mqtt.outgoing_publish(publish1).unwrap();
-        mqtt.outgoing_publish(publish2).unwrap();
+        mqtt.outgoing_publish(publish1, None).unwrap();
+        mqtt.outgoing_publish(publish2, None).unwrap();
         assert_eq!(mqtt.inflight, 2);
 
         mqtt.handle_incoming_puback(&PubAck::new(1, None)).unwrap();
@@ -931,8 +940,8 @@ mod test {
         let publish1 = build_outgoing_publish(QoS::AtLeastOnce);
         let publish2 = build_outgoing_publish(QoS::ExactlyOnce);
 
-        let _publish_out = mqtt.outgoing_publish(publish1);
-        let _publish_out = mqtt.outgoing_publish(publish2);
+        let _publish_out = mqtt.outgoing_publish(publish1, None);
+        let _publish_out = mqtt.outgoing_publish(publish2, None);
 
         mqtt.handle_incoming_pubrec(&PubRec::new(2, None)).unwrap();
         assert_eq!(mqtt.inflight, 2);
@@ -950,7 +959,7 @@ mod test {
         let mut mqtt = build_mqttstate();
 
         let publish = build_outgoing_publish(QoS::ExactlyOnce);
-        match mqtt.outgoing_publish(publish).unwrap().unwrap() {
+        match mqtt.outgoing_publish(publish, None).unwrap().unwrap() {
             Packet::Publish(publish) => assert_eq!(publish.pkid, 1),
             packet => panic!("Invalid network request: {:?}", packet),
         }
@@ -990,7 +999,7 @@ mod test {
         let mut mqtt = build_mqttstate();
         let publish = build_outgoing_publish(QoS::ExactlyOnce);
 
-        mqtt.outgoing_publish(publish).unwrap();
+        mqtt.outgoing_publish(publish, None).unwrap();
         mqtt.handle_incoming_pubrec(&PubRec::new(1, None)).unwrap();
 
         mqtt.handle_incoming_pubcomp(&PubComp::new(1, None))
@@ -1005,7 +1014,7 @@ mod test {
 
         // network activity other than pingresp
         let publish = build_outgoing_publish(QoS::AtLeastOnce);
-        mqtt.handle_outgoing_packet(Request::Publish(publish))
+        mqtt.handle_outgoing_packet(Request::Publish(None, publish))
             .unwrap();
         mqtt.handle_incoming_packet(Incoming::PubAck(PubAck::new(1, None)))
             .unwrap();


### PR DESCRIPTION
## Type of change
* New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.


## Explanation
This is the `acked` branch by @de-sh rebased onto `main` (as of now, it might fall behind over time).

The biggest issue with rebasing was a conflict with the `FixedBitset` change such that I had to remove some of them. I have some ideas on how a different API could change that though. I'll elaborate in #805.