### PR TITLE
fix(rumqttc): support binary passwords in Login

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed
+- Use `Vec<u8>` for password in `Login` to comply with MQTT 5.0 spec
+
 ### Deprecated
 ### Removed
 ### Fixed 

--- a/rumqttc/src/v5/mod.rs
+++ b/rumqttc/src/v5/mod.rs
@@ -267,7 +267,7 @@ impl MqttOptions {
     }
 
     /// Username and password
-    pub fn set_credentials<U: Into<String>, P: Into<String>>(
+    pub fn set_credentials<U: Into<String>, P: Into<Vec<u8>>>(
         &mut self,
         username: U,
         password: P,

--- a/rumqttc/src/v5/mqttbytes/v5/connect.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/connect.rs
@@ -606,11 +606,11 @@ impl LastWillProperties {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Login {
     pub username: String,
-    pub password: String,
+    pub password: Vec<u8>,
 }
 
 impl Login {
-    pub fn new<U: Into<String>, P: Into<String>>(u: U, p: P) -> Login {
+    pub fn new<U: Into<String>, P: Into<Vec<u8>>>(u: U, p: P) -> Login {
         Login {
             username: u.into(),
             password: p.into(),
@@ -624,11 +624,11 @@ impl Login {
         };
 
         let password = match connect_flags & 0b0100_0000 {
-            0 => String::new(),
-            _ => read_mqtt_string(bytes)?,
+            0 => Vec::new(),
+            _ => read_mqtt_bytes(bytes)?.to_vec(),
         };
 
-        if username.is_empty() && password.is_empty() {
+        if username.is_empty() && password.len() == 0 {
             Ok(None)
         } else {
             Ok(Some(Login { username, password }))
@@ -658,7 +658,7 @@ impl Login {
 
         if !self.password.is_empty() {
             connect_flags |= 0x40;
-            write_mqtt_string(buffer, &self.password);
+            write_mqtt_bytes(buffer, &self.password);
         }
 
         connect_flags


### PR DESCRIPTION
Closes: https://github.com/bytebeamio/rumqtt/issues/1044

## Type of change

Change the password field in the Login struct (v5) from String to Vec<u8>, aligning with the MQTT 5.0 spec, which defines the Password as Binary Data.

## Checklist:

- [ x] Formatted with `cargo fmt`
- [ x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
