### PR TITLE
docs: Update rustls docs, add crate feature docs

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Filter PUBACK in pending save requests to fix unexpected PUBACK sent to reconnected broker.
 * Resume session only if broker sends `CONNACK` with `session_present == 1`.
 * Remove v5 PubAck/PubRec/PubRel/PubComp/Sub/Unsub failures from `StateError` and log warnings on these failures.
+* Update crate documentation with feature flags and updated rustls docs.
 
 ### Security
 

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -85,14 +85,22 @@
 //! - Blocking inside the `connection.iter()`/`eventloop.poll()` loop will block
 //!   connection progress.
 //!
-//! ## FAQ
-//! **Connecting to a broker using raw ip doesn't work**
+//! ## Feature Flags
 //!
-//! You cannot create a TLS connection to a bare IP address with a self-signed
-//! certificate. This is a [limitation of rustls](https://github.com/ctz/rustls/issues/184).
-//! One workaround, which only works under *nix/BSD-like systems, is to add an
-//! entry to wherever your DNS resolver looks (e.g. `/etc/hosts`) for the bare IP
-//! address and use that name in your code.
+//! This crate offers a few feature flags to configure additional functionality.
+//!
+//! * `proxy`: Enables support for connecting via a HTTP Connect proxy using the
+//!   [`async-http-proxy`] crate.
+//! * `websocket`: Enables support for MQTT via WebSocket.
+//!
+//! To enable TLS support, one of these two options may be used:
+//!
+//! * `use-native-tls`: Enables TLS support using the [`native_tls`] library.
+//! * `use-rustls`: Enables TLS support using the [`rustls`] TLS library.
+//!
+//! [`async-http-proxy`]: https://docs.rs/async-http-proxy/
+//! [`native_tls`]: https://docs.rs/native-tls/
+//! [`rustls`]: https://docs.rs/rustls/
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[macro_use]


### PR DESCRIPTION
* Removes outdated documentation regarding rustls connection to IP addresses (this is now possible with Subject Alt Names `IP:xxx.xxx.xxx.xxx`).
* Adds some documentation about crate features to help with feature discovery for new users.

Signed off: decryphe

Thanks for the great library!

<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
- Miscellaneous (related to maintenance)

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
