### PR TITLE
feat(rumqttc): add openssl tls support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2226,6 +2226,7 @@ dependencies = [
  "log",
  "matches",
  "native-tls",
+ "openssl",
  "pretty_assertions",
  "pretty_env_logger",
  "rustls-native-certs",
@@ -2235,6 +2236,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tokio-native-tls",
+ "tokio-openssl",
  "tokio-rustls 0.26.4",
  "tokio-stream",
  "tokio-util",
@@ -2923,6 +2925,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-openssl"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59df6849caa43bb7567f9a36f863c447d95a11d5903c9cc334ba32576a27eadd"
+dependencies = [
+ "openssl",
+ "openssl-sys",
  "tokio",
 ]
 

--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+* `use-openssl` feature flag to allow using openssl crypto backend
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -20,6 +20,7 @@ default = ["use-rustls"]
 use-rustls = ["use-rustls-no-provider", "tokio-rustls/default"]
 use-rustls-no-provider = ["dep:tokio-rustls", "dep:rustls-webpki", "dep:rustls-pemfile", "dep:rustls-native-certs"]
 use-native-tls = ["dep:tokio-native-tls", "dep:native-tls"]
+use-openssl = ["dep:tokio-openssl", "dep:openssl"]
 websocket = ["dep:async-tungstenite", "dep:ws_stream_tungstenite", "dep:http"]
 proxy = ["dep:async-http-proxy"]
 
@@ -45,6 +46,9 @@ http = { version = "1.0.0", optional = true }
 # native-tls
 tokio-native-tls = { version = "0.3.1", optional = true }
 native-tls = { version = "0.2.12", optional = true }
+# openssl
+tokio-openssl = { version = "0.6", optional = true }
+openssl = { version = "0.10", optional = true }
 # url
 url = { version = "2", default-features = false, optional = true }
 # proxy
@@ -74,6 +78,11 @@ required-features = ["use-native-tls"]
 name = "tls2"
 path = "examples/tls2.rs"
 required-features = ["use-rustls"]
+
+[[example]]
+name = "tls_openssl"
+path = "examples/tls_openssl.rs"
+required-features = ["use-openssl"]
 
 [[example]]
 name = "websocket"

--- a/rumqttc/examples/tls_openssl.rs
+++ b/rumqttc/examples/tls_openssl.rs
@@ -1,0 +1,41 @@
+//! Example of how to configure rumqttc to connect to a server using OpenSSL TLS.
+use std::error::Error;
+
+use rumqttc::{AsyncClient, Event, Incoming, MqttOptions, Transport};
+
+use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn Error>> {
+    pretty_env_logger::init();
+    color_backtrace::install();
+
+    let mut mqttoptions = MqttOptions::new("test-1", "test.mosquitto.org", 8886);
+    mqttoptions.set_keep_alive(std::time::Duration::from_secs(5));
+
+    // Build an OpenSSL connector with default CA roots
+    let mut builder = SslConnector::builder(SslMethod::tls_client())?;
+    builder.set_verify(SslVerifyMode::PEER);
+    builder.set_default_verify_paths()?;
+    let connector = builder.build();
+
+    mqttoptions.set_transport(Transport::tls_with_config(connector.into()));
+
+    let (_client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+
+    loop {
+        match eventloop.poll().await {
+            Ok(Event::Incoming(Incoming::Publish(p))) => {
+                println!("Topic: {}, Payload: {:?}", p.topic, p.payload);
+            }
+            Ok(Event::Incoming(i)) => {
+                println!("Incoming = {i:?}");
+            }
+            Ok(Event::Outgoing(o)) => println!("Outgoing = {o:?}"),
+            Err(e) => {
+                println!("Error = {e:?}");
+                return Ok(());
+            }
+        }
+    }
+}

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -18,7 +18,11 @@ use std::time::Duration;
 #[cfg(unix)]
 use {std::path::Path, tokio::net::UnixStream};
 
-#[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]
+#[cfg(any(
+    feature = "use-rustls-no-provider",
+    feature = "use-native-tls",
+    feature = "use-openssl"
+))]
 use crate::tls;
 
 #[cfg(feature = "websocket")]
@@ -46,7 +50,11 @@ pub enum ConnectionError {
     #[cfg(feature = "websocket")]
     #[error("Websocket Connect: {0}")]
     WsConnect(#[from] http::Error),
-    #[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]
+    #[cfg(any(
+        feature = "use-rustls-no-provider",
+        feature = "use-native-tls",
+        feature = "use-openssl"
+    ))]
     #[error("TLS: {0}")]
     Tls(#[from] tls::Error),
     #[error("I/O: {0}")]
@@ -416,7 +424,11 @@ async fn network_connect(
             options.max_incoming_packet_size,
             options.max_outgoing_packet_size,
         ),
-        #[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]
+        #[cfg(any(
+            feature = "use-rustls-no-provider",
+            feature = "use-native-tls",
+            feature = "use-openssl"
+        ))]
         Transport::Tls(tls_config) => {
             let socket =
                 tls::tls_connect(&options.broker_addr, options.port, &tls_config, tcp_stream)

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -112,7 +112,11 @@ pub mod mqttbytes;
 mod state;
 pub mod v5;
 
-#[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]
+#[cfg(any(
+    feature = "use-rustls-no-provider",
+    feature = "use-native-tls",
+    feature = "use-openssl"
+))]
 mod tls;
 
 #[cfg(feature = "websocket")]
