### PR TITLE
fix: token interfaces

### DIFF
--- a/rumqttc/examples/ack_promise.rs
+++ b/rumqttc/examples/ack_promise.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .unwrap()
         .await
     {
-        Ok(pkid) => println!("Acknowledged Sub({pkid})"),
+        Ok(pkid) => println!("Acknowledged Sub({pkid:?})"),
         Err(e) => println!("Subscription failed: {e:?}"),
     }
 
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .unwrap()
             .await
         {
-            Ok(pkid) => println!("Acknowledged Pub({pkid})"),
+            Ok(ack) => println!("Acknowledged Pub({ack:?})"),
             Err(e) => println!("Publish failed: {e:?}"),
         }
     }
@@ -66,14 +66,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     while let Some(Ok(res)) = set.join_next().await {
         match res {
-            Ok(pkid) => println!("Acknowledged Pub({pkid})"),
+            Ok(ack) => println!("Acknowledged Pub({ack:?})"),
             Err(e) => println!("Publish failed: {e:?}"),
         }
     }
 
     // Unsubscribe and wait for broker acknowledgement
     match client.unsubscribe("hello/world").await.unwrap().await {
-        Ok(pkid) => println!("Acknowledged Unsub({pkid})"),
+        Ok(ack) => println!("Acknowledged Unsub({ack:?})"),
         Err(e) => println!("Unsubscription failed: {e:?}"),
     }
 

--- a/rumqttc/examples/ack_promise_sync.rs
+++ b/rumqttc/examples/ack_promise_sync.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .unwrap()
         .wait()
     {
-        Ok(pkid) => println!("Acknowledged Sub({pkid})"),
+        Ok(pkid) => println!("Acknowledged Sub({pkid:?})"),
         Err(e) => println!("Subscription failed: {e:?}"),
     }
 
@@ -42,7 +42,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .unwrap()
             .wait()
         {
-            Ok(pkid) => println!("Acknowledged Pub({pkid})"),
+            Ok(ack) => println!("Acknowledged Pub({ack:?})"),
             Err(e) => println!("Publish failed: {e:?}"),
         }
     }
@@ -83,14 +83,14 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     while let Ok(res) = rx.recv() {
         match res {
-            Ok(pkid) => println!("Acknowledged Pub({pkid})"),
+            Ok(ack) => println!("Acknowledged Pub({ack:?})"),
             Err(e) => println!("Publish failed: {e:?}"),
         }
     }
 
     // Unsubscribe and wait for broker acknowledgement
     match client.unsubscribe("hello/world").unwrap().wait() {
-        Ok(pkid) => println!("Acknowledged Unsub({pkid})"),
+        Ok(ack) => println!("Acknowledged Unsub({ack:?})"),
         Err(e) => println!("Unsubscription failed: {e:?}"),
     }
 

--- a/rumqttc/examples/ack_promise_v5.rs
+++ b/rumqttc/examples/ack_promise_v5.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .unwrap()
         .await
     {
-        Ok(pkid) => println!("Acknowledged Sub({pkid})"),
+        Ok(pkid) => println!("Acknowledged Sub({pkid:?})"),
         Err(e) => println!("Subscription failed: {e:?}"),
     }
 
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .unwrap()
             .await
         {
-            Ok(pkid) => println!("Acknowledged Pub({pkid})"),
+            Ok(pkid) => println!("Acknowledged Pub({pkid:?})"),
             Err(e) => println!("Publish failed: {e:?}"),
         }
     }
@@ -66,14 +66,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     while let Some(Ok(res)) = set.join_next().await {
         match res {
-            Ok(pkid) => println!("Acknowledged Pub({pkid})"),
+            Ok(pkid) => println!("Acknowledged Pub({pkid:?})"),
             Err(e) => println!("Publish failed: {e:?}"),
         }
     }
 
     // Unsubscribe and wait for broker acknowledgement
     match client.unsubscribe("hello/world").await.unwrap().await {
-        Ok(pkid) => println!("Acknowledged Unsub({pkid})"),
+        Ok(pkid) => println!("Acknowledged Unsub({pkid:?})"),
         Err(e) => println!("Unsubscription failed: {e:?}"),
     }
 

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -160,6 +160,21 @@ pub use proxy::{Proxy, ProxyAuth, ProxyType};
 
 pub type Incoming = Packet;
 
