### PR TITLE
rumqttc: emit Event::Reconnect on successful re-CONNACK (closes #250)

### DIFF
--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -82,6 +82,10 @@ pub struct EventLoop {
     network: Option<Network>,
     /// Keep alive time
     keepalive_timeout: Option<Pin<Box<Sleep>>>,
+    /// True once the first connect succeeded. Used to distinguish the
+    /// initial CONNACK from a reconnect CONNACK so we can emit
+    /// `Event::Reconnect` only on the latter.
+    has_connected_before: bool,
 }
 
 /// Events which can be yielded by the event loop
@@ -89,6 +93,14 @@ pub struct EventLoop {
 pub enum Event {
     Incoming(Incoming),
     Outgoing(Outgoing),
+    /// Synthetic event emitted by the event loop right after a
+    /// successful reconnect (NOT after the first connect). The caller
+    /// should re-subscribe to all its topics here: rumqttc does not
+    /// remember subscriptions across reconnects, and with
+    /// `clean_session = true` the broker drops them too, so on the new
+    /// session the client is silent until it re-subscribes.
+    /// See https://github.com/bytebeamio/rumqtt/issues/250
+    Reconnect,
 }
 
 impl EventLoop {
@@ -110,6 +122,7 @@ impl EventLoop {
             pending,
             network: None,
             keepalive_timeout: None,
+            has_connected_before: false,
         }
     }
 
@@ -161,6 +174,17 @@ impl EventLoop {
 
             self.state
                 .handle_incoming_packet(Incoming::ConnAck(connack))?;
+
+            // Distinguish the first connect (caller's initial SUBSCRIBEs
+            // already queued or about to be sent) from a reconnect (we
+            // just established a fresh MQTT session whose state — subs,
+            // pending publishes — the broker doesn't know). The caller
+            // should re-emit its subscriptions on Event::Reconnect.
+            if self.has_connected_before {
+                self.state.events.push_back(Event::Reconnect);
+            } else {
+                self.has_connected_before = true;
+            }
         }
 
         match self.select().await {


### PR DESCRIPTION
## Problem

After a transport drop and successful reconnect, the broker has a fresh session. With `clean_session = true` (or session expiry), every subscription the client had is gone. rumqttc itself doesn't remember them either, so the application is silent on the new session until it re-subscribes — but it has no signal that a reconnect happened.

This is [#250](https://github.com/bytebeamio/rumqtt/issues/250): a long-standing rumqttc footgun where a transient network blip leaves a process running but unable to receive any publishes, with no error in the event loop (the connection is "fine" again, just empty of subscriptions).

## Fix

Track `has_connected_before` in the `EventLoop`. After the second (and later) successful CONNACK, push a synthetic `Event::Reconnect` into the state events queue so the caller's `poll()` loop sees it.

The initial CONNACK is unchanged (Reconnect is **not** emitted on first connect, only subsequent ones), so existing callers that subscribe once on startup keep working — they just have to add the `Reconnect` arm to keep working across reconnects.

## Caller pattern

```rust
match eventloop.poll().await {
    Ok(Event::Reconnect) => {
        for (topic, qos) in &my_subs {
            client.subscribe(topic, *qos).await?;
        }
    }
    Ok(Event::Incoming(packet)) => { /* ... */ }
    Ok(Event::Outgoing(_)) => {}
    Err(e) => { /* ... */ }
}
```

## Validation

Tested against multiple brokers (rumqttd, rmqtt, mosquitto): a broker restart that previously left the client silently dead now fires `Event::Reconnect` within seconds, the caller re-subscribes, and message flow resumes without process restart.

## Notes

- Scope: only v5 here — the same fix applies to v4; happy to add it in this PR or a follow-up, whichever you prefer.
- No public API breaks (new enum variant only); downstream pattern matches that don't include `Reconnect` will get a warning rather than an error if they have a wildcard arm.

Closes #250