@@ -143,7 +147,11 @@ pub use mqttbytes::*;
 #[cfg(feature = "use-rustls-no-provider")]
 use rustls_native_certs::load_native_certs;
 pub use state::{MqttState, StateError};
-#[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]
+#[cfg(any(
+    feature = "use-rustls-no-provider",
+    feature = "use-native-tls",
+    feature = "use-openssl"
+))]
 pub use tls::Error as TlsError;
 #[cfg(feature = "use-native-tls")]
 pub use tokio_native_tls;
@@ -226,7 +234,11 @@ impl From<Unsubscribe> for Request {
 #[derive(Clone)]
 pub enum Transport {
     Tcp,
-    #[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]
+    #[cfg(any(
+        feature = "use-rustls-no-provider",
+        feature = "use-native-tls",
+        feature = "use-openssl"
+    ))]
     Tls(TlsConfiguration),
     #[cfg(unix)]
     Unix,
@@ -274,7 +286,11 @@ impl Transport {
         Self::tls_with_config(config)
     }
 
-    #[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]
+    #[cfg(any(
+        feature = "use-rustls-no-provider",
+        feature = "use-native-tls",
+        feature = "use-openssl"
+    ))]
     pub fn tls_with_config(tls_config: TlsConfiguration) -> Self {
         Self::Tls(tls_config)
     }
