### PR TITLE
refactor(rumqttc): make AsyncClient/Eventloop mockable

### DIFF
--- a/benchmarks/clients/rumqttasync.rs
+++ b/benchmarks/clients/rumqttasync.rs
@@ -1,4 +1,4 @@
-use rumqttc::{AsyncClient, Event, Incoming, MqttOptions, QoS};
+use rumqttc::{AsyncClient, Event, Incoming, MqttOptions, PollableEventLoop, QoS};
 
 use std::error::Error;
 use std::time::{Duration, Instant};

--- a/benchmarks/clients/rumqttasyncqos0.rs
+++ b/benchmarks/clients/rumqttasyncqos0.rs
@@ -1,4 +1,4 @@
-use rumqttc::{AsyncClient, Event, Incoming, MqttOptions, QoS};
+use rumqttc::{AsyncClient, Event, Incoming, MqttOptions, PollableEventLoop, QoS};
 
 use std::error::Error;
 use std::time::{Duration, Instant};

--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Made `DisconnectProperties` struct public.
 * Replace `Vec<Option<u16>>` with `FixedBitSet` for managing packet ids of released QoS 2 publishes and incoming QoS 2 publishes in `MqttState`.
 * Accept `native_tls::TlsConnector` as input for `Transport::tls_with_config`.
+* put `EventLoop::poll` behind a new trait: `PollableEventLoop`, to make it mockable. When using an EventLoop you now have to make the trait known to the compiler: `use rumqttc::PollableEventLoop`.
 
 ### Deprecated
 

--- a/rumqttc/examples/async_manual_acks.rs
+++ b/rumqttc/examples/async_manual_acks.rs
@@ -1,6 +1,6 @@
 use tokio::{task, time};
 
-use rumqttc::{AsyncClient, Event, EventLoop, Incoming, MqttOptions, QoS};
+use rumqttc::{AsyncClient, Event, EventLoop, Incoming, MqttOptions, PollableEventLoop, QoS};
 use std::error::Error;
 use std::time::Duration;
 

--- a/rumqttc/examples/async_manual_acks_v5.rs
+++ b/rumqttc/examples/async_manual_acks_v5.rs
@@ -1,5 +1,6 @@
 use rumqttc::v5::mqttbytes::v5::Packet;
 use rumqttc::v5::mqttbytes::QoS;
+use rumqttc::PollableEventLoop;
 use tokio::{task, time};
 
 use rumqttc::v5::{AsyncClient, Event, EventLoop, MqttOptions};

--- a/rumqttc/examples/asyncpubsub.rs
+++ b/rumqttc/examples/asyncpubsub.rs
@@ -1,6 +1,6 @@
 use tokio::{task, time};
 
-use rumqttc::{AsyncClient, MqttOptions, QoS};
+use rumqttc::{AsyncClient, MqttOptions, PollableEventLoop, QoS};
 use std::error::Error;
 use std::time::Duration;
 

--- a/rumqttc/examples/asyncpubsub_v5.rs
+++ b/rumqttc/examples/asyncpubsub_v5.rs
@@ -2,6 +2,7 @@ use rumqttc::v5::mqttbytes::QoS;
 use tokio::{task, time};
 
 use rumqttc::v5::{AsyncClient, MqttOptions};
+use rumqttc::PollableEventLoop;
 use std::error::Error;
 use std::time::Duration;
 

