### PR TITLE
fix(rumqttc): respond with PUBCOMP instead of disconnecting on unsoli…

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -11,7 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Deprecated
 ### Removed
-### Fixed 
+### Fixed
+* Respond with PUBCOMP instead of disconnecting on unsolicited PUBREL (#1053).
+  When a broker retransmits PUBREL (e.g. PUBCOMP was delayed beyond
+  `message_retry_interval`), rumqttc previously returned
+  `StateError::Unsolicited`, causing a disconnect/reconnect loop. Now it
+  sends PUBCOMP and continues the session, matching MQTT v5 spec §3.6.2.
+  The same conservative fix is applied to the v3.1.1 state machine.
 ### Security
 
 

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -269,8 +269,20 @@ impl MqttState {
 
     fn handle_incoming_pubrel(&mut self, pubrel: &PubRel) -> Result<Option<Packet>, StateError> {
         if !self.incoming_pub.contains(pubrel.pkid as usize) {
-            error!("Unsolicited pubrel packet: {:?}", pubrel.pkid);
-            return Err(StateError::Unsolicited(pubrel.pkid));
+            // After TCP reconnect with clean_session=false, incoming_pub is cleared by clean()
+            // but the broker (per MQTT 3.1.1 spec §4.3.3) replays PUBREL for incomplete QoS 2
+            // transactions. The payload was already delivered via state.events on PUBLISH receipt.
+            // Respond with PUBCOMP to let the broker complete the transaction instead of
+            // returning an error that would trigger another disconnect → reconnect loop.
+            warn!(
+                "rumqttc: unsolicited PUBREL pkid={} after reconnect, \
+                 sending PUBCOMP to recover broker session (clean_session=false)",
+                pubrel.pkid
+            );
+            let event = Event::Outgoing(Outgoing::PubComp(pubrel.pkid));
+            let pubcomp = PubComp { pkid: pubrel.pkid };
+            self.events.push_back(event);
+            return Ok(Some(Packet::PubComp(pubcomp)));
         }
 
         self.incoming_pub.set(pubrel.pkid as usize, false);
@@ -753,6 +765,27 @@ mod test {
         match packet {
             Packet::PubComp(pubcomp) => assert_eq!(pubcomp.pkid, 1),
             packet => panic!("Invalid network request: {:?}", packet),
+        }
+    }
+
+    #[test]
+    fn unsolicited_pubrel_should_send_pubcomp_without_disconnecting() {
+        // Regression test: when a broker retransmits PUBREL because PUBCOMP was delayed
+        // in transit (e.g. broker congestion), the client must NOT disconnect.
+        // Instead it should respond with PUBCOMP so the broker can complete the transaction.
+        // Disconnecting would cause an infinite reconnect loop when message_retry_interval
+        // is short (e.g. 1s) and network latency exceeds it.
+        let mut mqtt = build_mqttstate();
+
+        // Simulate a PUBREL arriving for a pkid the client has no record of
+        // (e.g. because state was cleared on reconnect, or PUBCOMP was already sent).
+        let result = mqtt.handle_incoming_pubrel(&PubRel::new(42));
+
+        // Must NOT return an error (which would trigger disconnect).
+        let packet = result.unwrap().unwrap();
+        match packet {
+            Packet::PubComp(pubcomp) => assert_eq!(pubcomp.pkid, 42),
+            packet => panic!("Expected PUBCOMP, got: {:?}", packet),
         }
     }
 

--- a/rumqttc/src/v5/state.rs
+++ b/rumqttc/src/v5/state.rs
@@ -417,8 +417,23 @@ impl MqttState {
 
     fn handle_incoming_pubrel(&mut self, pubrel: &PubRel) -> Result<Option<Packet>, StateError> {
         if !self.incoming_pub.contains(pubrel.pkid as usize) {
-            error!("Unsolicited pubrel packet: {:?}", pubrel.pkid);
-            return Err(StateError::Unsolicited(pubrel.pkid));
+            // After TCP reconnect with clean_start=false, incoming_pub is cleared by clean()
+            // but the broker (per MQTT v5 spec §4.3.3) replays PUBREL for incomplete QoS 2
+            // transactions. The payload was already delivered via state.events on PUBLISH receipt.
+            // Respond with PUBCOMP to let the broker complete the transaction instead of
+            // returning an error that would trigger another disconnect → reconnect loop.
+            warn!(
+                "rumqttc: unsolicited PUBREL pkid={} after reconnect, \
+                 sending PUBCOMP to recover broker session (clean_start=false)",
+                pubrel.pkid
+            );
+            let event = Event::Outgoing(Outgoing::PubComp(pubrel.pkid));
+            self.events.push_back(event);
+            return Ok(Some(Packet::PubComp(PubComp {
+                pkid: pubrel.pkid,
+                reason: PubCompReason::PacketIdentifierNotFound,
+                properties: None,
+            })));
         }
         self.incoming_pub.set(pubrel.pkid as usize, false);
 
@@ -965,6 +980,31 @@ mod test {
         {
             Packet::PubComp(pubcomp) => assert_eq!(pubcomp.pkid, 1),
             packet => panic!("Invalid network request: {:?}", packet),
+        }
+    }
+
+    #[test]
+    fn unsolicited_pubrel_should_send_pubcomp_without_disconnecting() {
+        // Regression test: when a broker retransmits PUBREL because PUBCOMP was delayed
+        // in transit (e.g. broker congestion), the client must NOT disconnect.
+        // Per MQTT v5 spec §3.6.2, the receiver MUST respond with PUBCOMP
+        // (Reason Code 0x92 Packet Identifier Not Found) and continue the session.
+        // Disconnecting would cause an infinite reconnect loop when message_retry_interval
+        // is short (e.g. 1s) and network latency exceeds it.
+        let mut mqtt = build_mqttstate();
+
+        // Simulate a PUBREL arriving for a pkid the client has no record of
+        // (e.g. because state was cleared on reconnect, or PUBCOMP was already sent).
+        let result = mqtt.handle_incoming_pubrel(&PubRel::new(42, None));
+
+        // Must NOT return an error (which would trigger disconnect).
+        let packet = result.unwrap().unwrap();
+        match packet {
+            Packet::PubComp(pubcomp) => {
+                assert_eq!(pubcomp.pkid, 42);
+                assert_eq!(pubcomp.reason, PubCompReason::PacketIdentifierNotFound);
+            }
+            packet => panic!("Expected PUBCOMP, got: {:?}", packet),
         }
     }
 


### PR DESCRIPTION
…cited PUBREL

When a broker retransmits PUBREL because PUBCOMP was delayed in transit (e.g. under broker congestion), rumqttc currently returns StateError::Unsolicited(pkid), which triggers TCP disconnect/reconnect.

This creates an infinite loop under short message_retry_interval:
1. Broker sends PUBREL, starts retry timer (e.g. 1s)
2. Client sends PUBCOMP, clears QoS 2 state
3. PUBCOMP is delayed > retry interval due to congestion
4. Broker retransmits PUBREL
5. Client has no state for this pkid → Unsolicited error → disconnect
6. Reconnect with session_present=true, broker replays all pending PUBRELs
7. Back to step 4 → infinite reconnect storm

Fix for v5 (src/v5/state.rs):
Per MQTT v5 spec §3.6.2, on receiving PUBREL with unknown Packet Identifier, respond with PUBCOMP and continue the session.

Fix for v3.1.1 (src/state.rs):
The spec is silent here, but sending PUBCOMP and staying connected is strictly safer than disconnecting, since the broker is completing a transaction the client already acknowledged.

Adds regression test unsolicited_pubrel_should_send_pubcomp_without_disconnecting to both v3.1.1 and v5 state modules.

<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
