### PR TITLE
feat(rumqttc): Support fallible request modifiers for websocket connections

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+* `set_request_modifier` now supports fallible closures that return `Result<http::Request<()>, E>`, in addition to the existing infallible API. Modifier errors surface as `ConnectionError::RequestModifier`.
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -66,6 +66,9 @@ pub enum ConnectionError {
     #[cfg(feature = "websocket")]
     #[error("Websocket response validation error: ")]
     ResponseValidation(#[from] crate::websockets::ValidationError),
+    #[cfg(feature = "websocket")]
+    #[error("Websocket request modifier failed: {0}")]
+    RequestModifier(#[source] Box<dyn std::error::Error + Send + Sync>),
 }
 
 /// Eventloop with all the state of a connection
@@ -437,7 +440,9 @@ async fn network_connect(
                 .insert("Sec-WebSocket-Protocol", "mqtt".parse().unwrap());
 
             if let Some(request_modifier) = options.request_modifier() {
-                request = request_modifier(request).await;
+                request = request_modifier(request)
+                    .await
+                    .map_err(ConnectionError::RequestModifier)?;
             }
 
             let (socket, response) =
@@ -458,7 +463,9 @@ async fn network_connect(
                 .insert("Sec-WebSocket-Protocol", "mqtt".parse().unwrap());
 
             if let Some(request_modifier) = options.request_modifier() {
-                request = request_modifier(request).await;
+                request = request_modifier(request)
+                    .await
+                    .map_err(ConnectionError::RequestModifier)?;
             }
 
             let connector = tls::rustls_connector(&tls_config).await?;

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -119,17 +119,14 @@ mod tls;
 mod websockets;
 
 #[cfg(feature = "websocket")]
-use std::{
-    future::{Future, IntoFuture},
-    pin::Pin,
-};
+mod request_modifier;
+#[cfg(feature = "websocket")]
+use request_modifier::IntoModifierResult;
+#[cfg(feature = "websocket")]
+use request_modifier::RequestModifierFn;
 
 #[cfg(feature = "websocket")]
-type RequestModifierFn = Arc<
-    dyn Fn(http::Request<()>) -> Pin<Box<dyn Future<Output = http::Request<()>> + Send>>
-        + Send
-        + Sync,
->;
+use std::future::IntoFuture;
 
 #[cfg(feature = "proxy")]
 mod proxy;
@@ -726,16 +723,48 @@ impl MqttOptions {
         self.proxy.clone()
     }
 
+    /// Sets a handler for modifying the websocket HTTP request before it is sent.
+    ///
+    /// This can be used to add custom headers (e.g., authentication tokens) to the
+    /// websocket upgrade request.
+    ///
+    /// The modifier function accepts the request and returns a (possibly modified) request.
+    /// It supports both infallible and fallible closures:
+    ///
+    /// # Infallible modifier (returns request directly)
+    /// ```ignore
+    /// options.set_request_modifier(|mut req| async move {
+    ///     req.headers_mut().insert("X-Custom-Header", "value".parse().unwrap());
+    ///     req
+    /// });
+    /// ```
+    ///
+    /// # Fallible modifier (returns Result)
+    /// ```ignore
+    /// options.set_request_modifier(|mut req| async move {
+    ///     let token = get_auth_token().await?;
+    ///     req.headers_mut().insert("Authorization", token.parse()?);
+    ///     Ok(req)
+    /// });
+    /// ```
+    ///
+    /// If the modifier returns an error, the connection will fail with
+    /// [`ConnectionError::RequestModifier`].
     #[cfg(feature = "websocket")]
     pub fn set_request_modifier<F, O>(&mut self, request_modifier: F) -> &mut Self
     where
         F: Fn(http::Request<()>) -> O + Send + Sync + 'static,
-        O: IntoFuture<Output = http::Request<()>> + 'static,
+        O: IntoFuture + 'static,
         O::IntoFuture: Send,
+        O::Output: IntoModifierResult,
     {
         self.request_modifier = Some(Arc::new(move |request| {
-            let request_modifier = request_modifier(request).into_future();
-            Box::pin(request_modifier)
+            let fut = request_modifier(request).into_future();
+            Box::pin(async move {
+                fut.await
+                    .into_modifier_result()
+                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
+            })
         }));
 
         self
@@ -937,6 +966,68 @@ impl Debug for MqttOptions {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[cfg(all(feature = "use-rustls-no-provider", feature = "websocket"))]
+    mod request_modifier_tests {
+        use super::MqttOptions;
+
+        /// Test that infallible request modifier works (backwards compatibility)
+        #[test]
+        fn request_modifier_infallible() {
+            let mut options = MqttOptions::new("test", "ws://localhost", 8080);
+
+            // Old API: returning Request directly (no Result wrapper)
+            options.set_request_modifier(|req| async move { req });
+
+            assert!(
+                options.request_modifier().is_some(),
+                "Request modifier should be set"
+            );
+        }
+
+        /// Test that fallible request modifier works (new API)
+        #[test]
+        fn request_modifier_fallible() {
+            let mut options = MqttOptions::new("test", "ws://localhost", 8080);
+
+            // New API: returning Result
+            options.set_request_modifier(|req| async move { Ok::<_, std::io::Error>(req) });
+
+            assert!(
+                options.request_modifier().is_some(),
+                "Request modifier should be set"
+            );
+        }
+
+        /// Test that fallible modifier with custom error type works
+        #[test]
+        fn request_modifier_custom_error() {
+            #[derive(Debug)]
+            struct CustomError(String);
+
+            impl std::fmt::Display for CustomError {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    write!(f, "{}", self.0)
+                }
+            }
+
+            impl std::error::Error for CustomError {}
+
+            let mut options = MqttOptions::new("test", "ws://localhost", 8080);
+
+            options.set_request_modifier(|req| async move {
+                if req.uri().host() == Some("forbidden") {
+                    return Err(CustomError("forbidden host".into()));
+                }
+                Ok(req)
+            });
+
+            assert!(
+                options.request_modifier().is_some(),
+                "Request modifier should be set"
+            );
+        }
+    }
 
     #[test]
     #[cfg(all(feature = "use-rustls-no-provider", feature = "websocket"))]

--- a/rumqttc/src/request_modifier.rs
+++ b/rumqttc/src/request_modifier.rs
@@ -1,0 +1,39 @@
+//! Request modifier types for websocket connections.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+/// A boxed future returned by the request modifier function.
+type ModifierFuture = Pin<
+    Box<
+        dyn Future<Output = Result<http::Request<()>, Box<dyn std::error::Error + Send + Sync>>>
+            + Send,
+    >,
+>;
+
+/// The stored request modifier closure.
+pub(crate) type RequestModifierFn = Arc<dyn Fn(http::Request<()>) -> ModifierFuture + Send + Sync>;
+
+/// Trait to convert request modifier output to Result, enabling backwards compatibility.
+/// Accepts both `http::Request<()>` (infallible) and `Result<http::Request<()>, E>` (fallible).
+pub trait IntoModifierResult {
+    type Error: std::error::Error + Send + Sync + 'static;
+    fn into_modifier_result(self) -> Result<http::Request<()>, Self::Error>;
+}
+
+impl IntoModifierResult for http::Request<()> {
+    type Error = std::convert::Infallible;
+    fn into_modifier_result(self) -> Result<http::Request<()>, Self::Error> {
+        Ok(self)
+    }
+}
+
+impl<E: std::error::Error + Send + Sync + 'static> IntoModifierResult
+    for Result<http::Request<()>, E>
+{
+    type Error = E;
+    fn into_modifier_result(self) -> Result<http::Request<()>, Self::Error> {
+        self
+    }
+}

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -64,6 +64,9 @@ pub enum ConnectionError {
     #[cfg(feature = "websocket")]
     #[error("Websocket response validation error: ")]
     ResponseValidation(#[from] crate::websockets::ValidationError),
+    #[cfg(feature = "websocket")]
+    #[error("Websocket request modifier failed: {0}")]
+    RequestModifier(#[source] Box<dyn std::error::Error + Send + Sync>),
 }
 
 /// Eventloop with all the state of a connection
@@ -357,7 +360,9 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
                 .insert("Sec-WebSocket-Protocol", "mqtt".parse().unwrap());
 
             if let Some(request_modifier) = options.request_modifier() {
-                request = request_modifier(request).await;
+                request = request_modifier(request)
+                    .await
+                    .map_err(ConnectionError::RequestModifier)?;
             }
 
             let (socket, response) =
@@ -374,7 +379,9 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
                 .insert("Sec-WebSocket-Protocol", "mqtt".parse().unwrap());
 
             if let Some(request_modifier) = options.request_modifier() {
-                request = request_modifier(request).await;
+                request = request_modifier(request)
+                    .await
+                    .map_err(ConnectionError::RequestModifier)?;
             }
 
             let connector = tls::rustls_connector(&tls_config).await?;

--- a/rumqttc/src/v5/mod.rs
+++ b/rumqttc/src/v5/mod.rs
@@ -1,12 +1,10 @@
 use bytes::Bytes;
 use std::fmt::{self, Debug, Formatter};
-use std::time::Duration;
 #[cfg(feature = "websocket")]
-use std::{
-    future::{Future, IntoFuture},
-    pin::Pin,
-    sync::Arc,
-};
+use std::future::IntoFuture;
+#[cfg(feature = "websocket")]
+use std::sync::Arc;
+use std::time::Duration;
 
 mod client;
 mod eventloop;
@@ -14,6 +12,10 @@ mod framed;
 pub mod mqttbytes;
 mod state;
 
+#[cfg(feature = "websocket")]
+use crate::request_modifier::IntoModifierResult;
+#[cfg(feature = "websocket")]
+use crate::request_modifier::RequestModifierFn;
 use crate::Outgoing;
 use crate::{NetworkOptions, Transport};
 
@@ -56,13 +58,6 @@ impl From<Subscribe> for Request {
         Self::Subscribe(subscribe)
     }
 }
-
-#[cfg(feature = "websocket")]
-type RequestModifierFn = Arc<
-    dyn Fn(http::Request<()>) -> Pin<Box<dyn Future<Output = http::Request<()>> + Send>>
-        + Send
-        + Sync,
->;
 
 // TODO: Should all the options be exposed as public? Drawback
 // would be loosing the ability to panic when the user options
@@ -197,16 +192,24 @@ impl MqttOptions {
         self.last_will.clone()
     }
 
+    /// Sets a handler for modifying the websocket HTTP request before it is sent.
+    ///
+    /// See the similar [`crate::MqttOptions::set_request_modifier`] for more details.
     #[cfg(feature = "websocket")]
     pub fn set_request_modifier<F, O>(&mut self, request_modifier: F) -> &mut Self
     where
         F: Fn(http::Request<()>) -> O + Send + Sync + 'static,
-        O: IntoFuture<Output = http::Request<()>> + 'static,
+        O: IntoFuture + 'static,
         O::IntoFuture: Send,
+        O::Output: IntoModifierResult,
     {
         self.request_modifier = Some(Arc::new(move |request| {
-            let request_modifier = request_modifier(request).into_future();
-            Box::pin(request_modifier)
+            let fut = request_modifier(request).into_future();
+            Box::pin(async move {
+                fut.await
+                    .into_modifier_result()
+                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
+            })
         }));
 
         self

--- a/rumqttc/tests/mqtt_options.rs
+++ b/rumqttc/tests/mqtt_options.rs
@@ -1,0 +1,111 @@
+#[cfg(feature = "websocket")]
+#[allow(dead_code)]
+mod broker;
+
+//
+// Request modifier tests (websocket feature)
+//
+
+#[cfg(feature = "websocket")]
+#[derive(Debug)]
+struct RequestModifierTestError(&'static str);
+
+#[cfg(feature = "websocket")]
+impl std::fmt::Display for RequestModifierTestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(feature = "websocket")]
+impl std::error::Error for RequestModifierTestError {}
+
+/// Test that a fallible request modifier error propagates to ConnectionError
+#[cfg(feature = "websocket")]
+#[tokio::test]
+async fn fallible_request_modifier_error_propagates() {
+    use rumqttc::{ConnectionError, EventLoop, MqttOptions, Transport};
+    use std::time::Duration;
+    use tokio::{task, time};
+
+    use broker::Broker;
+
+    // Start a broker to accept TCP connections
+    task::spawn(async move {
+        let _broker = Broker::new(3010, 0, false).await;
+        time::sleep(Duration::from_secs(5)).await;
+    });
+
+    time::sleep(Duration::from_millis(100)).await;
+
+    let mut options = MqttOptions::new("test", "ws://127.0.0.1:3010/mqtt", 3010);
+    options.set_transport(Transport::Ws);
+
+    // Set a modifier that always fails
+    options.set_request_modifier(|_req| async move {
+        Err(RequestModifierTestError("modifier failed intentionally"))
+    });
+
+    let mut eventloop = EventLoop::new(options, 5);
+
+    // The connection should fail with RequestModifier error
+    let result = time::timeout(Duration::from_secs(5), eventloop.poll()).await;
+
+    match result {
+        Ok(Err(ConnectionError::RequestModifier(e))) => {
+            assert!(
+                e.to_string().contains("modifier failed intentionally"),
+                "Error message should contain our message, got: {}",
+                e
+            );
+        }
+        Ok(Err(e)) => panic!("Expected RequestModifier error, got: {:?}", e),
+        Ok(Ok(event)) => panic!("Expected error, got event: {:?}", event),
+        Err(_) => panic!("Test timed out"),
+    }
+}
+
+/// Test that an infallible request modifier doesn't cause RequestModifier error
+#[cfg(feature = "websocket")]
+#[tokio::test]
+async fn infallible_request_modifier_no_modifier_error() {
+    use rumqttc::{ConnectionError, EventLoop, MqttOptions, Transport};
+    use std::time::Duration;
+    use tokio::{task, time};
+
+    use broker::Broker;
+
+    // Start a broker to accept TCP connections
+    task::spawn(async move {
+        let _broker = Broker::new(3011, 0, false).await;
+        time::sleep(Duration::from_secs(5)).await;
+    });
+
+    time::sleep(Duration::from_millis(100)).await;
+
+    let mut options = MqttOptions::new("test", "ws://127.0.0.1:3011/mqtt", 3011);
+    options.set_transport(Transport::Ws);
+
+    // Set an infallible modifier (backwards compatible API)
+    options.set_request_modifier(|req| async move { req });
+
+    let mut eventloop = EventLoop::new(options, 5);
+
+    // The connection will fail (broker doesn't speak WS), but NOT with RequestModifier error
+    let result = time::timeout(Duration::from_secs(5), eventloop.poll()).await;
+
+    match result {
+        Ok(Err(ConnectionError::RequestModifier(_))) => {
+            panic!("Infallible modifier should never produce RequestModifier error")
+        }
+        Ok(Err(_)) => {
+            // Expected: connection fails for other reasons (no WS support)
+        }
+        Ok(Ok(_)) => {
+            // Unexpected but acceptable if somehow connected
+        }
+        Err(_) => {
+            // Timeout is acceptable
+        }
+    }
+}


### PR DESCRIPTION
The set_request_modifier API now accepts closures that return either `http::Request<()>` (infallible) or `Result<http::Request<()>, E>` (fallible).

This change is backwards compatible - existing code returning requests directly continues to work unchanged. New code can now use the ? operator and propagate errors instead of using unwrap().

Modifier errors are surfaced as ConnectionError::RequestModifier, allowing proper error handling during connection establishment.

<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->


## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
