### PR TITLE
feat(rumqttd): expose retain flag on local LinkTx publish

### DIFF
--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `local::LinkTx::publish_with_retain` and
+  `local::LinkTx::try_publish_with_retain` for in-process callers
+  that need to seed the retained store with a custom retain flag.
+  Existing `publish` / `try_publish` keep the previous
+  `retain: false` behaviour and now delegate.
 ### Changed
 ### Deprecated
 ### Removed

--- a/rumqttd/src/link/local.rs
+++ b/rumqttd/src/link/local.rs
@@ -211,8 +211,30 @@ impl LinkTx {
         Ok(())
     }
 
-    /// Sends a MQTT Publish to the router
+    /// Sends a MQTT Publish to the router with `retain: false`.
     pub fn publish<S, V>(&mut self, topic: S, payload: V) -> Result<usize, LinkError>
+    where
+        S: Into<Bytes>,
+        V: Into<Bytes>,
+    {
+        self.publish_with_retain(topic, payload, false)
+    }
+
+    /// Sends a MQTT Publish to the router with an explicit retain flag.
+    ///
+    /// Useful for embedded-broker setups that need to seed the
+    /// retained store with snapshot-class topics from a local
+    /// data source (a captured fixture, an SQLite snapshot, ...)
+    /// before any external client connects. Without this method
+    /// callers either had to spin up a loopback rumqttc client to
+    /// publish-with-retain over the wire, or wait for the next live
+    /// publish to populate the retained store.
+    pub fn publish_with_retain<S, V>(
+        &mut self,
+        topic: S,
+        payload: V,
+        retain: bool,
+    ) -> Result<usize, LinkError>
     where
         S: Into<Bytes>,
         V: Into<Bytes>,
@@ -220,7 +242,7 @@ impl LinkTx {
         let publish = Publish {
             dup: false,
             qos: QoS::AtMostOnce,
-            retain: false,
+            retain,
             topic: topic.into(),
             pkid: 0,
             payload: payload.into(),
@@ -230,8 +252,23 @@ impl LinkTx {
         Ok(len)
     }
 
-    /// Sends a MQTT Publish to the router
+    /// Sends a MQTT Publish to the router with `retain: false`.
     pub fn try_publish<S, V>(&mut self, topic: S, payload: V) -> Result<usize, LinkError>
+    where
+        S: Into<Bytes>,
+        V: Into<Bytes>,
+    {
+        self.try_publish_with_retain(topic, payload, false)
+    }
+
+    /// Sends a MQTT Publish to the router (non-blocking) with an
+    /// explicit retain flag. See [`LinkTx::publish_with_retain`].
+    pub fn try_publish_with_retain<S, V>(
+        &mut self,
+        topic: S,
+        payload: V,
+        retain: bool,
+    ) -> Result<usize, LinkError>
     where
         S: Into<Bytes>,
         V: Into<Bytes>,
@@ -239,7 +276,7 @@ impl LinkTx {
         let publish = Publish {
             dup: false,
             qos: QoS::AtMostOnce,
-            retain: false,
+            retain,
             topic: topic.into(),
             pkid: 0,
             payload: payload.into(),


### PR DESCRIPTION
## Type of change

New feature (non-breaking change which adds functionality).

## What this fixes

`local::LinkTx::publish` and `try_publish` hardcode `retain: false` (`rumqttd/src/link/local.rs:223,242`), which prevents an in-process publisher from seeding the broker's retained store. Anyone embedding `rumqttd` and wanting to serve a snapshot to late subscribers on first SUBSCRIBE has had to either:

- spin up a loopback `rumqttc` client and publish-with-retain over the wire (extra dependency, extra connect/CONNACK race window), or
- wait for the next live publish to land before retained delivery kicks in.

## What this PR does

Add two thin wrappers that take an explicit retain flag:

```rust
pub fn publish_with_retain<S, V>(&mut self, topic: S, payload: V, retain: bool) -> Result<usize, LinkError>
pub fn try_publish_with_retain<S, V>(&mut self, topic: S, payload: V, retain: bool) -> Result<usize, LinkError>
```

The existing `publish` and `try_publish` keep their previous behaviour (`retain: false`) and now delegate, so the change is fully backwards-compatible.

## Use case

`ec-ui-light` (a Tauri desktop app that ships an embedded `rumqttd` to replay captured Victron MQTT fixtures) needs to seed the retained store with a small set of dashboard-critical topics (`system/0/Serial`, `system/0/Dc/Battery/Soc`, `system/0/Ac/Grid/...`) before the WebView's MQTT client subscribes. Doing this through a loopback `rumqttc` client raced the WebView's first SUBSCRIBE; calling `publish_with_retain` directly on a freshly-built `LinkTx` populates the retained store synchronously and the race goes away.

## Checklist

- [x] Formatted with `cargo fmt`
- [x] CHANGELOG entry added under `[Unreleased]`
- [x] Backwards-compatible — existing callers see no behaviour change
