### PR TITLE
docs: fix spelling for EventLoop

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -38,7 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Filter PUBACK in pending save requests to fix unexpected PUBACK sent to reconnected broker.
 * Resume session only if broker sends `CONNACK` with `session_present == 1`.
 * Remove v5 PubAck/PubRec/PubRel/PubComp/Sub/Unsub failures from `StateError` and log warnings on these failures.
-* Wrong spelling of `EventLoop` in docs.
 
 ### Security
 

--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Filter PUBACK in pending save requests to fix unexpected PUBACK sent to reconnected broker.
 * Resume session only if broker sends `CONNACK` with `session_present == 1`.
 * Remove v5 PubAck/PubRec/PubRel/PubComp/Sub/Unsub failures from `StateError` and log warnings on these failures.
+* Wrong spelling of `EventLoop` in docs.
 
 ### Security
 

--- a/rumqttc/src/client.rs
+++ b/rumqttc/src/client.rs
@@ -450,10 +450,10 @@ impl Connection {
         Iter { connection: self }
     }
 
-    /// Attempt to fetch an incoming [`Event`] on the [`EvenLoop`], returning an error
+    /// Attempt to fetch an incoming [`Event`] on the [`EventLoop`], returning an error
     /// if all clients/users have closed requests channel.
     ///
-    /// [`EvenLoop`]: super::EventLoop
+    /// [`EventLoop`]: super::EventLoop
     pub fn recv(&mut self) -> Result<Result<Event, ConnectionError>, RecvError> {
         let f = self.eventloop.poll();
         let event = self.runtime.block_on(f);
@@ -461,10 +461,10 @@ impl Connection {
         resolve_event(event).ok_or(RecvError)
     }
 
-    /// Attempt to fetch an incoming [`Event`] on the [`EvenLoop`], returning an error
+    /// Attempt to fetch an incoming [`Event`] on the [`EventLoop`], returning an error
     /// if none immediately present or all clients/users have closed requests channel.
     ///
-    /// [`EvenLoop`]: super::EventLoop
+    /// [`EventLoop`]: super::EventLoop
     pub fn try_recv(&mut self) -> Result<Result<Event, ConnectionError>, TryRecvError> {
         let f = self.eventloop.poll();
         // Enters the runtime context so we can poll the future, as required by `now_or_never()`.
@@ -475,10 +475,10 @@ impl Connection {
         resolve_event(event).ok_or(TryRecvError::Disconnected)
     }
 
-    /// Attempt to fetch an incoming [`Event`] on the [`EvenLoop`], returning an error
+    /// Attempt to fetch an incoming [`Event`] on the [`EventLoop`], returning an error
     /// if all clients/users have closed requests channel or the timeout has expired.
     ///
-    /// [`EvenLoop`]: super::EventLoop
+    /// [`EventLoop`]: super::EventLoop
     pub fn recv_timeout(
         &mut self,
         duration: Duration,

--- a/rumqttc/src/v5/client.rs
+++ b/rumqttc/src/v5/client.rs
@@ -798,10 +798,10 @@ impl Connection {
         Iter { connection: self }
     }
 
-    /// Attempt to fetch an incoming [`Event`] on the [`EvenLoop`], returning an error
+    /// Attempt to fetch an incoming [`Event`] on the [`EventLoop`], returning an error
     /// if all clients/users have closed requests channel.
     ///
-    /// [`EvenLoop`]: super::EventLoop
+    /// [`EventLoop`]: super::EventLoop
     pub fn recv(&mut self) -> Result<Result<Event, ConnectionError>, RecvError> {
         let f = self.eventloop.poll();
         let event = self.runtime.block_on(f);
@@ -809,10 +809,10 @@ impl Connection {
         resolve_event(event).ok_or(RecvError)
     }
 
-    /// Attempt to fetch an incoming [`Event`] on the [`EvenLoop`], returning an error
+    /// Attempt to fetch an incoming [`Event`] on the [`EventLoop`], returning an error
     /// if none immediately present or all clients/users have closed requests channel.
     ///
-    /// [`EvenLoop`]: super::EventLoop
+    /// [`EventLoop`]: super::EventLoop
     pub fn try_recv(&mut self) -> Result<Result<Event, ConnectionError>, TryRecvError> {
         let f = self.eventloop.poll();
         // Enters the runtime context so we can poll the future, as required by `now_or_never()`.
@@ -823,10 +823,10 @@ impl Connection {
         resolve_event(event).ok_or(TryRecvError::Disconnected)
     }
 
-    /// Attempt to fetch an incoming [`Event`] on the [`EvenLoop`], returning an error
+    /// Attempt to fetch an incoming [`Event`] on the [`EventLoop`], returning an error
     /// if all clients/users have closed requests channel or the timeout has expired.
     ///
-    /// [`EvenLoop`]: super::EventLoop
+    /// [`EventLoop`]: super::EventLoop
     pub fn recv_timeout(
         &mut self,
         duration: Duration,


### PR DESCRIPTION
## Type of change
- Miscellaneous (related to maintenance): docs spelling fix

In [this](https://docs.rs/rumqttc/0.24.0/rumqttc/struct.Connection.html) example, `EventLoop` is spelled wrongly as `EvenLoop`.

## Checklist:

- [ ] Formatted with `cargo fmt`
Note: I have not ran this, as doing so would also change other lines which I have not altered, should I do so?
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
Note: Have done so, but not sure if it is appropiate.