### PR TITLE
fix: clear collision state on reconnection with clean session

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Deprecated
 ### Removed
-### Fixed 
+### Fixed
+* Clear collision state on reconnection with clean session
 ### Security
 
 

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -157,9 +157,10 @@ impl EventLoop {
                 Ok(inner) => inner?,
                 Err(_) => return Err(ConnectionError::NetworkTimeout),
             };
-            // Last session might contain packets which aren't acked. If it's a new session, clear the pending packets.
+            // Last session might contain packets which aren't acked. If it's a new session, clear the pending packets and any existing collision state.
             if !connack.session_present {
                 self.pending.clear();
+                self.state.clear_collision();
             }
             self.network = Some(network);
 

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -184,6 +184,11 @@ impl MqttState {
         Ok(outgoing)
     }
 
+    pub fn clear_collision(&mut self) {
+        self.collision = None;
+        self.collision_ping_count = 0;
+    }
+
     fn handle_incoming_suback(&mut self) -> Result<Option<Packet>, StateError> {
         Ok(None)
     }

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -149,9 +149,10 @@ impl EventLoop {
                 connect(&mut self.options),
             )
             .await??;
-            // Last session might contain packets which aren't acked. If it's a new session, clear the pending packets.
+            // Last session might contain packets which aren't acked. If it's a new session, clear the pending packets and any existing collision state.
             if !connack.session_present {
                 self.pending.clear();
+                self.state.clear_collision();
             }
             self.network = Some(network);
 

--- a/rumqttc/src/v5/state.rs
+++ b/rumqttc/src/v5/state.rs
@@ -231,6 +231,11 @@ impl MqttState {
         self.outgoing_disconnect(DisconnectReasonCode::ProtocolError)
     }
 
+    pub fn clear_collision(&mut self) {
+        self.collision = None;
+        self.collision_ping_count = 0;
+    }
+
     fn handle_incoming_suback(
         &mut self,
         suback: &mut SubAck,

--- a/rumqttc/tests/reliability.rs
+++ b/rumqttc/tests/reliability.rs
@@ -549,6 +549,71 @@ async fn reconnection_resends_unacked_packets_from_the_previous_connection_first
 }
 
 #[tokio::test]
+async fn reconnection_clean_both_pending_packets_and_collision_when_clean_session_is_true() {
+    let mut options = MqttOptions::new("dummy", "127.0.0.1", 3003);
+    options
+        .set_inflight(2)
+        .set_keep_alive(Duration::from_secs(2))
+        .set_clean_session(true);
+
+    // A broker which does not ack the first publish to trigger collision
+    task::spawn(async move {
+        // in a loop to not return after the first connection closes
+        loop {
+            let mut broker = Broker::new(3003, 0, false).await;
+
+            let mut first_publish_unacked = false;
+            while let Some(packet) = broker.read_packet().await {
+                match packet {
+                    Packet::PingReq => broker.pingresp().await,
+                    Packet::Publish(publish) => {
+                        if first_publish_unacked {
+                            // don't ack the first publish to trigger collision
+                            broker.ack(publish.pkid).await;
+                        }
+                        first_publish_unacked = true;
+                    }
+                    _ => (),
+                }
+                time::sleep(Duration::from_secs_f64(0.5)).await;
+            }
+        }
+    });
+
+    // start sending qos0 publishes. this makes sure that there is
+    // outgoing activity but no incoming activity
+    let (client, mut eventloop) = AsyncClient::new(options, 5);
+    task::spawn(async move {
+        start_requests(3, QoS::AtLeastOnce, 1, client).await;
+        time::sleep(Duration::from_secs(10)).await;
+    });
+
+    // wait for the collision to happen
+    loop {
+        if let Err(ConnectionError::MqttState(StateError::CollisionTimeout)) =
+            eventloop.poll().await
+        {
+            break;
+        };
+    }
+
+    // Let's allow the broker to be created again
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // poll again, and check that there is no pending packets nor collision
+    match eventloop.poll().await {
+        Ok(Event::Incoming(Packet::ConnAck(ConnAck {
+            code: ConnectReturnCode::Success,
+            session_present: false, // this validates the "clean session" behavior
+        }))) => {
+            assert!(eventloop.pending.is_empty());
+            assert!(eventloop.state.collision.is_none());
+        }
+        v => panic!("Expected ConnAck Success. Found = {:?}", v),
+    }
+}
+
+#[tokio::test]
 async fn state_is_being_cleaned_properly_and_pending_request_calculated_properly() {
     let mut options = MqttOptions::new("dummy", "127.0.0.1", 3004);
     options.set_keep_alive(Duration::from_secs(5));


### PR DESCRIPTION
When reconnecting with a clean session (session_present=false), the collision state was not being cleared along with the pending packets. This could cause issues if a collision had occurred in the previous session, as the stale collision state would persist into the new session.

This is a fix for #1014 

<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

- Bug fix (non-breaking change which fixes an issue)
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
