### PR TITLE
fix(v5): Protocol Error on invalid property values

### DIFF
--- a/rumqttc/src/v5/mqttbytes/v5/connack.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/connack.rs
@@ -233,7 +233,12 @@ impl ConnAckProperties {
                     cursor += 4;
                 }
                 PropertyType::ReceiveMaximum => {
-                    receive_max = Some(read_u16(bytes)?);
+                    let val = read_u16(bytes)?;
+                    // MQTT 5.0 §3.2.2.3.3: Receive Maximum value of 0 is not permitted
+                    if val == 0 {
+                        return Err(Error::MalformedPacket);
+                    }
+                    receive_max = Some(val);
                     cursor += 2;
                 }
                 PropertyType::MaximumQos => {
@@ -526,5 +531,67 @@ mod test {
 
         assert_eq!(size_from_write, size_from_bytes);
         assert_eq!(size_from_size, size_from_bytes);
+    }
+
+    #[test]
+    fn connack_with_all_properties() {
+        let props = ConnAckProperties {
+            session_expiry_interval: Some(120),
+            receive_max: Some(100),
+            max_qos: Some(1),
+            retain_available: Some(1),
+            max_packet_size: Some(65536),
+            assigned_client_identifier: Some("server-assigned-id".to_string()),
+            topic_alias_max: Some(10),
+            reason_string: Some("all good".to_string()),
+            user_properties: vec![("key".to_string(), "value".to_string())],
+            wildcard_subscription_available: Some(1),
+            subscription_identifiers_available: Some(1),
+            shared_subscription_available: Some(0),
+            server_keep_alive: Some(30),
+            response_information: Some("/response".to_string()),
+            server_reference: Some("other.broker.example".to_string()),
+            authentication_method: Some("PLAIN".to_string()),
+            authentication_data: Some(bytes::Bytes::from(vec![1, 2, 3])),
+        };
+
+        let pkt = ConnAck {
+            session_present: true,
+            code: ConnectReturnCode::Success,
+            properties: Some(props.clone()),
+        };
+
+        let mut buf = BytesMut::new();
+        pkt.write(&mut buf).unwrap();
+
+        let fixed_header = super::super::check(buf.iter(), None).unwrap();
+        let decoded = ConnAck::read(fixed_header, buf.freeze()).unwrap();
+
+        assert_eq!(decoded.session_present, true);
+        assert_eq!(decoded.code, ConnectReturnCode::Success);
+        assert_eq!(decoded.properties.unwrap(), props);
+    }
+
+    #[test]
+    fn connack_receive_maximum_zero_rejected() {
+        // Craft a CONNACK with Receive Maximum property (0x21) = 0, which is forbidden
+        let inner = [
+            0x00u8, // session_present flags
+            0x00,   // return code = Success
+            0x03,   // properties length = 3
+            0x21,   // property id: Receive Maximum
+            0x00, 0x00, // value = 0 (invalid)
+        ];
+        let mut stream = BytesMut::new();
+        stream.put_u8(0x20); // CONNACK type
+        stream.put_u8(inner.len() as u8); // remaining length
+        stream.extend_from_slice(&inner);
+
+        let fixed_header = super::super::check(stream.iter(), None).unwrap();
+        let pkt = stream.freeze();
+        assert!(matches!(
+            ConnAck::read(fixed_header, pkt),
+            Err(Error::MalformedPacket)
+        ));
     }
 }

--- a/rumqttc/src/v5/mqttbytes/v5/connect.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/connect.rs
@@ -199,7 +199,12 @@ impl ConnectProperties {
                     cursor += 4;
                 }
                 PropertyType::ReceiveMaximum => {
-                    receive_maximum = Some(read_u16(bytes)?);
+                    let val = read_u16(bytes)?;
+                    // MQTT 5.0 §3.1.2.11.3: Receive Maximum value of 0 is not permitted
+                    if val == 0 {
+                        return Err(Error::MalformedPacket);
+                    }
+                    receive_maximum = Some(val);
                     cursor += 2;
                 }
                 PropertyType::MaximumPacketSize => {
@@ -690,5 +695,19 @@ mod test {
         let size_from_bytes = dummy_bytes.len();
 
         assert_eq!(reported_size, size_from_bytes);
+    }
+
+    #[test]
+    fn connect_receive_maximum_zero_rejected() {
+        // Property id=0x21 (Receive Maximum), value=0x0000 — value 0 is not permitted
+        let props_payload = [0x21u8, 0x00, 0x00];
+        let mut buf = bytes::BytesMut::new();
+        buf.put_u8(props_payload.len() as u8); // properties length VBI
+        buf.extend_from_slice(&props_payload);
+        let mut b = buf.freeze();
+        assert!(matches!(
+            ConnectProperties::read(&mut b),
+            Err(Error::MalformedPacket)
+        ));
     }
 }

