### PR TITLE
Implementing the automatic_topic_alias

### DIFF
--- a/rumqttc/src/v5/mod.rs
+++ b/rumqttc/src/v5/mod.rs
@@ -255,6 +255,10 @@ impl MqttOptions {
     /// operations on the client when reconnection with same `client_id`
     /// happens. Local queue state is also held to retransmit packets after reconnection.
     pub fn set_clean_start(&mut self, clean_start: bool) -> &mut Self {
+        assert!(
+            !self.client_id.is_empty() || clean_start,
+            "Cannot unset clean session when client id is empty"
+        );
         self.clean_start = clean_start;
         self
     }


### PR DESCRIPTION


## Type of change
- Adding check for empty client_id before applying for clean_start in v5
- Implementing the automatic_topic_alias

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
