### PR TITLE
fix: recover the collision-stashed publish in MqttState::clean()

### DIFF
--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Deprecated
 ### Removed
-### Fixed 
+### Fixed
+* `MqttState::clean()` now recovers the publish stashed in `collision`, preventing a silent message loss and a permanent `CollisionTimeout` reconnect livelock when the session is lost while a collision is pending (#1056)
 ### Security
 
 

--- a/rumqttc/src/state.rs
+++ b/rumqttc/src/state.rs
@@ -113,6 +113,15 @@ impl MqttState {
             }
         }
 
+        // A publish stashed on a pkid collision must survive the reconnect:
+        // its colliding counterpart may never be re-acked (e.g. the session
+        // was lost and pending was dropped), which would otherwise leave the
+        // publish lost and the request branch disabled forever.
+        if let Some(publish) = self.collision.take() {
+            let request = Request::Publish(publish);
+            pending.push(request);
+        }
+
         // remove and collect pending releases
         for pkid in self.outgoing_rel.ones() {
             let request = Request::PubRel(PubRel::new(pkid as u16));
@@ -878,6 +887,25 @@ mod test {
             } else {
                 unreachable!()
             }
+        }
+    }
+
+    #[test]
+    fn clean_recovers_collision_stashed_publish() {
+        let mut mqtt = build_mqttstate();
+
+        let mut publish = build_outgoing_publish(QoS::AtLeastOnce);
+        publish.pkid = 1;
+        mqtt.collision = Some(publish);
+        mqtt.collision_ping_count = 1;
+
+        let requests = mqtt.clean();
+
+        assert!(mqtt.collision.is_none());
+        assert_eq!(mqtt.collision_ping_count, 0);
+        match requests.as_slice() {
+            [Request::Publish(publish)] => assert_eq!(publish.pkid, 1),
+            requests => unreachable!("unexpected pending: {requests:?}"),
         }
     }
 }

--- a/rumqttc/src/v5/state.rs
+++ b/rumqttc/src/v5/state.rs
@@ -151,6 +151,15 @@ impl MqttState {
             }
         }
 
+        // A publish stashed on a pkid collision must survive the reconnect:
+        // its colliding counterpart may never be re-acked (e.g. the session
+        // was lost and pending was dropped), which would otherwise leave the
+        // publish lost and the request branch disabled forever.
+        if let Some(publish) = self.collision.take() {
+            let request = Request::Publish(publish);
+            pending.push(request);
+        }
+
         // remove and collect pending releases
         for pkid in self.outgoing_rel.ones() {
             let request = Request::PubRel(PubRel::new(pkid as u16, None));
@@ -1012,5 +1021,24 @@ mod test {
 
         // should ping
         mqtt.outgoing_ping().unwrap();
+    }
+
+    #[test]
+    fn clean_recovers_collision_stashed_publish() {
+        let mut mqtt = build_mqttstate();
+
+        let mut publish = build_outgoing_publish(QoS::AtLeastOnce);
+        publish.pkid = 1;
+        mqtt.collision = Some(publish);
+        mqtt.collision_ping_count = 1;
+
+        let requests = mqtt.clean();
+
+        assert!(mqtt.collision.is_none());
+        assert_eq!(mqtt.collision_ping_count, 0);
+        match requests.as_slice() {
+            [Request::Publish(publish)] => assert_eq!(publish.pkid, 1),
+            requests => unreachable!("unexpected pending: {requests:?}"),
+        }
     }
 }


### PR DESCRIPTION
Fixes #1056.

## Problem

`MqttState::clean()` rebuilds `pending` from `outgoing_pub`/`outgoing_rel` and resets `collision_ping_count`, but never takes `self.collision`. When the session is lost across a reconnect (`clean_session = true`, or `session_present = false` dropping `pending`), the colliding pkid is never re-acked, so:

- the stashed QoS ≥ 1 publish is silently lost, and
- the request branch stays disabled (`!collision` gate in `eventloop.rs`), so the client loops `CollisionTimeout` → reconnect → `clean()` forever, sending nothing but pings and CONNECTs.

Full analysis in #1056.

## Fix

Push the stashed publish into `pending` during `clean()` — its `outgoing_pub` slot is free after the sweep and it already carries a pkid, so it rides the normal retransmission path. Applied to both v4 and v5 state, with a regression test each (`clean_recovers_collision_stashed_publish`).

On a *resumed* session the old self-heal path (`check_collision` on the ack of the colliding pkid) still works; this change only matters when that ack can never arrive.

Tests: `cargo test -p rumqttc --lib --no-default-features` — 75 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