--- a/rumqttc/examples/asyncpubsub_v5_mocked.rs
+++ b/rumqttc/examples/asyncpubsub_v5_mocked.rs
@@ -1,0 +1,189 @@
+use std::{error::Error, time::Duration, vec::IntoIter};
+use tokio::{task, time};
+use tokio_stream::{Iter, StreamExt};
+
+use flume::{bounded, Receiver, Sender};
+
+use rumqttc::{
+    v5::{
+        mqttbytes::{
+            v5::{Filter, Publish, Subscribe},
+            QoS,
+        },
+        AsyncClient, ConnectionError, Event, Incoming, Request,
+    },
+    Outgoing, PollableEventLoop,
+};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn Error>> {
+    pretty_env_logger::init();
+
+    #[rustfmt::skip]
+    let exp_subs = vec![Subscribe::new(
+        Filter::new("hello/world", QoS::AtMostOnce),
+        None,
+    )];
+
+    #[rustfmt::skip]
+    let exp_pubs = vec![
+        Publish::new("hello/world", QoS::ExactlyOnce, vec![1], None),
+        Publish::new("hello/world", QoS::ExactlyOnce, vec![1, 1], None),
+        Publish::new("hello/world", QoS::ExactlyOnce, vec![1, 1, 1], None),
+        Publish::new("hello/world", QoS::ExactlyOnce, vec![1, 1, 1, 1], None),
+        Publish::new("hello/world", QoS::ExactlyOnce, vec![1, 1, 1, 1, 1], None),
+        Publish::new("hello/world", QoS::ExactlyOnce, vec![1, 1, 1, 1, 1, 1], None),
+        Publish::new("hello/world", QoS::ExactlyOnce, vec![1, 1, 1, 1, 1, 1, 1], None),
+        Publish::new("hello/world", QoS::ExactlyOnce, vec![1, 1, 1, 1, 1, 1, 1, 1], None),
+        Publish::new("hello/world", QoS::ExactlyOnce, vec![1, 1, 1, 1, 1, 1, 1, 1, 1], None),
+        Publish::new("hello/world", QoS::ExactlyOnce, vec![1, 1, 1, 1, 1, 1, 1, 1, 1, 1], None),
+    ];
+
+    let (client, mut eventloop) = EventLoopMock::new_async_client_mock(exp_subs, exp_pubs);
+
+    task::spawn(async move {
+        requests(client).await;
+        time::sleep(Duration::from_secs(2)).await;
+    });
+
+    loop {
+        let event = &eventloop.poll().await;
+        match &event {
+            Ok(ev) => {
+                println!("Event = {ev:?}");
+                if let Event::Outgoing(Outgoing::Disconnect) = ev {
+                    break;
+                }
+            }
+            Err(e) => {
+                println!("Error = {e:?}");
+                break;
+            }
+        }
+    }
+
+    eventloop.assert_expectations();
+
+    Ok(())
+}
+
+async fn requests(client: AsyncClient) {
+    client
+        .subscribe("hello/world", QoS::AtMostOnce)
+        .await
+        .unwrap();
+
+    for i in 1..=10 {
+        client
+            .publish("hello/world", QoS::ExactlyOnce, false, vec![1; i])
+            .await
+            .unwrap();
+
+        time::sleep(Duration::from_secs(1)).await;
+    }
+
+    time::sleep(Duration::from_secs(25)).await;
+    _ = client.disconnect().await;
+}
+
+/// Simple non-elaborated example of a mocked EventLoop.
+/// You should use your favourite mocking library for proper mocking
+pub struct EventLoopMock {
+    /// Request stream
+    requests_rx: Receiver<Request>,
+    /// Requests handle to send requests
+    pub(crate) _requests_tx: Sender<Request>,
+    /// saved subscriptions for comparison
+    expected_subs: Vec<Subscribe>,
+    /// saved publications for comparison
+    expected_pubs: Vec<Publish>,
+    /// saved subscriptions for comparison
+    saved_subs: Vec<Subscribe>,
+    /// saved publications for comparison
+    saved_pubs: Vec<Publish>,
+    /// async iterator for simulated incoming events
+    sim_incoming: Iter<IntoIter<Publish>>,
+}
+
+impl EventLoopMock {
+    #[must_use]
+    pub fn new_async_client_mock(
+        expected_subs: Vec<Subscribe>,
+        expected_pubs: Vec<Publish>,
+    ) -> (AsyncClient, EventLoopMock) {
+        let (requests_tx, requests_rx) = bounded(5);
+        let client = AsyncClient::from_senders(requests_tx.clone());
+        let sim_incoming = tokio_stream::iter(expected_pubs.clone());
+        let eventloop = EventLoopMock {
+            requests_rx,
+            _requests_tx: requests_tx,
+            expected_subs,
+            expected_pubs,
+            saved_subs: Vec::new(),
+            saved_pubs: Vec::new(),
+            sim_incoming,
+        };
+        (client, eventloop)
+    }
+
+    /// assert if expectations met
+    pub fn assert_expectations(&self) {
+        // dbg!(&self.expected_subs);
+        // dbg!(&self.saved_subs);
+        assert_eq!(self.expected_subs.iter().eq(self.saved_subs.iter()), true);
+
+        // dbg!(&self.expected_pubs);
+        // dbg!(&self.saved_pubs);
+        assert_eq!(self.expected_pubs.iter().eq(self.saved_pubs.iter()), true);
+
+        println!("assertions passed");
+    }
+}
+
+#[allow(refining_impl_trait)]
+impl PollableEventLoop for EventLoopMock {
+    type Event = rumqttc::v5::Event;
+    type ConnectionError = rumqttc::v5::ConnectionError;
+
+    async fn poll(&mut self) -> Result<Self::Event, Self::ConnectionError> {
+        tokio::select! {
+            out_request = self.requests_rx.recv_async() => {
+                match out_request {
+                    Ok(out_req) => {
+                        match out_req {
+                            Request::Publish(p) => {
+                                println!("pub {p:?}");
+                                self.saved_pubs.push(p);
+                                return Ok(Event::Outgoing(Outgoing::Publish(0))) // return fake event, will be ignored here
+                            },
+                            Request::Subscribe(s) => {
+                                println!("sub {s:?}");
+                                self.saved_subs.push(s);
+                                return Ok(Event::Outgoing(Outgoing::Subscribe(0))) // return fake event, will be ignored here
+                            },
+                            Request::Disconnect => {
+                                println!("disconn");
+                                return Ok(Event::Outgoing(Outgoing::Disconnect)) // shutdown eventloop
+                            }
+                            _ => {
+                                println!("Unknown {out_req:?}");
+                                return Err(ConnectionError::RequestsDone)
+                            }
+                        }
+                    },
+                    Err(_) => {
+                        return Err(ConnectionError::RequestsDone)
+                    }
+                }
+
+            }
+            _ = tokio::time::sleep(Duration::from_millis(1200)) => {
+                // delayed, so it will only trigger when no outgoing event
+                match self.sim_incoming.next().await {
+                    Some(ev) => return Ok(Event::Incoming(Incoming::Publish(ev))),
+                    None => return Err(ConnectionError::RequestsDone),
+                }
+            }
+        }
+    }
+}

