### PR TITLE
fix:(rumqttc): Remove tls default provider from dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2230,7 +2230,7 @@ dependencies = [
  "pretty_env_logger",
  "rustls-native-certs",
  "rustls-pemfile",
- "rustls-webpki 0.102.8",
+ "rustls-webpki 0.103.8",
  "serde",
  "thiserror 2.0.17",
  "tokio",

--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Deprecated
 ### Removed
-### Fixed 
+### Fixed
+* Fixed `use-rustls-no-provider` feature flag with removing `ring` dependency of `rustls-webpki`
+
 ### Security
 
 

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -35,7 +35,7 @@ thiserror = "2.0.8"
 # Optional
 # rustls
 tokio-rustls = { version = "0.26.0", optional = true, default-features = false }
-rustls-webpki = { version = "0.102.8", optional = true }
+rustls-webpki = { version = "0.103.0", optional = true }
 rustls-pemfile = { version = "2.2.0", optional = true }
 rustls-native-certs = { version = "0.8.1", optional = true }
 # websockets


### PR DESCRIPTION
Updating 'rustls-webpki' to 0.103.0 removes default ring tls-provider from 'rustls-webpki' dependency and allows to specifically choose between 'ring' and 'aws-lc-rs'. Consider this commit fixing usage of 'use-rustls-no-provider' feature.