### PR TITLE
fix(simplerouter): use `write_all` instead of `write` in send_data

### DIFF
--- a/benchmarks/simplerouter/src/network.rs
+++ b/benchmarks/simplerouter/src/network.rs
@@ -93,10 +93,8 @@ impl Network {
     }
 
     pub(crate) async fn send_data(&mut self, data: &Bytes) -> Result<(), Error> {
-        debug!(
-            "network: sent {} bytes",
-            self.stream.write(data.as_ref()).await?
-        );
+        self.stream.write_all(data.as_ref()).await?;
+        debug!("network: sent {} bytes", data.len());
         Ok(())
     }
 }


### PR DESCRIPTION
`AsyncWriteExt::write` can perform partial writes when the TCP send buffer is under pressure. `send_data` silently discarded the byte count and returned early, so `PUBACK` and `CONNACK` packets were silently truncated under benchmark load. The client saw malformed frames, disconnected, and reconnected in a loop, making throughput numbers meaningless and profiling data invalid.

Switches to `write_all`, which retries internally until every byte is sent or returns an error if it fails.

<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [ ] Formatted with `cargo fmt`
- [ ] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
