### PR TITLE
fix(rumqttd): Expose bridge module and Event type.

### DIFF
--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed
+- Export the `Event` type, so the Router's Sender can be used.
+- Export the `bridge` module so a bridge can be constructed directly, rather than using the `Broker`.
 ### Deprecated
 ### Removed
 ### Fixed 

--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -19,9 +19,12 @@ use tracing_subscriber::{
 };
 
 pub use link::alerts;
+pub use link::bridge;
 pub use link::local;
 pub use link::meters;
-pub use router::{Alert, Forward, IncomingMeter, Meter, Notification, OutgoingMeter, Router};
+pub use router::{
+    Alert, Event, Forward, IncomingMeter, Meter, Notification, OutgoingMeter, Router,
+};
 use segments::Storage;
 pub use server::{Broker, LinkType, Server};
 


### PR DESCRIPTION
The bridge module wasn't exposed, which meant the only way to create a bridge was to use the Broker directly.

The event type is also on a public API via the Router but isn't exposed, meaning you can't name this type.

Signed off: Jeremy Barrow <jeremy.a.barrow@gmail.com>

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
