### PR TITLE
Fix rumqttc build with websocket feature enabled

### DIFF
--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -39,8 +39,8 @@ rustls-webpki = { version = "0.102.8", optional = true }
 rustls-pemfile = { version = "2.2.0", optional = true }
 rustls-native-certs = { version = "0.8.1", optional = true }
 # websockets
-async-tungstenite = { version = "0.28.0", default-features = false, features = ["tokio-rustls-native-certs"], optional = true }
-ws_stream_tungstenite = { version= "0.14.0", default-features = false, features = ["tokio_io"], optional = true }
+async-tungstenite = { version = "0.29.0", default-features = false, features = ["tokio-rustls-native-certs"], optional = true }
+ws_stream_tungstenite = { version= "0.15.0", default-features = false, features = ["tokio_io"], optional = true }
 http = { version = "1.0.0", optional = true }
 # native-tls
 tokio-native-tls = { version = "0.3.1", optional = true }


### PR DESCRIPTION
This is a fix for building rumqttc with the websocket feature enabled.

Note that the Cargo.lock in the workspace is hopelessly outdated and build fails, so I locally had to do cargo update first. That is not included in the PR.

```
error[E0277]: the trait bound `WebSocketStream<S>: futures_sink::Sink<Message>` is not satisfied
   --> /home/ondra/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ws_stream_tungstenite-0.14.0/src/tung_websocket.rs:145:53
    |
145 |         if ready!( Pin::new( &mut self.closer ).run( &mut self.inner, &mut self.notifier, cx) ).is_err()
    |                                                 ---       ^^^^^^^^^^ the trait `futures_sink::Sink<Message>` is not implemented for `WebSocketStream<S>`
    |                                                 |
    |                                                 required by a bound introduced by this call
    |
    = help: the following other types implement trait `futures_sink::Sink<Item>`:
              `&futures_channel::mpsc::UnboundedSender<T>` implements `futures_sink::Sink<T>`
              `&mut S` implements `futures_sink::Sink<Item>`
              `Box<S>` implements `futures_sink::Sink<Item>`
              `Buffer<Si, Item>` implements `futures_sink::Sink<Item>`
              `BufferUnordered<S>` implements `futures_sink::Sink<Item>`
              `Buffered<S>` implements `futures_sink::Sink<Item>`
              `Either<A, B>` implements `futures_sink::Sink<Item>`
              `Fanout<Si1, Si2>` implements `futures_sink::Sink<Item>`
            and 60 others
    = note: required for `&mut WebSocketStream<S>` to implement `futures_sink::Sink<Message>`
note: required by a bound in `Closer::run`
   --> /home/ondra/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ws_stream_tungstenite-0.14.0/src/tung_websocket/closer.rs:95:21
    |
 92 |     pub(super) fn run
    |                   --- required by a bound in this associated function
...
 95 |         mut socket : impl Sink<tungstenite::Message, Error=TungErr> + Unpin ,
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Closer::run`

```
