### PR TITLE
feat(rumqttc): add use-rustls-no-provider feature

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+* `use-rustls-no-provider` feature flag to allow choosing crypto backend without being forced to compile `aws_lc_rs`
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -17,7 +17,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["use-rustls"]
-use-rustls = ["dep:tokio-rustls", "dep:rustls-webpki", "dep:rustls-pemfile", "dep:rustls-native-certs"]
+use-rustls = ["use-rustls-no-provider", "tokio-rustls/default"]
+use-rustls-no-provider = ["dep:tokio-rustls", "dep:rustls-webpki", "dep:rustls-pemfile", "dep:rustls-native-certs"]
 use-native-tls = ["dep:tokio-native-tls", "dep:native-tls"]
 websocket = ["dep:async-tungstenite", "dep:ws_stream_tungstenite", "dep:http"]
 proxy = ["dep:async-http-proxy"]
@@ -33,7 +34,7 @@ thiserror = "2.0.8"
 
 # Optional
 # rustls
-tokio-rustls = { version = "0.26.0", optional = true }
+tokio-rustls = { version = "0.26.0", optional = true, default-features = false }
 rustls-webpki = { version = "0.102.8", optional = true }
 rustls-pemfile = { version = "2.2.0", optional = true }
 rustls-native-certs = { version = "0.8.1", optional = true }

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 #[cfg(unix)]
 use {std::path::Path, tokio::net::UnixStream};
 
-#[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]
+#[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]
 use crate::tls;
 
 #[cfg(feature = "websocket")]
