### PR TITLE
fix: adjust logging

### DIFF
--- a/rumqttd/src/router/routing.rs
+++ b/rumqttd/src/router/routing.rs
@@ -232,7 +232,7 @@ impl Router {
     }
 
     fn events(&mut self, id: ConnectionId, data: Event) {
-        let span = tracing::error_span!("[>] incoming", connection_id = id);
+        let span = tracing::info_span!("[>] incoming", connection_id = id);
         let _guard = span.enter();
 
         match data {
@@ -542,7 +542,7 @@ impl Router {
         };
 
         let client_id = incoming.client_id.clone();
-        let span = tracing::error_span!("incoming_payload", client_id);
+        let span = tracing::info_span!("incoming_payload", client_id);
         let _guard = span.enter();
 
         // Instead of exchanging, we should just append new incoming packets inside cache
@@ -558,7 +558,7 @@ impl Router {
         for packet in packets.drain(0..) {
             match packet {
                 Packet::Publish(publish, properties) => {
-                    let span = tracing::error_span!("publish", topic = ?publish.topic, pkid = publish.pkid);
+                    let span = tracing::info_span!("publish", topic = ?publish.topic, pkid = publish.pkid);
                     let _guard = span.enter();
 
                     let qos = publish.qos;

--- a/rumqttd/src/server/broker.rs
+++ b/rumqttd/src/server/broker.rs
@@ -452,7 +452,7 @@ impl<P: Protocol + Clone + Send + 'static> Server<P> {
                         protocol,
                         self.awaiting_will_handler.clone(),
                     )
-                    .instrument(tracing::error_span!(
+                    .instrument(tracing::info_span!(
                         "remote_link",
                         ?tenant_id,
                         client_id = field::Empty,


### PR DESCRIPTION
Change error_span instances to info_span

Don't seem like instances should be error level and they spam the logs.

## Adjust logging

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
