### PR TITLE
`Eq, PartialEq` derive trait on `ClientError`

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* `Eq` and `PartialEq` derive implementation on `ClientError`.
 * `size()` method on `Packet` calculates size once serialized.
 * `read()` and `write()` methods on `Packet`.
 * `ConnectionAborted` variant on `StateError` type to denote abrupt end to a connection

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -12,7 +12,7 @@ use tokio::runtime::{self, Runtime};
 use tokio::time::timeout;
 
 /// Client Error
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
 pub enum ClientError {
     #[error("Failed to send mqtt requests to eventloop")]
     Request(Request),


### PR DESCRIPTION
<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Miscellaneous (related to maintenance)

`ClientError` enum used to store flume error which didn't (at the time) implement equality trait.
This was fixed in #420, and the enum now always store a `Request`, which itself implement the trait.
There used to be a feature request at #340 to also add equality comparison to `ConnectionError`, but it internally store a `std::io::Error` which doesn't implement the traits.

Equality comparison helps for testing code for downstream.

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
