### PR TITLE
feat(rumqttc): Do concurrent network connections (#939)

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `set_session_expiry_interval` and `session_expiry_interval` methods on `MqttOptions`.
 * `Auth` packet as per MQTT5 standards
 * Allow configuring  the `nodelay` property of underlying TCP client with the `tcp_nodelay` field in `NetworkOptions`
+* Concurrently attempt multiple socket connections instead of blocking on each
 
 ### Changed
 


### PR DESCRIPTION
In case of routing issues, the individual socket connections will take ~4.5 minutes depending on OS level socket syn retransmit settings, which means that if there is a connection timeout that is shorter than that, connection will never be established even if other IP's resolve and route properly.

This implements concurrent connection attempts with a staggerd delay between attempts. I have chosen not to implement a full version of RFC8305 (Happy Eyeballs) here, as that is a much more invasive change.


Issue: https://github.com/bytebeamio/rumqtt/issues/939

<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change
 Bug fix

## Checklist:

- [x ] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
