### PR TITLE
feat: add backoffs when reconnecting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2216,6 +2225,7 @@ version = "0.25.1"
 dependencies = [
  "async-http-proxy",
  "async-tungstenite 0.29.1",
+ "backon",
  "bincode",
  "bytes",
  "color-backtrace",

--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * `use-rustls-no-provider` feature flag to allow choosing crypto backend without being forced to compile `aws_lc_rs`
+* `NetworkOptions.connection_backoff` configuration option to enable binary exponential backoff for reconnection attempts 
 
 ### Changed
 ### Deprecated

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -31,6 +31,7 @@ bytes = "1.5"
 log = "0.4"
 flume = { version = "0.11", default-features = false, features = ["async"] }
 thiserror = "2.0.8"
+backon = { version = "1.6.0", default-features = false }
 
 # Optional
 # rustls
@@ -51,6 +52,7 @@ url = { version = "2", default-features = false, optional = true }
 async-http-proxy = { version = "1.2.5", features = ["runtime-tokio", "basic-auth"], optional = true }
 tokio-stream = "0.1.16"
 fixedbitset = "0.5.7"
+
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -4,6 +4,7 @@ use crate::{MqttOptions, Outgoing};
 
 use crate::framed::AsyncReadWrite;
 use crate::mqttbytes::v4::*;
+use backon::{BackoffBuilder, ExponentialBackoff, ExponentialBuilder};
 use flume::{bounded, Receiver, Sender};
 use tokio::net::{lookup_host, TcpSocket, TcpStream};
 use tokio::select;
@@ -84,6 +85,8 @@ pub struct EventLoop {
     pub network: Option<Network>,
     /// Keep alive time
     keepalive_timeout: Option<Pin<Box<Sleep>>>,
+    /// Connection backoff state
+    backoff: Option<ExponentialBackoff>,
     pub network_options: NetworkOptions,
 }
 
@@ -113,6 +116,7 @@ impl EventLoop {
             pending,
             network: None,
             keepalive_timeout: None,
+            backoff: None,
             network_options: NetworkOptions::new(),
         }
     }
@@ -154,8 +158,30 @@ impl EventLoop {
             )
             .await
             {
-                Ok(inner) => inner?,
-                Err(_) => return Err(ConnectionError::NetworkTimeout),
+                Ok(inner) => {
+                    // Clear the backoff state on successful connection
+                    self.backoff = None;
+
+                    // Return the network and connack
+                    inner?
+                }
+                Err(_) => {
+                    // If backoff is enabled, wait here for a time proportional to the
+                    // number of retries before returning timeout error.
+                    if self.network_options.connection_backoff {
+                        // Initialize backoff on the first connection failure
+                        let backoff = self.backoff.get_or_insert_with(|| {
+                            ExponentialBuilder::new().without_max_times().build()
+                        });
+
+                        // Wait for the next backoff duration
+                        if let Some(backoff_duration) = backoff.next() {
+                            time::sleep(backoff_duration).await;
+                        }
+                    }
+
+                    return Err(ConnectionError::NetworkTimeout);
+                }
             };
             // Last session might contain packets which aren't acked. If it's a new session, clear the pending packets.
             if !connack.session_present {

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -400,6 +400,7 @@ pub struct NetworkOptions {
     conn_timeout: u64,
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
     bind_device: Option<String>,
+    connection_backoff: bool,
 }
 
 impl NetworkOptions {
@@ -411,6 +412,7 @@ impl NetworkOptions {
             conn_timeout: 5,
             #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
             bind_device: None,
+            connection_backoff: true,
         }
     }
 
@@ -435,6 +437,12 @@ impl NetworkOptions {
     /// get timeout in secs
     pub fn connection_timeout(&self) -> u64 {
         self.conn_timeout
+    }
+
+    /// Enable or disable backoffs for connection retries
+    pub fn set_connection_backoff(&mut self, backoff: bool) -> &mut Self {
+        self.connection_backoff = backoff;
+        self
     }
 
     /// bind connection to a specific network device by name


### PR DESCRIPTION
<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

hiya, thanks for making a neat library!

we ran into an issue where on a connection failure the library loops attempting re-connection, which (depending on your timeouts) can occur at a pace that is hazardous to other things sharing the executor.

while it's pretty easy to wrap the connection failed path with a backoff, we thought it might be nice to solve this at the library level? so this PR introduces an (optional) exponential backoff to re-connection attempts, with a flag to enable/disable this on the `NetworkOptions` object.

at the moment this just uses the defaults from [backon](https://docs.rs/backon/latest/backon/struct.ExponentialBuilder.html#default) with `max_times` unset, but more configuration could be exposed if it was useful.

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