--- a/rumqttc/examples/subscription_ids.rs
+++ b/rumqttc/examples/subscription_ids.rs
@@ -1,5 +1,6 @@
 use rumqttc::v5::mqttbytes::v5::SubscribeProperties;
 use rumqttc::v5::mqttbytes::QoS;
+use rumqttc::PollableEventLoop;
 use tokio::{task, time};
 
 use rumqttc::v5::{AsyncClient, MqttOptions};

--- a/rumqttc/examples/tls.rs
+++ b/rumqttc/examples/tls.rs
@@ -1,7 +1,7 @@
 //! Example of how to configure rumqttc to connect to a server using TLS and authentication.
 use std::error::Error;
 
-use rumqttc::{AsyncClient, Event, Incoming, MqttOptions, Transport};
+use rumqttc::{AsyncClient, Event, Incoming, MqttOptions, PollableEventLoop, Transport};
 use tokio_rustls::rustls::ClientConfig;
 
 #[tokio::main(flavor = "current_thread")]

--- a/rumqttc/examples/tls2.rs
+++ b/rumqttc/examples/tls2.rs
@@ -1,7 +1,7 @@
 //! Example of how to configure rumqttd to connect to a server using TLS and authentication.
 use std::error::Error;
 
-use rumqttc::{AsyncClient, MqttOptions, TlsConfiguration, Transport};
+use rumqttc::{AsyncClient, MqttOptions, PollableEventLoop, TlsConfiguration, Transport};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn Error>> {

--- a/rumqttc/examples/topic_alias.rs
+++ b/rumqttc/examples/topic_alias.rs
@@ -2,6 +2,7 @@ use rumqttc::v5::mqttbytes::{v5::PublishProperties, QoS};
 use tokio::{task, time};
 
 use rumqttc::v5::{AsyncClient, MqttOptions};
+use rumqttc::PollableEventLoop;
 use std::error::Error;
 use std::time::Duration;
 

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -3,6 +3,7 @@
 use std::time::Duration;
 
 use crate::mqttbytes::{v4::*, QoS};
+use crate::PollableEventLoop;
 use crate::{valid_filter, valid_topic, ConnectionError, Event, EventLoop, MqttOptions, Request};
 
 use bytes::Bytes;

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -917,6 +917,15 @@ impl Debug for MqttOptions {
     }
 }
 
