### PR TITLE
perf(v5): replace `copy_from_slice` in `Publish::new` and `LastWill::new`

### DIFF
--- a/rumqttc/src/v5/client.rs
+++ b/rumqttc/src/v5/client.rs
@@ -83,11 +83,13 @@ impl AsyncClient {
         S: Into<String>,
         P: Into<Bytes>,
     {
-        let topic = topic.into();
-        let mut publish = Publish::new(&topic, qos, payload, properties);
+        let topic: String = topic.into();
+        let topic_valid = valid_topic(&topic);
+        let topic_bytes = Bytes::from(topic.into_bytes());
+        let mut publish = Publish::new(topic_bytes, qos, payload, properties);
         publish.retain = retain;
         let publish = Request::Publish(publish);
-        if !valid_topic(&topic) {
+        if !topic_valid {
             return Err(ClientError::Request(publish));
         }
         self.request_tx.send_async(publish).await?;
@@ -137,11 +139,13 @@ impl AsyncClient {
         S: Into<String>,
         P: Into<Bytes>,
     {
-        let topic = topic.into();
-        let mut publish = Publish::new(&topic, qos, payload, properties);
+        let topic: String = topic.into();
+        let topic_valid = valid_topic(&topic);
+        let topic_bytes = Bytes::from(topic.into_bytes());
+        let mut publish = Publish::new(topic_bytes, qos, payload, properties);
         publish.retain = retain;
         let publish = Request::Publish(publish);
-        if !valid_topic(&topic) {
+        if !topic_valid {
             return Err(ClientError::TryRequest(publish));
         }
         self.request_tx.try_send(publish)?;
@@ -208,11 +212,13 @@ impl AsyncClient {
     where
         S: Into<String>,
     {
-        let topic = topic.into();
-        let mut publish = Publish::new(&topic, qos, payload, properties);
+        let topic: String = topic.into();
+        let topic_valid = valid_topic(&topic);
+        let topic_bytes = Bytes::from(topic.into_bytes());
+        let mut publish = Publish::new(topic_bytes, qos, payload, properties);
         publish.retain = retain;
         let publish = Request::Publish(publish);
-        if !valid_topic(&topic) {
+        if !topic_valid {
             return Err(ClientError::TryRequest(publish));
         }
         self.request_tx.send_async(publish).await?;
@@ -508,11 +514,13 @@ impl Client {
         S: Into<String>,
         P: Into<Bytes>,
     {
-        let topic = topic.into();
-        let mut publish = Publish::new(&topic, qos, payload, properties);
+        let topic: String = topic.into();
+        let topic_valid = valid_topic(&topic);
+        let topic_bytes = Bytes::from(topic.into_bytes());
+        let mut publish = Publish::new(topic_bytes, qos, payload, properties);
         publish.retain = retain;
         let publish = Request::Publish(publish);
-        if !valid_topic(&topic) {
+        if !topic_valid {
             return Err(ClientError::Request(publish));
         }
         self.client.request_tx.send(publish)?;

--- a/rumqttc/src/v5/mqttbytes/v5/connect.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/connect.rs
@@ -371,7 +371,7 @@ impl LastWill {
         retain: bool,
         properties: Option<LastWillProperties>,
     ) -> LastWill {
-        let topic = Bytes::copy_from_slice(topic.into().as_bytes());
+        let topic = Bytes::from(topic.into());
         LastWill {
             topic,
             message: Bytes::from(payload.into()),

--- a/rumqttc/src/v5/mqttbytes/v5/publish.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/publish.rs
@@ -20,7 +20,7 @@ impl Publish {
         payload: P,
         properties: Option<PublishProperties>,
     ) -> Self {
-        let topic = Bytes::copy_from_slice(topic.into().as_bytes());
+        let topic = Bytes::from(topic.into());
         Self {
             qos,
             topic,

--- a/rumqttc/src/v5/mqttbytes/v5/publish.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/publish.rs
@@ -14,7 +14,7 @@ pub struct Publish {
 }
 
 impl Publish {
-    pub fn new<T: Into<String>, P: Into<Bytes>>(
+    pub fn new<T: Into<Bytes>, P: Into<Bytes>>(
         topic: T,
         qos: QoS,
         payload: P,


### PR DESCRIPTION
Both used `Bytes::copy_from_slice`, which allocates a String and copies its bytes into a second Bytes allocation before dropping the String. Replace with `Bytes::from` to take ownership of the String's buffer directly — same approach as the v4 Publish constructor — cutting the topic allocation count from 2, down to 1 per publish.

benchmarked with [bench/throughput](https://github.com/bytebeamio/rumqtt/compare/main...de-sh:rumqtt:bench/throughput?expand=1)

  |      Scenario       |    Before     |           After             |
  | --- | --- | --- |
  | fresh (Vec/msg)      | 40,157 blocks | 30,157 blocks (–1 alloc/msg) |
  | reused (Bytes clone) | 30,158 blocks | 20,158 blocks (–1 alloc/msg) |

<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [ ] Formatted with `cargo fmt`
- [ ] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
