### PR TITLE
feat(rumqttd): Make Server public

### DIFF
--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Public re-export `Strategy` for shared subscriptions
+- Public export `Server` and `LinkType` so Server can be spawned on custom (or global) tokio runtime
 - Peer initiated disconnects logged as info rather than error.
 - External authentication function must be async
 - Update `tokio-rustls` to `0.25.0`, `rustls-webpki` to `0.102.1`, `tokio-native-tls` to `0.3.1` and

--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -21,9 +21,9 @@ use tracing_subscriber::{
 pub use link::alerts;
 pub use link::local;
 pub use link::meters;
-pub use router::{Alert, Forward, IncomingMeter, Meter, Notification, OutgoingMeter};
+pub use router::{Alert, Forward, IncomingMeter, Meter, Notification, OutgoingMeter, Router};
 use segments::Storage;
-pub use server::Broker;
+pub use server::{Broker, LinkType, Server};
 
 pub use self::router::shared_subs::Strategy;
 

--- a/rumqttd/src/server/broker.rs
+++ b/rumqttd/src/server/broker.rs
@@ -344,7 +344,7 @@ enum AwaitingWill {
     Fire,
 }
 
-struct Server<P> {
+pub struct Server<P> {
     config: ServerSettings,
     router_tx: Sender<(ConnectionId, Event)>,
     protocol: P,
@@ -379,7 +379,7 @@ impl<P: Protocol + Clone + Send + 'static> Server<P> {
         Ok((Box::new(stream), None))
     }
 
-    async fn start(&mut self, link_type: LinkType) -> Result<(), Error> {
+    pub async fn start(&mut self, link_type: LinkType) -> Result<(), Error> {
         let listener = TcpListener::bind(&self.config.listen).await?;
         let delay = Duration::from_millis(self.config.next_connection_delay_ms);
         let mut count: usize = 0;

--- a/rumqttd/src/server/mod.rs
+++ b/rumqttd/src/server/mod.rs
@@ -4,7 +4,7 @@ mod broker;
 #[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]
 mod tls;
 
-pub use broker::Broker;
+pub use broker::{Broker, LinkType, Server};
 
 // pub trait IO: AsyncRead + AsyncWrite + Send + Sync + Unpin {}
 // impl<T: AsyncRead + AsyncWrite + Send + Sync + Unpin> IO for T {}


### PR DESCRIPTION
<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

Publicly export `Server`, `Router` and `LinkType`.

I don't really see a problem with making these types `pub`, the constructor for `Server` is pub already but not accessible from outside the crate afaik.

As-is, calling `Broker::start` and thus spawning a new runtime for each config panics inside already async contexts. With this PR new Servers can just be spawned with `tokio::spawn` or `my_runtime::spawn` instead.

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
New feature

<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