@@ -332,7 +348,11 @@ impl Transport {
 
 /// TLS configuration method
 #[derive(Clone, Debug)]
-#[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]
+#[cfg(any(
+    feature = "use-rustls-no-provider",
+    feature = "use-native-tls",
+    feature = "use-openssl"
+))]
 pub enum TlsConfiguration {
     #[cfg(feature = "use-rustls-no-provider")]
     Simple {
@@ -360,6 +380,19 @@ pub enum TlsConfiguration {
     #[cfg(feature = "use-native-tls")]
     /// Injected native-tls TlsConnector for TLS, to allow more customisation.
     NativeConnector(TlsConnector),
+    #[cfg(feature = "use-openssl")]
+    /// Simple OpenSSL configuration with CA cert and optional client auth.
+    SimpleOpenSsl {
+        /// ca certificate (PEM)
+        ca: Vec<u8>,
+        /// alpn settings
+        alpn: Option<Vec<Vec<u8>>>,
+        /// tls client_authentication (cert PEM, key PEM)
+        client_auth: Option<(Vec<u8>, Vec<u8>)>,
+    },
+    #[cfg(feature = "use-openssl")]
+    /// Injected OpenSSL SslConnector for TLS, to allow more customisation.
+    OpenSsl(openssl::ssl::SslConnector),
 }
 
 #[cfg(feature = "use-rustls-no-provider")]
@@ -388,6 +421,13 @@ impl From<ClientConfig> for TlsConfiguration {
 impl From<TlsConnector> for TlsConfiguration {
     fn from(connector: TlsConnector) -> Self {
         TlsConfiguration::NativeConnector(connector)
+    }
+}
+
+#[cfg(feature = "use-openssl")]
+impl From<openssl::ssl::SslConnector> for TlsConfiguration {
+    fn from(connector: openssl::ssl::SslConnector) -> Self {
+        TlsConfiguration::OpenSsl(connector)
     }
 }
 

--- a/rumqttc/src/tls.rs
+++ b/rumqttc/src/tls.rs
@@ -28,6 +28,9 @@ use tokio_native_tls::native_tls::{Error as NativeTlsError, Identity};
 use std::io;
 use std::net::AddrParseError;
 
+#[cfg(feature = "use-openssl")]
+use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Error parsing IP address
@@ -63,6 +66,12 @@ pub enum Error {
     #[cfg(feature = "use-native-tls")]
     #[error("Native TLS error {0}")]
     NativeTls(#[from] NativeTlsError),
+    #[cfg(feature = "use-openssl")]
+    #[error("OpenSSL error: {0}")]
+    OpenSsl(#[from] openssl::error::ErrorStack),
+    #[cfg(feature = "use-openssl")]
+    #[error("OpenSSL handshake error: {0}")]
+    OpenSslHandshake(String),
 }
 
 #[cfg(feature = "use-rustls-no-provider")]
@@ -163,6 +172,51 @@ pub async fn native_tls_connector(
     Ok(connector.into())
 }
 
+#[cfg(feature = "use-openssl")]
+pub fn openssl_connector(tls_config: &TlsConfiguration) -> Result<SslConnector, Error> {
+    let connector = match tls_config {
+        TlsConfiguration::SimpleOpenSsl {
+            ca,
+            alpn,
+            client_auth,
+        } => {
+            let mut builder = SslConnector::builder(SslMethod::tls_client())?;
+            builder.set_verify(SslVerifyMode::PEER);
+
+            // Load CA certificate
+            let ca_cert = openssl::x509::X509::from_pem(ca)?;
+            builder.cert_store_mut().add_cert(ca_cert)?;
+
+            // Load client auth if provided
+            if let Some((cert_pem, key_pem)) = client_auth {
+                let cert = openssl::x509::X509::from_pem(cert_pem)?;
+                let key = openssl::pkey::PKey::private_key_from_pem(key_pem)?;
+                builder.set_certificate(&cert)?;
+                builder.set_private_key(&key)?;
+                builder.check_private_key()?;
+            }
+
+            // Set ALPN protocols
+            if let Some(alpn) = alpn {
+                // OpenSSL ALPN wire format: each protocol prefixed with its length byte
+                let mut wire = Vec::new();
+                for proto in alpn {
+                    wire.push(proto.len() as u8);
+                    wire.extend_from_slice(proto);
+                }
+                builder.set_alpn_protos(&wire)?;
+            }
+
+            builder.build()
+        }
+        TlsConfiguration::OpenSsl(connector) => connector.clone(),
+        #[allow(unreachable_patterns)]
+        _ => unreachable!("This cannot be called for other TLS backends than OpenSSL"),
+    };
+
+    Ok(connector)
+}
+
 pub async fn tls_connect(
     addr: &str,
     _port: u16,
@@ -182,6 +236,18 @@ pub async fn tls_connect(
         | TlsConfiguration::SimpleNative { .. } => {
             let connector = native_tls_connector(tls_config).await?;
             Box::new(connector.connect(addr, tcp).await?)
+        }
+        #[cfg(feature = "use-openssl")]
+        TlsConfiguration::SimpleOpenSsl { .. } | TlsConfiguration::OpenSsl(_) => {
+            let connector = openssl_connector(tls_config)?;
+            let ssl = connector.configure()?.into_ssl(addr)?;
+            let mut stream = Box::pin(tokio_openssl::SslStream::new(ssl, tcp)?);
+            stream
+                .as_mut()
+                .connect()
+                .await
+                .map_err(|e| Error::OpenSslHandshake(e.to_string()))?;
+            Box::new(stream)
         }
         #[allow(unreachable_patterns)]
         _ => panic!("Unknown or not enabled TLS backend configuration"),

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -15,7 +15,11 @@ use std::time::Duration;
 
 use super::mqttbytes::v5::ConnectReturnCode;
 
-#[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]
+#[cfg(any(
+    feature = "use-rustls-no-provider",
+    feature = "use-native-tls",
+    feature = "use-openssl"
+))]
 use crate::tls;
 
 #[cfg(unix)]
@@ -44,7 +48,11 @@ pub enum ConnectionError {
     #[cfg(feature = "websocket")]
     #[error("Websocket Connect: {0}")]
     WsConnect(#[from] http::Error),
-    #[cfg(any(feature = "use-rustls-no-provider", feature = "use-native-tls"))]
+    #[cfg(any(
+        feature = "use-rustls-no-provider",
+        feature = "use-native-tls",
+        feature = "use-openssl"
+    ))]
     #[error("TLS: {0}")]
     Tls(#[from] tls::Error),
     #[error("I/O: {0}")]
@@ -340,7 +348,11 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
 
     let network = match options.transport() {
         Transport::Tcp => Network::new(tcp_stream, max_incoming_pkt_size),
-        #[cfg(any(feature = "use-native-tls", feature = "use-rustls-no-provider"))]
+        #[cfg(any(
+            feature = "use-native-tls",
+            feature = "use-rustls-no-provider",
+            feature = "use-openssl"
+        ))]
         Transport::Tls(tls_config) => {
             let socket =
                 tls::tls_connect(&options.broker_addr, options.port, &tls_config, tcp_stream)

--- a/rumqttc/src/v5/mod.rs
+++ b/rumqttc/src/v5/mod.rs
@@ -25,7 +25,11 @@ pub use client::{
 pub use eventloop::{ConnectionError, Event, EventLoop};
 pub use state::{MqttState, StateError};
 
-#[cfg(feature = "use-rustls-no-provider")]
+#[cfg(any(
+    feature = "use-rustls-no-provider",
+    feature = "use-native-tls",
+    feature = "use-openssl"
+))]
 pub use crate::tls::Error as TlsError;
 
 #[cfg(feature = "proxy")]


### PR DESCRIPTION
This commit adds openssl as an additional backend for tls connections gated behind the use-openssl feature.

Using openssl allows using the full feature set of openssl in establishing tls connections. For example with tss2-openssl you can keep your private key protected inside the tpm.

If use-openssl is enabled openssl and tokio-openssl are pulled in as additional dependencies.

<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [X] Formatted with `cargo fmt`
- [X] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