@@ -46,7 +46,7 @@ pub enum ConnectionError {
     #[cfg(feature = "websocket")]
     #[error("Websocket Connect: {0}")]
     WsConnect(#[from] http::Error),
-    #[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]
+    #[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]
     #[error("TLS: {0}")]
     Tls(#[from] tls::Error),
     #[error("I/O: {0}")]
@@ -387,7 +387,7 @@ async fn network_connect(
     let (domain, port) = match options.transport() {
         #[cfg(feature = "websocket")]
         Transport::Ws => split_url(&options.broker_addr)?,
-        #[cfg(all(feature = "use-rustls", feature = "websocket"))]
+        #[cfg(all(feature = "use-rustls-no-provider", feature = "websocket"))]
         Transport::Wss(_) => split_url(&options.broker_addr)?,
         _ => options.broker_address(),
     };
@@ -416,7 +416,7 @@ async fn network_connect(
             options.max_incoming_packet_size,
             options.max_outgoing_packet_size,
         ),
-        #[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]
+        #[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]
         Transport::Tls(tls_config) => {
             let socket =
                 tls::tls_connect(&options.broker_addr, options.port, &tls_config, tcp_stream)
@@ -450,7 +450,7 @@ async fn network_connect(
                 options.max_outgoing_packet_size,
             )
         }
-        #[cfg(all(feature = "use-rustls", feature = "websocket"))]
+        #[cfg(all(feature = "use-rustls-no-provider", feature = "websocket"))]
         Transport::Wss(tls_config) => {
             let mut request = options.broker_addr.as_str().into_client_request()?;
             request

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -100,7 +100,7 @@ extern crate log;
 
 use std::fmt::{self, Debug, Formatter};
 
-#[cfg(any(feature = "use-rustls", feature = "websocket"))]
+#[cfg(any(feature = "use-rustls-no-provider", feature = "websocket"))]
 use std::sync::Arc;
 
 use std::time::Duration;
@@ -112,7 +112,7 @@ pub mod mqttbytes;
 mod state;
 pub mod v5;
 
-#[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]
+#[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]
 mod tls;
 
 #[cfg(feature = "websocket")]
@@ -140,18 +140,18 @@ pub use client::{
 pub use eventloop::{ConnectionError, Event, EventLoop};
 pub use mqttbytes::v4::*;
 pub use mqttbytes::*;
-#[cfg(feature = "use-rustls")]
+#[cfg(feature = "use-rustls-no-provider")]
 use rustls_native_certs::load_native_certs;
 pub use state::{MqttState, StateError};
-#[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]
+#[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]
 pub use tls::Error as TlsError;
 #[cfg(feature = "use-native-tls")]
 pub use tokio_native_tls;
 #[cfg(feature = "use-native-tls")]
 use tokio_native_tls::native_tls::TlsConnector;
-#[cfg(feature = "use-rustls")]
+#[cfg(feature = "use-rustls-no-provider")]
 pub use tokio_rustls;
-#[cfg(feature = "use-rustls")]
+#[cfg(feature = "use-rustls-no-provider")]
 use tokio_rustls::rustls::{ClientConfig, RootCertStore};
 
 #[cfg(feature = "proxy")]
@@ -226,15 +226,18 @@ impl From<Unsubscribe> for Request {
 #[derive(Clone)]
 pub enum Transport {
     Tcp,
-    #[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]
+    #[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]
     Tls(TlsConfiguration),
     #[cfg(unix)]
     Unix,
     #[cfg(feature = "websocket")]
     #[cfg_attr(docsrs, doc(cfg(feature = "websocket")))]
     Ws,
-    #[cfg(all(feature = "use-rustls", feature = "websocket"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "use-rustls", feature = "websocket"))))]
+    #[cfg(all(feature = "use-rustls-no-provider", feature = "websocket"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "use-rustls-no-provider", feature = "websocket")))
+    )]
     Wss(TlsConfiguration),
 }
 
@@ -250,13 +253,13 @@ impl Transport {
         Self::Tcp
     }
 
-    #[cfg(feature = "use-rustls")]
+    #[cfg(feature = "use-rustls-no-provider")]
     pub fn tls_with_default_config() -> Self {
         Self::tls_with_config(Default::default())
     }
 
     /// Use secure tcp with tls as transport
-    #[cfg(feature = "use-rustls")]
+    #[cfg(feature = "use-rustls-no-provider")]
     pub fn tls(
         ca: Vec<u8>,
         client_auth: Option<(Vec<u8>, Vec<u8>)>,
@@ -271,7 +274,7 @@ impl Transport {
         Self::tls_with_config(config)
     }
 
-    #[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]
+    #[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]
     pub fn tls_with_config(tls_config: TlsConfiguration) -> Self {
         Self::Tls(tls_config)
     }
@@ -289,8 +292,11 @@ impl Transport {
     }
 
     /// Use secure websockets with tls as transport
-    #[cfg(all(feature = "use-rustls", feature = "websocket"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "use-rustls", feature = "websocket"))))]
+    #[cfg(all(feature = "use-rustls-no-provider", feature = "websocket"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "use-rustls-no-provider", feature = "websocket")))
+    )]
     pub fn wss(
         ca: Vec<u8>,
         client_auth: Option<(Vec<u8>, Vec<u8>)>,
@@ -305,14 +311,20 @@ impl Transport {
         Self::wss_with_config(config)
     }
 
-    #[cfg(all(feature = "use-rustls", feature = "websocket"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "use-rustls", feature = "websocket"))))]
+    #[cfg(all(feature = "use-rustls-no-provider", feature = "websocket"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "use-rustls-no-provider", feature = "websocket")))
+    )]
     pub fn wss_with_config(tls_config: TlsConfiguration) -> Self {
         Self::Wss(tls_config)
     }
 
-    #[cfg(all(feature = "use-rustls", feature = "websocket"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "use-rustls", feature = "websocket"))))]
+    #[cfg(all(feature = "use-rustls-no-provider", feature = "websocket"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "use-rustls-no-provider", feature = "websocket")))
+    )]
     pub fn wss_with_default_config() -> Self {
         Self::Wss(Default::default())
     }
@@ -320,9 +332,9 @@ impl Transport {
 
 /// TLS configuration method
 #[derive(Clone, Debug)]
-#[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]
+#[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]
 pub enum TlsConfiguration {
-    #[cfg(feature = "use-rustls")]
+    #[cfg(feature = "use-rustls-no-provider")]
     Simple {
         /// ca certificate
         ca: Vec<u8>,
@@ -339,7 +351,7 @@ pub enum TlsConfiguration {
         /// password for use with der
         client_auth: Option<(Vec<u8>, String)>,
     },
-    #[cfg(feature = "use-rustls")]
+    #[cfg(feature = "use-rustls-no-provider")]
     /// Injected rustls ClientConfig for TLS, to allow more customisation.
     Rustls(Arc<ClientConfig>),
     #[cfg(feature = "use-native-tls")]
@@ -350,7 +362,7 @@ pub enum TlsConfiguration {
     NativeConnector(TlsConnector),
 }
 
-#[cfg(feature = "use-rustls")]
+#[cfg(feature = "use-rustls-no-provider")]
 impl Default for TlsConfiguration {
     fn default() -> Self {
         let mut root_cert_store = RootCertStore::empty();
@@ -365,7 +377,7 @@ impl Default for TlsConfiguration {
     }
 }
 
-#[cfg(feature = "use-rustls")]
+#[cfg(feature = "use-rustls-no-provider")]
 impl From<ClientConfig> for TlsConfiguration {
     fn from(config: ClientConfig) -> Self {
         TlsConfiguration::Rustls(Arc::new(config))
@@ -788,12 +800,12 @@ impl std::convert::TryFrom<url::Url> for MqttOptions {
             // Encrypted connections are supported, but require explicit TLS configuration. We fall
             // back to the unencrypted transport layer, so that `set_transport` can be used to
             // configure the encrypted transport layer with the provided TLS configuration.
-            #[cfg(feature = "use-rustls")]
+            #[cfg(feature = "use-rustls-no-provider")]
             "mqtts" | "ssl" => (Transport::tls_with_default_config(), 8883),
             "mqtt" | "tcp" => (Transport::Tcp, 1883),
             #[cfg(feature = "websocket")]
             "ws" => (Transport::Ws, 8000),
-            #[cfg(all(feature = "use-rustls", feature = "websocket"))]
+            #[cfg(all(feature = "use-rustls-no-provider", feature = "websocket"))]
             "wss" => (Transport::wss_with_default_config(), 8000),
             _ => return Err(OptionError::Scheme),
         };
@@ -927,7 +939,7 @@ mod test {
     use super::*;
 
     #[test]
-    #[cfg(all(feature = "use-rustls", feature = "websocket"))]
+    #[cfg(all(feature = "use-rustls-no-provider", feature = "websocket"))]
     fn no_scheme() {
         let mut mqttoptions = MqttOptions::new("client_a", "a3f8czas.iot.eu-west-1.amazonaws.com/mqtt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=MyCreds%2F20201001%2Feu-west-1%2Fiotdevicegateway%2Faws4_request&X-Amz-Date=20201001T130812Z&X-Amz-Expires=7200&X-Amz-Signature=9ae09b49896f44270f2707551581953e6cac71a4ccf34c7c3415555be751b2d1&X-Amz-SignedHeaders=host", 443);
 

--- a/rumqttc/src/proxy.rs
+++ b/rumqttc/src/proxy.rs
@@ -4,7 +4,7 @@ use crate::NetworkOptions;
 
 use std::io;
 
-#[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]
+#[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]
 use crate::{tls, TlsConfiguration};
 
 #[derive(Clone, Debug)]
@@ -18,7 +18,7 @@ pub struct Proxy {
 #[derive(Clone, Debug)]
 pub enum ProxyType {
     Http,
-    #[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]
+    #[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]
     Https(TlsConfiguration),
 }
 
@@ -35,7 +35,7 @@ pub enum ProxyError {
     #[error("Proxy connect: {0}.")]
     Proxy(#[from] async_http_proxy::HttpError),
 
-    #[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]
+    #[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]
     #[error("Tls connect: {0}.")]
     Tls(#[from] tls::Error),
 }
@@ -53,7 +53,7 @@ impl Proxy {
             Box::new(socket_connect(proxy_addr, network_options).await?);
         let mut tcp = match self.ty {
             ProxyType::Http => tcp,
-            #[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]
+            #[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]
             ProxyType::Https(tls_config) => {
                 tls::tls_connect(&self.addr, self.port, &tls_config, tcp).await?
             }

--- a/rumqttc/src/tls.rs
+++ b/rumqttc/src/tls.rs
@@ -1,19 +1,19 @@
-#[cfg(feature = "use-rustls")]
+#[cfg(feature = "use-rustls-no-provider")]
 use rustls_pemfile::Item;
-#[cfg(feature = "use-rustls")]
+#[cfg(feature = "use-rustls-no-provider")]
 use tokio_rustls::rustls::{
     self,
     pki_types::{InvalidDnsNameError, ServerName},
     ClientConfig, RootCertStore,
 };
-#[cfg(feature = "use-rustls")]
+#[cfg(feature = "use-rustls-no-provider")]
 use tokio_rustls::TlsConnector as RustlsConnector;
 
-#[cfg(feature = "use-rustls")]
+#[cfg(feature = "use-rustls-no-provider")]
 use std::convert::TryFrom;
-#[cfg(feature = "use-rustls")]
+#[cfg(feature = "use-rustls-no-provider")]
 use std::io::{BufReader, Cursor};
-#[cfg(feature = "use-rustls")]
+#[cfg(feature = "use-rustls-no-provider")]
 use std::sync::Arc;
 
 use crate::framed::AsyncReadWrite;
@@ -36,27 +36,27 @@ pub enum Error {
     /// I/O related error
     #[error("I/O: {0}")]
     Io(#[from] io::Error),
-    #[cfg(feature = "use-rustls")]
+    #[cfg(feature = "use-rustls-no-provider")]
     /// Certificate/Name validation error
     #[error("Web Pki: {0}")]
     WebPki(#[from] webpki::Error),
     /// Invalid DNS name
-    #[cfg(feature = "use-rustls")]
+    #[cfg(feature = "use-rustls-no-provider")]
     #[error("DNS name")]
     DNSName(#[from] InvalidDnsNameError),
-    #[cfg(feature = "use-rustls")]
+    #[cfg(feature = "use-rustls-no-provider")]
     /// Error from rustls module
     #[error("TLS error: {0}")]
     TLS(#[from] rustls::Error),
-    #[cfg(feature = "use-rustls")]
+    #[cfg(feature = "use-rustls-no-provider")]
     /// No valid CA cert found
     #[error("No valid CA certificate provided")]
     NoValidCertInChain,
-    #[cfg(feature = "use-rustls")]
+    #[cfg(feature = "use-rustls-no-provider")]
     /// No valid client cert found
     #[error("No valid certificate for client authentication in chain")]
     NoValidClientCertInChain,
-    #[cfg(feature = "use-rustls")]
+    #[cfg(feature = "use-rustls-no-provider")]
     /// No valid key found
     #[error("No valid key in chain")]
     NoValidKeyInChain,
@@ -65,7 +65,7 @@ pub enum Error {
     NativeTls(#[from] NativeTlsError),
 }
 
-#[cfg(feature = "use-rustls")]
+#[cfg(feature = "use-rustls-no-provider")]
 pub async fn rustls_connector(tls_config: &TlsConfiguration) -> Result<RustlsConnector, Error> {
     let config = match tls_config {
         TlsConfiguration::Simple {
@@ -170,7 +170,7 @@ pub async fn tls_connect(
     tcp: Box<dyn AsyncReadWrite>,
 ) -> Result<Box<dyn AsyncReadWrite>, Error> {
     let tls: Box<dyn AsyncReadWrite> = match tls_config {
-        #[cfg(feature = "use-rustls")]
+        #[cfg(feature = "use-rustls-no-provider")]
         TlsConfiguration::Simple { .. } | TlsConfiguration::Rustls(_) => {
             let connector = rustls_connector(tls_config).await?;
             let domain = ServerName::try_from(addr)?.to_owned();

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 
 use super::mqttbytes::v5::ConnectReturnCode;
 
-#[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]
+#[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]
 use crate::tls;
 
 #[cfg(unix)]
@@ -44,7 +44,7 @@ pub enum ConnectionError {
     #[cfg(feature = "websocket")]
     #[error("Websocket Connect: {0}")]
     WsConnect(#[from] http::Error),
-    #[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]
+    #[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]
     #[error("TLS: {0}")]
     Tls(#[from] tls::Error),
     #[error("I/O: {0}")]
@@ -311,7 +311,7 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
     let (domain, port) = match options.transport() {
         #[cfg(feature = "websocket")]
         Transport::Ws => split_url(&options.broker_addr)?,
-        #[cfg(all(feature = "use-rustls", feature = "websocket"))]
+        #[cfg(all(feature = "use-rustls-no-provider", feature = "websocket"))]
         Transport::Wss(_) => split_url(&options.broker_addr)?,
         _ => options.broker_address(),
     };
@@ -340,7 +340,7 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
 
     let network = match options.transport() {
         Transport::Tcp => Network::new(tcp_stream, max_incoming_pkt_size),
-        #[cfg(any(feature = "use-native-tls", feature = "use-rustls"))]
+        #[cfg(any(feature = "use-native-tls", feature = "use-rustls-no-provider"))]
         Transport::Tls(tls_config) => {
             let socket =
                 tls::tls_connect(&options.broker_addr, options.port, &tls_config, tcp_stream)
@@ -366,7 +366,7 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
 
             Network::new(WsStream::new(socket), max_incoming_pkt_size)
         }
-        #[cfg(all(feature = "use-rustls", feature = "websocket"))]
+        #[cfg(all(feature = "use-rustls-no-provider", feature = "websocket"))]
         Transport::Wss(tls_config) => {
             let mut request = options.broker_addr.as_str().into_client_request()?;
             request

--- a/rumqttc/src/v5/mod.rs
+++ b/rumqttc/src/v5/mod.rs
@@ -25,7 +25,7 @@ pub use client::{
 pub use eventloop::{ConnectionError, Event, EventLoop};
 pub use state::{MqttState, StateError};
 
-#[cfg(feature = "use-rustls")]
+#[cfg(feature = "use-rustls-no-provider")]
 pub use crate::tls::Error as TlsError;
 
 #[cfg(feature = "proxy")]
@@ -618,12 +618,12 @@ impl std::convert::TryFrom<url::Url> for MqttOptions {
             // Encrypted connections are supported, but require explicit TLS configuration. We fall
             // back to the unencrypted transport layer, so that `set_transport` can be used to
             // configure the encrypted transport layer with the provided TLS configuration.
-            #[cfg(feature = "use-rustls")]
+            #[cfg(feature = "use-rustls-no-provider")]
             "mqtts" | "ssl" => (Transport::tls_with_default_config(), 8883),
             "mqtt" | "tcp" => (Transport::Tcp, 1883),
             #[cfg(feature = "websocket")]
             "ws" => (Transport::Ws, 8000),
-            #[cfg(all(feature = "use-rustls", feature = "websocket"))]
+            #[cfg(all(feature = "use-rustls-no-provider", feature = "websocket"))]
             "wss" => (Transport::wss_with_default_config(), 8000),
             _ => return Err(OptionError::Scheme),
         };
@@ -753,7 +753,7 @@ mod test {
     use super::*;
 
     #[test]
-    #[cfg(all(feature = "use-rustls", feature = "websocket"))]
+    #[cfg(all(feature = "use-rustls-no-provider", feature = "websocket"))]
     fn no_scheme() {
         use crate::{TlsConfiguration, Transport};
         let mut mqttoptions = MqttOptions::new("client_a", "a3f8czas.iot.eu-west-1.amazonaws.com/mqtt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=MyCreds%2F20201001%2Feu-west-1%2Fiotdevicegateway%2Faws4_request&X-Amz-Date=20201001T130812Z&X-Amz-Expires=7200&X-Amz-Signature=9ae09b49896f44270f2707551581953e6cac71a4ccf34c7c3415555be751b2d1&X-Amz-SignedHeaders=host", 443);


### PR DESCRIPTION
Add new feature 'use-rustls-no-provider' which uses rustls but does not enable the default features so that the consumer can choose which crypto backend to use (ring, or rustls-openssl, etc) without being
forced to compile aws_lc_rs.

Because it is a new feature, this should be backwards compatible. Ideally, this crate should not have used default = true at all but just removing it could break some clients that expect rumqttc to run
without explicitly specifying the dependency. Worse, adding 'default-features = False' would allow the clients to compile but panic during runtime with

Could not automatically determine the process-level CryptoProvider from Rustls crate features.
Call CryptoProvider::install_default() before this point to select a provider manually, or make sure exactly one of the 'aws-lc-rs' and 'ring' features is enabled.
See the documentation of the CryptoProvider type for more information.

This feature is inspired by reqwest which has a similar feature: 'rustls-tls-webpki-roots-no-provider'.

Additionally, it might make sense to add the feature 'rustls-tls-min' in the future which does not pull in 'rustls-tls-webpki' and requires the developer to provide their own trust store with a custom
config to make the binary smaller.

<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
