### PR TITLE
feat(rumqttc): Add custom socket connector to MqttOptions

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+* `MqttOptions::set_socket_connector` to override the default TCP socket creation logic
+* `default_socket_connect` public function to allow composing custom connectors with the default behaviour
+* `NetworkOptions` now implements `Debug`
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -318,7 +318,13 @@ async fn connect(
     Ok((network, connack))
 }
 
-pub(crate) async fn socket_connect(
+/// Default TCP socket connection logic used by the MQTT event loop.
+///
+/// This function resolves the given host, creates a TCP socket, applies the
+/// provided [`NetworkOptions`], and connects. It can be used inside a custom
+/// socket connector set via [`MqttOptions::set_socket_connector`] to wrap or
+/// extend the default behaviour.
+pub async fn default_socket_connect(
     host: String,
     network_options: NetworkOptions,
 ) -> io::Result<TcpStream> {
@@ -395,18 +401,20 @@ async fn network_connect(
     let tcp_stream: Box<dyn AsyncReadWrite> = {
         #[cfg(feature = "proxy")]
         match options.proxy() {
-            Some(proxy) => proxy.connect(&domain, port, network_options).await?,
+            Some(proxy) => {
+                proxy
+                    .connect(&domain, port, network_options, options.socket_connector())
+                    .await?
+            }
             None => {
                 let addr = format!("{domain}:{port}");
-                let tcp = socket_connect(addr, network_options).await?;
-                Box::new(tcp)
+                options.socket_connect(addr, network_options).await?
             }
         }
         #[cfg(not(feature = "proxy"))]
         {
             let addr = format!("{domain}:{port}");
-            let tcp = socket_connect(addr, network_options).await?;
-            Box::new(tcp)
+            options.socket_connect(addr, network_options).await?
         }
     };
 

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -100,9 +100,7 @@ extern crate log;
 
 use std::fmt::{self, Debug, Formatter};
 
-#[cfg(any(feature = "use-rustls-no-provider", feature = "websocket"))]
 use std::sync::Arc;
-
 use std::time::Duration;
 
 mod client;
@@ -137,7 +135,8 @@ mod proxy;
 pub use client::{
     AsyncClient, Client, ClientError, Connection, Iter, RecvError, RecvTimeoutError, TryRecvError,
 };
-pub use eventloop::{ConnectionError, Event, EventLoop};
+pub use eventloop::{default_socket_connect, ConnectionError, Event, EventLoop};
+pub use framed::AsyncReadWrite;
 pub use mqttbytes::v4::*;
 pub use mqttbytes::*;
 #[cfg(feature = "use-rustls-no-provider")]
@@ -221,6 +220,20 @@ impl From<Unsubscribe> for Request {
         Request::Unsubscribe(unsubscribe)
     }
 }
+
+/// Custom socket connector function type used internally.
+pub(crate) type SocketConnector = Arc<
+    dyn Fn(
+            String,
+            NetworkOptions,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Box<dyn AsyncReadWrite>, std::io::Error>>
+                    + Send,
+            >,
+        > + Send
+        + Sync,
+>;
 
 /// Transport methods. Defaults to TCP.
 #[derive(Clone)]
@@ -392,7 +405,7 @@ impl From<TlsConnector> for TlsConfiguration {
 }
 
 /// Provides a way to configure low level network connection configurations
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct NetworkOptions {
     tcp_send_buffer_size: Option<u32>,
     tcp_recv_buffer_size: Option<u32>,
@@ -492,6 +505,7 @@ pub struct MqttOptions {
     proxy: Option<Proxy>,
     #[cfg(feature = "websocket")]
     request_modifier: Option<RequestModifierFn>,
+    socket_connector: Option<SocketConnector>,
 }
 
 impl MqttOptions {
@@ -525,6 +539,7 @@ impl MqttOptions {
             proxy: None,
             #[cfg(feature = "websocket")]
             request_modifier: None,
+            socket_connector: None,
         }
     }
 
@@ -744,6 +759,68 @@ impl MqttOptions {
     #[cfg(feature = "websocket")]
     pub fn request_modifier(&self) -> Option<RequestModifierFn> {
         self.request_modifier.clone()
+    }
+
+    /// Sets a custom socket connector, overriding the default TCP socket creation logic for MQTT connections.
+    ///
+    /// This enables you to fully control how socket streams are established, such as integrating a custom TLS implementation,
+    /// injecting a proxy layer, or facilitating network mocking in tests.
+    ///
+    /// # Important
+    ///
+    /// When providing a custom socket connector, be mindful to avoid redundant or conflicting connection layers.
+    /// You can combine the custom connector with the library's built-in proxy and TLS/WSS transports when appropriate —
+    /// for example, you might use the connector to mock TCP, and still let [`MqttOptions`] handle TLS or a proxy.
+    ///
+    /// **However**, if your connector already establishes a TLS or proxied connection, you should set the transport to a plain option
+    /// (like [`Transport::Tcp`]) and leave proxy/TLS configs unset in [`MqttOptions`], to prevent duplicate layers.
+    ///
+    /// In summary, coordinate the responsibilities between your connector and the library to avoid double-wrapping.
+    ///
+    /// # Example
+    /// ```
+    /// # use rumqttc::MqttOptions;
+    /// # let mut options = MqttOptions::new("test", "localhost", 1883);
+    /// options.set_socket_connector(|host, network_options| async move {
+    ///     rumqttc::default_socket_connect(host, network_options)
+    ///         .await
+    ///         .map(|s| Box::new(s) as Box<dyn rumqttc::AsyncReadWrite>)
+    /// });
+    /// ```
+    pub fn set_socket_connector<F, Fut>(&mut self, f: F) -> &mut Self
+    where
+        F: Fn(String, NetworkOptions) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = Result<Box<dyn AsyncReadWrite>, std::io::Error>>
+            + Send
+            + 'static,
+    {
+        self.socket_connector = Some(Arc::new(move |host, network_options| {
+            Box::pin(f(host, network_options))
+        }));
+        self
+    }
+
+    /// Returns whether a custom socket connector has been set.
+    pub fn has_socket_connector(&self) -> bool {
+        self.socket_connector.is_some()
+    }
+
+    #[cfg(feature = "proxy")]
+    pub(crate) fn socket_connector(&self) -> Option<SocketConnector> {
+        self.socket_connector.clone()
+    }
+
+    pub(crate) async fn socket_connect(
+        &self,
+        host: String,
+        network_options: NetworkOptions,
+    ) -> std::io::Result<Box<dyn crate::framed::AsyncReadWrite>> {
+        if let Some(ref connector) = self.socket_connector {
+            connector(host, network_options).await
+        } else {
+            let tcp = default_socket_connect(host, network_options).await?;
+            Ok(Box::new(tcp))
+        }
     }
 }
 

--- a/rumqttc/src/proxy.rs
+++ b/rumqttc/src/proxy.rs
@@ -1,6 +1,6 @@
-use crate::eventloop::socket_connect;
+use crate::default_socket_connect;
 use crate::framed::AsyncReadWrite;
-use crate::NetworkOptions;
+use crate::{NetworkOptions, SocketConnector};
 
 use std::io;
 
@@ -46,11 +46,15 @@ impl Proxy {
         broker_addr: &str,
         broker_port: u16,
         network_options: NetworkOptions,
+        socket_connector: Option<SocketConnector>,
     ) -> Result<Box<dyn AsyncReadWrite>, ProxyError> {
         let proxy_addr = format!("{}:{}", self.addr, self.port);
 
-        let tcp: Box<dyn AsyncReadWrite> =
-            Box::new(socket_connect(proxy_addr, network_options).await?);
+        let tcp: Box<dyn AsyncReadWrite> = if let Some(connector) = socket_connector {
+            connector(proxy_addr, network_options).await?
+        } else {
+            Box::new(default_socket_connect(proxy_addr, network_options).await?)
+        };
         let mut tcp = match self.ty {
             ProxyType::Http => tcp,
             #[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -1,7 +1,6 @@
 use super::framed::Network;
 use super::mqttbytes::v5::*;
 use super::{Incoming, MqttOptions, MqttState, Outgoing, Request, StateError, Transport};
-use crate::eventloop::socket_connect;
 use crate::framed::AsyncReadWrite;
 
 use flume::{bounded, Receiver, Sender};
@@ -321,20 +320,27 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
         match options.proxy() {
             Some(proxy) => {
                 proxy
-                    .connect(&domain, port, options.network_options())
+                    .connect(
+                        &domain,
+                        port,
+                        options.network_options(),
+                        options.socket_connector(),
+                    )
                     .await?
             }
             None => {
                 let addr = format!("{domain}:{port}");
-                let tcp = socket_connect(addr, options.network_options()).await?;
-                Box::new(tcp)
+                options
+                    .socket_connect(addr, options.network_options())
+                    .await?
             }
         }
         #[cfg(not(feature = "proxy"))]
         {
             let addr = format!("{domain}:{port}");
-            let tcp = socket_connect(addr, options.network_options()).await?;
-            Box::new(tcp)
+            options
+                .socket_connect(addr, options.network_options())
+                .await?
         }
     };
 

--- a/rumqttc/src/v5/mod.rs
+++ b/rumqttc/src/v5/mod.rs
@@ -1,11 +1,11 @@
 use bytes::Bytes;
 use std::fmt::{self, Debug, Formatter};
+use std::sync::Arc;
 use std::time::Duration;
 #[cfg(feature = "websocket")]
 use std::{
     future::{Future, IntoFuture},
     pin::Pin,
-    sync::Arc,
 };
 
 mod client;
@@ -14,8 +14,7 @@ mod framed;
 pub mod mqttbytes;
 mod state;
 
-use crate::Outgoing;
-use crate::{NetworkOptions, Transport};
+use crate::{default_socket_connect, NetworkOptions, Outgoing, SocketConnector, Transport};
 
 use mqttbytes::v5::*;
 
@@ -112,6 +111,7 @@ pub struct MqttOptions {
     outgoing_inflight_upper_limit: Option<u16>,
     #[cfg(feature = "websocket")]
     request_modifier: Option<RequestModifierFn>,
+    socket_connector: Option<SocketConnector>,
 }
 
 impl MqttOptions {
@@ -147,6 +147,7 @@ impl MqttOptions {
             outgoing_inflight_upper_limit: None,
             #[cfg(feature = "websocket")]
             request_modifier: None,
+            socket_connector: None,
         }
     }
 
@@ -559,6 +560,45 @@ impl MqttOptions {
     /// The server may set its own maximum inflight limit, the smaller of the two will be used.
     pub fn get_outgoing_inflight_upper_limit(&self) -> Option<u16> {
         self.outgoing_inflight_upper_limit
+    }
+
+    /// Sets a custom socket connector, overriding the default TCP socket creation logic for MQTT connections.
+    ///
+    /// See the similar method [`crate::MqttOptions::set_socket_connector`] for more details.
+    pub fn set_socket_connector<F, Fut>(&mut self, f: F) -> &mut Self
+    where
+        F: Fn(String, NetworkOptions) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = Result<Box<dyn crate::AsyncReadWrite>, std::io::Error>>
+            + Send
+            + 'static,
+    {
+        self.socket_connector = Some(Arc::new(move |host, network_options| {
+            Box::pin(f(host, network_options))
+        }));
+        self
+    }
+
+    /// Returns whether a custom socket connector has been set.
+    pub fn has_socket_connector(&self) -> bool {
+        self.socket_connector.is_some()
+    }
+
+    #[cfg(feature = "proxy")]
+    pub(crate) fn socket_connector(&self) -> Option<SocketConnector> {
+        self.socket_connector.clone()
+    }
+
+    pub(crate) async fn socket_connect(
+        &self,
+        host: String,
+        network_options: NetworkOptions,
+    ) -> std::io::Result<Box<dyn crate::framed::AsyncReadWrite>> {
+        if let Some(ref connector) = self.socket_connector {
+            connector(host, network_options).await
+        } else {
+            let tcp = default_socket_connect(host, network_options).await?;
+            Ok(Box::new(tcp))
+        }
     }
 }
 

--- a/rumqttc/tests/broker.rs
+++ b/rumqttc/tests/broker.rs
@@ -24,7 +24,11 @@ impl Broker {
     pub async fn new(port: u16, connack: u8, session_saved: bool) -> Broker {
         let addr = format!("127.0.0.1:{port}");
         let listener = TcpListener::bind(&addr).await.unwrap();
+        Self::from_listener(listener, connack, session_saved).await
+    }
 
+    /// Create a broker from a pre-bound listener (useful for OS-assigned ports)
+    pub async fn from_listener(listener: TcpListener, connack: u8, session_saved: bool) -> Broker {
         let (stream, _) = listener.accept().await.unwrap();
         let mut framed = Network::new(stream, 10 * 1024);
         let mut incoming = VecDeque::new();

--- a/rumqttc/tests/mqtt_options.rs
+++ b/rumqttc/tests/mqtt_options.rs
@@ -1,0 +1,64 @@
+use rumqttc::{AsyncClient, MqttOptions};
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+use tokio::net::TcpListener;
+
+#[allow(dead_code)]
+mod broker;
+use broker::Broker;
+
+#[tokio::test]
+async fn test_custom_socket_connector() {
+    // Bind to port 0 so the OS assigns a free port, avoiding conflicts with
+    // other tests that may run in parallel.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    // Create a custom connector that wraps the default socket_connect.
+    // This allows us to verify the custom connector path is being used.
+    let called_flag = Arc::new(AtomicBool::new(false));
+    let called_flag_clone = called_flag.clone();
+
+    let mut options = MqttOptions::new("test-client", "127.0.0.1", port);
+    options.set_socket_connector(move |host, network_options| {
+        let called_flag = called_flag_clone.clone();
+        async move {
+            called_flag.store(true, std::sync::atomic::Ordering::Relaxed);
+            rumqttc::default_socket_connect(host, network_options)
+                .await
+                .map(|s| Box::new(s) as Box<dyn rumqttc::AsyncReadWrite>)
+        }
+    });
+
+    // Verify the connector is set
+    assert!(options.has_socket_connector());
+
+    // Create client and eventloop
+    let (_client, mut eventloop) = AsyncClient::new(options, 10);
+
+    // Spawn the event loop in the background so it can start connecting
+    let event_handle = tokio::spawn(async move { eventloop.poll().await.unwrap() });
+
+    // Accept a connection on our pre-bound listener, then hand off to Broker
+    Broker::from_listener(listener, 0, false).await;
+
+    // Wait for the event loop to complete and get the event
+    let event = event_handle.await.unwrap();
+
+    // Make sure the custom connector was the one used
+    assert!(
+        called_flag.load(std::sync::atomic::Ordering::Relaxed),
+        "Custom connector should have been called"
+    );
+
+    // Verify we got a ConnAck event indicating successful connection
+    match event {
+        rumqttc::Event::Incoming(rumqttc::Incoming::ConnAck(connack)) => {
+            assert_eq!(
+                connack.code,
+                rumqttc::mqttbytes::v4::ConnectReturnCode::Success
+            );
+        }
+        other => panic!("Expected ConnAck event, got: {:?}", other),
+    }
+}


### PR DESCRIPTION
Introduce a new `set_socket_connector` method that allows users to provide a custom socket connector function, overriding the default TCP socket creation logic for MQTT connections.

This enables integration with custom networking stacks, such as:
- Custom TLS implementations
- Proxy layers with retry/timeout logic
- Network mocking for tests

The connector receives the host address and network options, and returns a boxed AsyncReadWrite stream. The default behavior remains unchanged when no custom connector is set.

My use-case is wanting to integrate into a hyper-based connector stack with my own retry, timeout and proxy layers.

<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality) 
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [X] Formatted with `cargo fmt`
- [X] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