--- a/rumqttc/src/v5/mqttbytes/v5/publish.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/publish.rs
@@ -205,7 +205,13 @@ impl PublishProperties {
                     cursor += 4;
                 }
                 PropertyType::TopicAlias => {
-                    topic_alias = Some(read_u16(bytes)?);
+                    let alias = read_u16(bytes)?;
+                    // MQTT 5.0 §3.3.2.3.4: Topic Alias value of 0 is not permitted
+                    // TODO: disconnect with reason code 0x94 (Topic Alias Invalid)
+                    if alias == 0 {
+                        return Err(Error::MalformedPacket);
+                    }
+                    topic_alias = Some(alias);
                     cursor += 2;
                 }
                 PropertyType::ResponseTopic => {
@@ -336,5 +342,20 @@ mod test {
 
         assert_eq!(size_from_write, size_from_bytes);
         assert_eq!(size_from_size, size_from_bytes);
+    }
+
+    #[test]
+    fn publish_topic_alias_zero_rejected() {
+        // Build PublishProperties bytes with Topic Alias = 0 (property id 0x23)
+        // properties: id=0x23, value=0x0000
+        let props = [0x23u8, 0x00, 0x00];
+        let mut buf = bytes::BytesMut::new();
+        buf.put_u8(props.len() as u8); // properties length VBI
+        buf.extend_from_slice(&props);
+        let mut b = buf.freeze();
+        assert!(matches!(
+            PublishProperties::read(&mut b),
+            Err(Error::MalformedPacket)
+        ));
     }
 }

--- a/rumqttc/src/v5/mqttbytes/v5/subscribe.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/subscribe.rs
@@ -233,7 +233,10 @@ impl SubscribeProperties {
             match property(prop)? {
                 PropertyType::SubscriptionIdentifier => {
                     let (id_len, sub_id) = length(bytes.iter())?;
-                    // TODO: Validate 1 +. Tests are working either way
+                    // MQTT 5.0 §3.8.2.1.2: Subscription Identifier MUST be between 1 and 268,435,455
+                    if sub_id == 0 {
+                        return Err(Error::MalformedPacket);
+                    }
                     cursor += 1 + id_len;
                     bytes.advance(id_len);
                     id = Some(sub_id)
@@ -301,5 +304,20 @@ mod test {
 
         assert_eq!(size_from_write, size_from_bytes);
         assert_eq!(size_from_size, size_from_bytes);
+    }
+
+    #[test]
+    fn subscribe_identifier_zero_rejected() {
+        // Build SubscribeProperties bytes with Subscription Identifier = 0
+        // property id=0x0B, value=0x00 (VBI encoding of 0)
+        let props = [0x0Bu8, 0x00];
+        let mut buf = bytes::BytesMut::new();
+        buf.put_u8(props.len() as u8); // properties length VBI
+        buf.extend_from_slice(&props);
+        let mut b = buf.freeze();
+        assert!(matches!(
+            SubscribeProperties::read(&mut b),
+            Err(Error::MalformedPacket)
+        ));
     }
 }


### PR DESCRIPTION
Fixes three cases where MQTT 5.0 property values of `0` were silently accepted instead of rejected with a Protocol Error.

<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

  | Packet | Property | Spec | Forbidden value |
  |---|---|---|---|
  | `SUBSCRIBE` | Subscription Identifier | [§3.8.2.1.2](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901166) | `0` — valid range is 1–268,435,455 |
  | `PUBLISH` | Topic Alias | [§3.3.2.3.4](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901113) | `0` — aliases should not have value 0 |
  | `CONNECT` / `CONNACK` | Receive Maximum | [§3.1.2.11.3](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901049), [§3.2.2.3.3](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901083) | `0` — would mean no in-flight messages permitted |

  Each case now returns `Error::MalformedPacket` on parse and is covered by a test that constructs the raw bytes directly.

 
>  **Note:** the spec requires sending a `DISCONNECT` with a specific reason code for each violation (respectively `0x82`, `0x94`, `0x82`). This is not yet done — the error surfaces as a connection drop rather than a clean disconnect. See the `TODO` code comments.



<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [x] Formatted with `cargo fmt`
- [ ] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
