### PR TITLE
feat(rumqttc): add MqttOptions::set_client_id method

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `set_session_expiry_interval` and `session_expiry_interval` methods on `MqttOptions`.
 * `Auth` packet as per MQTT5 standards
 * Allow configuring  the `nodelay` property of underlying TCP client with the `tcp_nodelay` field in `NetworkOptions`
+* `set_client_id` method on `MqttOptions`
 
 ### Changed
 

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -563,6 +563,11 @@ impl MqttOptions {
         self.last_will.clone()
     }
 
+    pub fn set_client_id(&mut self, client_id: String) -> &mut Self {
+        self.client_id = client_id;
+        self
+    }
+
     pub fn set_transport(&mut self, transport: Transport) -> &mut Self {
         self.transport = transport;
         self

--- a/rumqttc/src/v5/mod.rs
+++ b/rumqttc/src/v5/mod.rs
@@ -215,6 +215,11 @@ impl MqttOptions {
         self.request_modifier.clone()
     }
 
+    pub fn set_client_id(&mut self, client_id: String) -> &mut Self {
+        self.client_id = client_id;
+        self
+    }
+
     pub fn set_transport(&mut self, transport: Transport) -> &mut Self {
         self.transport = transport;
         self


### PR DESCRIPTION
Other fields have respective setters, client_id has not, and I find it useful.

## Type of change

New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
       It's just a field setter function....
