### PR TITLE
fix: set default network timeout as `Duration::MAX` instead of zero.

### DIFF
--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - MQTT keep alive interval
+- Change MQTT keep alive interval from `Duration::ZERO` to `Duration::MAX`.
 - record client id for remote link's span
 - session present flag in connack
 - Make write method return the number of bytes written correctly everywhere

--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - MQTT keep alive interval
-- Change MQTT keep alive interval from `Duration::ZERO` to `Duration::MAX`.
+- Change default network keep alive interval from `Duration::ZERO` to `Duration::MAX`.
 - record client id for remote link's span
 - session present flag in connack
 - Make write method return the number of bytes written correctly everywhere

--- a/rumqttd/src/link/network.rs
+++ b/rumqttd/src/link/network.rs
@@ -55,7 +55,7 @@ impl<P: Protocol> Network<P> {
             write: BytesMut::with_capacity(10 * 1024),
             max_incoming_size,
             max_connection_buffer_len,
-            keepalive: Duration::ZERO,
+            keepalive: Duration::MAX,
             protocol,
         }
     }

--- a/rumqttd/src/link/network.rs
+++ b/rumqttd/src/link/network.rs
@@ -55,6 +55,9 @@ impl<P: Protocol> Network<P> {
             write: BytesMut::with_capacity(10 * 1024),
             max_incoming_size,
             max_connection_buffer_len,
+            // Overwritten by keepalive value in connect packet, otherwise we
+            // would wait indefinitely until we get a packet / network error
+            // when we call read.
             keepalive: Duration::MAX,
             protocol,
         }


### PR DESCRIPTION
## Type of change

Bug fix (non-breaking change which fixes an issue) 

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.


Closes https://github.com/bytebeamio/rumqtt/issues/945.
Closes https://github.com/bytebeamio/rumqtt/issues/948.
