### PR TITLE
perf(v4): only one never ending sleep

### DIFF
--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -84,6 +84,9 @@ pub struct EventLoop {
     pub network: Option<Network>,
     /// Keep alive time
     keepalive_timeout: Option<Pin<Box<Sleep>>>,
+    /// Dummy sleep used as a placeholder in select! when keepalive is disabled.
+    /// Initialized once with Duration::MAX so that it never fires.
+    no_sleep: Option<Pin<Box<Sleep>>>,
     pub network_options: NetworkOptions,
 }
 
@@ -113,6 +116,7 @@ impl EventLoop {
             pending,
             network: None,
             keepalive_timeout: None,
+            no_sleep: None,
             network_options: NetworkOptions::new(),
         }
     }
@@ -194,7 +198,9 @@ impl EventLoop {
             return Ok(event);
         }
 
-        let mut no_sleep = Box::pin(time::sleep(Duration::ZERO));
+        let no_sleep = self
+            .no_sleep
+            .get_or_insert_with(|| Box::pin(time::sleep(Duration::MAX)));
         // this loop is necessary since self.incoming.pop_front() might return None. In that case,
         // instead of returning a None event, we try again.
         select! {
@@ -255,7 +261,7 @@ impl EventLoop {
             },
             // We generate pings irrespective of network activity. This keeps the ping logic
             // simple. We can change this behavior in future if necessary (to prevent extra pings)
-            _ = self.keepalive_timeout.as_mut().unwrap_or(&mut no_sleep),
+            _ = self.keepalive_timeout.as_mut().unwrap_or(no_sleep),
                 if self.keepalive_timeout.is_some() && !self.mqtt_options.keep_alive.is_zero() => {
                 let timeout = self.keepalive_timeout.as_mut().unwrap();
                 timeout.as_mut().reset(Instant::now() + self.mqtt_options.keep_alive);


### PR DESCRIPTION
Fewer allocations when keep-alive is not set => better performance

Using a [perf benchmark](https://github.com/bytebeamio/rumqtt/compare/main...de-sh:rumqtt:bench/throughput?expand=1) against the client, I was able to confirm 2x througput and ~N fewer allocations.

| Metric | bench/throughput (baseline) | perf/lazy-sleep-alloc (fix) | Delta |
  |---|---|---|---|
  | fresh — total bytes | 2,274,000 | 1,235,664 | −45.6% |
  | fresh — total blocks | 40,141 | 30,157 | −9,984 allocs |
  | reused — total bytes | 2,274,024 | 1,235,688 | −45.6% |
  | reused — total blocks | 40,142 | 30,158 | −9,984 allocs |
  | time / 10k msgs (fresh) | 158.8 ms | 78.8 ms | −50% / 2× faster |
  | time / 10k msgs (reused) | 152.4 ms | 75.4 ms | −50% / 2× faster |

### Regarding the `Duration::MAX` change

This was a latent spin hazard. `sleep(Duration::ZERO)` produces a future that is ready instantly. If that `select!` branch fires on every call to `select()`. That would be a silent busy-loop: no panic, no log, just 100% CPU usage and also, no keepalives sent, which is why `Duration::MAX` makes more sense here.

<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

Performance improvement, should not break anything. Impact is clearest against v4 EventLoop that that has no keepalive configured.
<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [ ] Formatted with `cargo fmt`
- [ ] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