+/// Used to encapsulate all publish/pubrec acknowledgements in v4
+#[derive(Debug, PartialEq)]
+pub enum AckOfPub {
+    PubAck(PubAck),
+    PubComp(PubComp),
+    None,
+}
+
+/// Used to encapsulate all ack/pubrel acknowledgements in v4
+#[derive(Debug)]
+pub enum AckOfAck {
+    None,
+    PubRel(PubRel),
+}
+
 /// Current outgoing activity on the eventloop
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Outgoing {
@@ -191,12 +206,12 @@ pub enum Outgoing {
 /// handled one by one.
 #[derive(Debug)]
 pub enum Request {
-    Publish(Publish, Resolver<Pkid>),
-    PubAck(PubAck, Resolver<()>),
-    PubRec(PubRec, Resolver<()>),
-    PubRel(PubRel, Resolver<Pkid>),
-    Subscribe(Subscribe, Resolver<Pkid>),
-    Unsubscribe(Unsubscribe, Resolver<Pkid>),
+    Publish(Publish, Resolver<AckOfPub>),
+    PubAck(PubAck, Resolver<AckOfAck>),
+    PubRec(PubRec, Resolver<AckOfAck>),
+    PubRel(PubRel, Resolver<AckOfPub>),
+    Subscribe(Subscribe, Resolver<SubAck>),
+    Unsubscribe(Unsubscribe, Resolver<UnsubAck>),
     Disconnect(Resolver<()>),
     PingReq,
 }

--- a/rumqttc/src/v5/mod.rs
+++ b/rumqttc/src/v5/mod.rs
@@ -15,8 +15,7 @@ pub mod mqttbytes;
 mod state;
 
 use crate::tokens::Resolver;
-use crate::{NetworkOptions, Transport};
-use crate::{Outgoing, Pkid};
+use crate::{NetworkOptions, Outgoing, Transport};
 
 use mqttbytes::v5::*;
 
@@ -32,16 +31,31 @@ pub use crate::proxy::{Proxy, ProxyAuth, ProxyType};
 
 pub type Incoming = Packet;
 
+/// Used to encapsulate all publish acknowledgents in v5
+#[derive(Debug)]
+pub enum AckOfPub {
+    PubAck(PubAck),
+    PubComp(PubComp),
+    None,
+}
+
+/// Used to encapsulate all ack/pubrel acknowledgements in v5
+#[derive(Debug)]
+pub enum AckOfAck {
+    None,
+    PubRel(PubRel),
+}
+
 /// Requests by the client to mqtt event loop. Request are
 /// handled one by one.
 #[derive(Debug)]
 pub enum Request {
-    Publish(Publish, Resolver<Pkid>),
-    PubAck(PubAck, Resolver<()>),
-    PubRec(PubRec, Resolver<()>),
-    PubRel(PubRel, Resolver<Pkid>),
-    Subscribe(Subscribe, Resolver<Pkid>),
-    Unsubscribe(Unsubscribe, Resolver<Pkid>),
+    Publish(Publish, Resolver<AckOfPub>),
+    PubAck(PubAck, Resolver<AckOfAck>),
+    PubRec(PubRec, Resolver<AckOfAck>),
+    PubRel(PubRel, Resolver<AckOfPub>),
+    Subscribe(Subscribe, Resolver<SubAck>),
+    Unsubscribe(Unsubscribe, Resolver<UnsubAck>),
     Disconnect(Resolver<()>),
     PingReq,
 }

--- a/rumqttc/tests/reliability.rs
+++ b/rumqttc/tests/reliability.rs
@@ -622,7 +622,7 @@ async fn resolve_on_qos0_before_write_to_tcp_buffer() {
             .await
             .unwrap()
             .unwrap(),
-        0
+        AckOfPub::None
     );
 
     // Verify the packet still reached broker
@@ -704,7 +704,7 @@ async fn resolve_on_qos1_ack_from_broker() {
             .await
             .unwrap()
             .unwrap(),
-        1
+        AckOfPub::PubAck(PubAck { pkid: 1 })
     );
 }
 
@@ -777,7 +777,7 @@ async fn resolve_on_qos2_ack_from_broker() {
             .await
             .unwrap()
             .unwrap(),
-        1
+        AckOfPub::PubComp(PubComp { pkid: 1 })
     );
 }
 
@@ -839,7 +839,8 @@ async fn resolve_on_sub_ack_from_broker() {
         timeout(Duration::from_secs(1), &mut token)
             .await
             .unwrap()
-            .unwrap(),
+            .unwrap()
+            .pkid,
         1
     );
 }
@@ -894,6 +895,6 @@ async fn resolve_on_unsub_ack_from_broker() {
             .await
             .unwrap()
             .unwrap(),
-        1
+        UnsubAck { pkid: 1 }
     );
 }


### PR DESCRIPTION
1. Tokens should resolve with acknowledgement packets, in an expected manner.
2. Manual acknowledgement request tokens should resolve on associated completion states
3. enums `AckOfPub` and `AckOfAck`

<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->


Based on suggestions from @cratertinney https://github.com/bytebeamio/rumqtt/pull/916#issuecomment-2672703936
## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [ ] Formatted with `cargo fmt`
- [ ] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