+pub trait PollableEventLoop {
+    type Event;
+    type ConnectionError;
+
+    fn poll(
+        &mut self,
+    ) -> impl std::future::Future<Output = Result<Self::Event, Self::ConnectionError>> + Send;
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -33,7 +33,7 @@
 //! ------------------------------
 //!
 //! ```no_run
-//! use rumqttc::{MqttOptions, AsyncClient, QoS};
+//! use rumqttc::{MqttOptions, AsyncClient, QoS, PollableEventLoop};
 //! use tokio::{task, time};
 //! use std::time::Duration;
 //! use std::error::Error;

--- a/rumqttc/src/v5/client.rs
+++ b/rumqttc/src/v5/client.rs
@@ -8,7 +8,7 @@ use super::mqttbytes::v5::{
 };
 use super::mqttbytes::QoS;
 use super::{ConnectionError, Event, EventLoop, MqttOptions, Request};
-use crate::{valid_filter, valid_topic};
+use crate::{valid_filter, valid_topic, PollableEventLoop};
 
 use bytes::Bytes;
 use flume::{SendError, Sender, TrySendError};

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -3,6 +3,7 @@ use super::mqttbytes::v5::*;
 use super::{Incoming, MqttOptions, MqttState, Outgoing, Request, StateError, Transport};
 use crate::eventloop::socket_connect;
 use crate::framed::AsyncReadWrite;
+use crate::PollableEventLoop;
 
 use flume::{bounded, Receiver, Sender};
 use tokio::select;
@@ -138,42 +139,6 @@ impl EventLoop {
         self.pending.extend(requests_in_channel);
     }
 
-    /// Yields Next notification or outgoing request and periodically pings
-    /// the broker. Continuing to poll will reconnect to the broker if there is
-    /// a disconnection.
-    /// **NOTE** Don't block this while iterating
-    pub async fn poll(&mut self) -> Result<Event, ConnectionError> {
-        if self.network.is_none() {
-            let (network, connack) = time::timeout(
-                Duration::from_secs(self.options.connection_timeout()),
-                connect(&mut self.options),
-            )
-            .await??;
-            // Last session might contain packets which aren't acked. If it's a new session, clear the pending packets.
-            if !connack.session_present {
-                self.pending.clear();
-            }
-            self.network = Some(network);
-
-            if self.keepalive_timeout.is_none() {
-                self.keepalive_timeout = Some(Box::pin(time::sleep(self.options.keep_alive)));
-            }
-
-            self.state
-                .handle_incoming_packet(Incoming::ConnAck(connack))?;
-        }
-
-        match self.select().await {
-            Ok(v) => Ok(v),
-            Err(e) => {
-                // MQTT requires that packets pending acknowledgement should be republished on session resume.
-                // Move pending messages from state to eventloop.
-                self.clean();
-                Err(e)
-            }
-        }
-    }
-
     /// Select on network and requests and generate keepalive pings when necessary
     async fn select(&mut self) -> Result<Event, ConnectionError> {
         let network = self.network.as_mut().unwrap();
@@ -268,6 +233,48 @@ impl EventLoop {
             match rx.recv_async().await {
                 Ok(r) => Ok(r),
                 Err(_) => Err(ConnectionError::RequestsDone),
+            }
+        }
+    }
+}
+
+#[allow(refining_impl_trait)]
+impl PollableEventLoop for EventLoop {
+    type Event = Event;
+    type ConnectionError = ConnectionError;
+
+    /// Yields Next notification or outgoing request and periodically pings
+    /// the broker. Continuing to poll will reconnect to the broker if there is
+    /// a disconnection.
+    /// **NOTE** Don't block this while iterating
+    async fn poll(&mut self) -> Result<Event, ConnectionError> {
+        if self.network.is_none() {
+            let (network, connack) = time::timeout(
+                Duration::from_secs(self.options.connection_timeout()),
+                connect(&mut self.options),
+            )
+            .await??;
+            // Last session might contain packets which aren't acked. If it's a new session, clear the pending packets.
+            if !connack.session_present {
+                self.pending.clear();
+            }
+            self.network = Some(network);
+
+            if self.keepalive_timeout.is_none() {
+                self.keepalive_timeout = Some(Box::pin(time::sleep(self.options.keep_alive)));
+            }
+
+            self.state
+                .handle_incoming_packet(Incoming::ConnAck(connack))?;
+        }
+
+        match self.select().await {
+            Ok(v) => Ok(v),
+            Err(e) => {
+                // MQTT requires that packets pending acknowledgement should be republished on session resume.
+                // Move pending messages from state to eventloop.
+                self.clean();
+                Err(e)
             }
         }
     }


### PR DESCRIPTION
I have the need to mock the interface to the rumqttc client for testing/benching purposes. 

There was no evident way I could achieve this other than introducing a new trait `PollableEventLoop` defining the poll interface on the `EventLoop`.

Now it is possible to reuse the `AsyncClient` and mock the `EventLoop`.

I have also added a mocked version of the `asyncpubsub` example.

This change will make it mandatory to `use rumqttc::PollableEventLoop`, that is why I mark this as a breaking change.

<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
<!-- - New feature (non-breaking change which adds functionality) -->
Breaking change (fix or feature that would cause existing functionality to not work as expected)
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
