### PR TITLE
feat(rumqttd): configurable protocol version for WebSocket listeners

### DIFF
--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -109,6 +109,14 @@ impl TlsConfig {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ProtocolVersion {
+    #[default]
+    V4,
+    V5,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ServerSettings {
     pub name: String,
@@ -116,6 +124,9 @@ pub struct ServerSettings {
     pub tls: Option<TlsConfig>,
     pub next_connection_delay_ms: u64,
     pub connections: ConnectionSettings,
+    /// Protocol version for WebSocket listeners (default: v4 for backward compat)
+    #[serde(default)]
+    pub protocol: ProtocolVersion,
 }
 
 impl ServerSettings {

--- a/rumqttd/src/server/broker.rs
+++ b/rumqttd/src/server/broker.rs
@@ -9,7 +9,7 @@ use crate::protocol::v5::V5;
 use crate::protocol::{Packet, Protocol};
 #[cfg(any(feature = "use-rustls", feature = "use-native-tls"))]
 use crate::server::tls::{self, TLSAcceptor};
-use crate::{meters, ConnectionSettings, Meter};
+use crate::{meters, ConnectionSettings, Meter, ProtocolVersion};
 use flume::{RecvError, SendError, Sender};
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -247,15 +247,26 @@ impl Broker {
         if let Some(ws_config) = &self.config.ws {
             for (_, config) in ws_config.clone() {
                 let server_thread = thread::Builder::new().name(config.name.clone());
-                //TODO: Add support for V5 procotol with websockets. Registered in config or on ServerSettings
-                let mut server = Server::new(config, self.router_tx.clone(), V4);
+                let router_tx = self.router_tx.clone();
+                let protocol = config.protocol.clone();
                 let handle = server_thread.spawn(move || {
                     let mut runtime = tokio::runtime::Builder::new_current_thread();
                     let runtime = runtime.enable_all().build().unwrap();
 
                     runtime.block_on(async {
-                        if let Err(e) = server.start(LinkType::Websocket).await {
-                            error!(error=?e, "Server error - WS");
+                        match protocol {
+                            ProtocolVersion::V4 => {
+                                let mut server = Server::new(config, router_tx, V4);
+                                if let Err(e) = server.start(LinkType::Websocket).await {
+                                    error!(error=?e, "Server error - WS/V4");
+                                }
+                            }
+                            ProtocolVersion::V5 => {
+                                let mut server = Server::new(config, router_tx, V5);
+                                if let Err(e) = server.start(LinkType::Websocket).await {
+                                    error!(error=?e, "Server error - WS/V5");
+                                }
+                            }
                         }
                     });
                 })?;


### PR DESCRIPTION
## Summary

WebSocket listeners are currently hardcoded to MQTT v4 (`broker.rs:251`), with a TODO comment:
```rust
//TODO: Add support for V5 procotol with websockets. Registered in config or on ServerSettings
```

This PR resolves that TODO by adding a `protocol` field to `ServerSettings`.

## Changes (~27 LOC, 2 files)

### `src/lib.rs`
- Add `ProtocolVersion` enum (`V4`, `V5`) with serde support and `Default = V4`
- Add `#[serde(default)] pub protocol: ProtocolVersion` to `ServerSettings`

### `src/server/broker.rs`
- Import `ProtocolVersion`
- Match on `config.protocol` when spawning WS servers → `Server<V4>` or `Server<V5>`

## Config example

```toml
# Default (backward compatible) — MQTT v4 over WebSocket
[ws.1]
name = "ws-v4"
listen = "0.0.0.0:8883"
next_connection_delay_ms = 1

# New — MQTT v5 over WebSocket
[ws.2]
name = "ws-v5"
listen = "0.0.0.0:8884"
next_connection_delay_ms = 1
protocol = "v5"
```

## Backward compatibility

- `protocol` defaults to `v4` via `#[serde(default)]`, so existing configs work unchanged
- No changes to v4/v5 TCP listeners, network layer, or handshake logic

## Testing

Tested with:
- Python paho-mqtt (MQTTv5 over WebSocket) — connect, publish, subscribe, request-response with `response_topic` + `correlation_data`
- mqtt.js browser client (protocolVersion: 5 over WS)
- All v5 features (response_topic, correlation_data) work correctly over WebSocket
