### PR TITLE
feat(rumqttc): add pluggable Connector for custom transports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,6 +1439,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,6 +1676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2129,6 +2136,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2215,6 +2232,7 @@ name = "rumqttc"
 version = "0.25.1"
 dependencies = [
  "async-http-proxy",
+ "async-trait",
  "async-tungstenite 0.29.1",
  "bincode",
  "bytes",
@@ -2238,6 +2256,7 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tokio-stream",
  "tokio-util",
+ "turmoil",
  "url",
  "ws_stream_tungstenite 0.15.0",
 ]
@@ -2432,6 +2451,12 @@ checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -3144,6 +3169,21 @@ dependencies = [
  "sha1",
  "thiserror 2.0.17",
  "utf-8",
+]
+
+[[package]]
+name = "turmoil"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f0d6c134ef37268c94d50fb74252af1c34c5c88389e2c1af85654da944ceb52"
+dependencies = [
+ "bytes",
+ "indexmap",
+ "rand 0.8.5",
+ "rand_distr",
+ "scoped-tls",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add pluggable `Connector` trait to supply the base byte stream, enabling running the client over custom transports such as [`turmoil`](https://github.com/tokio-rs/turmoil) for simulation testing.
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -31,6 +31,7 @@ bytes = "1.5"
 log = "0.4"
 flume = { version = "0.11", default-features = false, features = ["async"] }
 thiserror = "2.0.8"
+async-trait = "0.1"
 
 # Optional
 # rustls
@@ -59,6 +60,7 @@ matches = "0.1"
 pretty_assertions = "1"
 pretty_env_logger = "0.5"
 serde = { version = "1", features = ["derive"] }
+turmoil = "0.6"
 
 [[example]]
 name = "tls"

--- a/rumqttc/src/connector.rs
+++ b/rumqttc/src/connector.rs
@@ -1,0 +1,61 @@
+use crate::framed::AsyncReadWrite;
+use crate::NetworkOptions;
+use async_trait::async_trait;
+use std::io;
+
+/// A pluggable source for the base byte stream the MQTT client communicates over.
+///
+/// By default `rumqttc` creates its connection with [`tokio::net`]. Implementing this
+/// trait and installing it via [`NetworkOptions::set_connector`](crate::NetworkOptions::set_connector)
+/// lets you run the client over an arbitrary transport instead. This is primarily
+/// useful for testing under a simulated network such as
+/// [`turmoil`](https://github.com/tokio-rs/turmoil).
+///
+/// When a connector is installed it fully owns socket creation, so it **replaces**
+/// the default TCP socket (and the `proxy` setting is bypassed). The configured
+/// [`NetworkOptions`] are handed to [`connect`](Connector::connect), so an
+/// implementation can honor the relevant low-level settings (nodelay, send/recv
+/// buffer sizes, `bind_addr`, `bind_device`) where they apply to its transport.
+/// TLS and WebSocket transports still layer on top of the stream the connector
+/// returns.
+///
+/// The connector is **not** used for `Transport::Unix`, which always connects
+/// through a local Unix domain socket.
+///
+/// # Example
+///
+/// ```ignore
+/// use rumqttc::{async_trait, AsyncReadWrite, Connector, NetworkOptions};
+/// use std::io;
+///
+/// struct TurmoilConnector;
+///
+/// #[async_trait]
+/// impl Connector for TurmoilConnector {
+///     async fn connect(
+///         &self,
+///         addr: &str,
+///         _network_options: &NetworkOptions,
+///     ) -> io::Result<Box<dyn AsyncReadWrite>> {
+///         let stream = turmoil::net::TcpStream::connect(addr).await?;
+///         Ok(Box::new(stream))
+///     }
+/// }
+/// ```
+#[async_trait]
+pub trait Connector: Send + Sync {
+    /// Establish the base byte stream to the broker.
+    ///
+    /// `addr` is the `"host:port"` string the client would otherwise hand to
+    /// [`tokio::net::lookup_host`]. The implementor is responsible for its own
+    /// name resolution and socket creation.
+    ///
+    /// `network_options` carries the low-level connection settings configured on
+    /// the event loop; the implementation may apply whichever are relevant to its
+    /// transport (see the getters on [`NetworkOptions`]).
+    async fn connect(
+        &self,
+        addr: &str,
+        network_options: &NetworkOptions,
+    ) -> io::Result<Box<dyn AsyncReadWrite>>;
+}

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -399,21 +399,23 @@ async fn network_connect(
         _ => options.broker_address(),
     };
 
-    let tcp_stream: Box<dyn AsyncReadWrite> = {
+    let addr = format!("{domain}:{port}");
+
+    // A custom connector, if installed, fully owns socket creation and takes
+    // precedence over the proxy setting and the default tokio socket.
+    let tcp_stream: Box<dyn AsyncReadWrite> = if let Some(connector) = network_options.connector() {
+        connector.connect(&addr, &network_options).await?
+    } else {
         #[cfg(feature = "proxy")]
-        match options.proxy() {
-            Some(proxy) => proxy.connect(&domain, port, network_options).await?,
-            None => {
-                let addr = format!("{domain}:{port}");
-                let tcp = socket_connect(addr, network_options).await?;
-                Box::new(tcp)
+        {
+            match options.proxy() {
+                Some(proxy) => proxy.connect(&domain, port, network_options).await?,
+                None => Box::new(socket_connect(addr, network_options).await?),
             }
         }
         #[cfg(not(feature = "proxy"))]
         {
-            let addr = format!("{domain}:{port}");
-            let tcp = socket_connect(addr, network_options).await?;
-            Box::new(tcp)
+            Box::new(socket_connect(addr, network_options).await?)
         }
     };
 

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -100,12 +100,12 @@ extern crate log;
 
 use std::fmt::{self, Debug, Formatter};
 
-#[cfg(any(feature = "use-rustls-no-provider", feature = "websocket"))]
 use std::sync::Arc;
 
 use std::time::Duration;
 
 mod client;
+mod connector;
 mod eventloop;
 mod framed;
 pub mod mqttbytes;
@@ -134,10 +134,13 @@ type RequestModifierFn = Arc<
 #[cfg(feature = "proxy")]
 mod proxy;
 
+pub use async_trait::async_trait;
 pub use client::{
     AsyncClient, Client, ClientError, Connection, Iter, RecvError, RecvTimeoutError, TryRecvError,
 };
+pub use connector::Connector;
 pub use eventloop::{ConnectionError, Event, EventLoop};
+pub use framed::AsyncReadWrite;
 pub use mqttbytes::v4::*;
 pub use mqttbytes::*;
 #[cfg(feature = "use-rustls-no-provider")]
@@ -403,6 +406,9 @@ pub struct NetworkOptions {
     /// Optional local address to bind the outgoing TCP socket to.
     /// Use `SocketAddr::new(ip, 0)` to let the OS pick the ephemeral port.
     bind_addr: Option<std::net::SocketAddr>,
+    /// Optional pluggable connector used to create the base byte stream instead
+    /// of the default `tokio::net` TCP socket.
+    connector: Option<Arc<dyn Connector>>,
 }
 
 impl Default for NetworkOptions {
@@ -421,6 +427,7 @@ impl NetworkOptions {
             #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
             bind_device: None,
             bind_addr: None,
+            connector: None,
         }
     }
 
@@ -428,12 +435,27 @@ impl NetworkOptions {
         self.tcp_nodelay = nodelay;
     }
 
+    /// Get whether `TCP_NODELAY` is enabled.
+    pub fn tcp_nodelay(&self) -> bool {
+        self.tcp_nodelay
+    }
+
     pub fn set_tcp_send_buffer_size(&mut self, size: u32) {
         self.tcp_send_buffer_size = Some(size);
     }
 
+    /// Get the configured TCP send buffer size, if any.
+    pub fn tcp_send_buffer_size(&self) -> Option<u32> {
+        self.tcp_send_buffer_size
+    }
+
     pub fn set_tcp_recv_buffer_size(&mut self, size: u32) {
         self.tcp_recv_buffer_size = Some(size);
+    }
+
+    /// Get the configured TCP receive buffer size, if any.
+    pub fn tcp_recv_buffer_size(&self) -> Option<u32> {
+        self.tcp_recv_buffer_size
     }
 
     /// set connection timeout in secs
@@ -458,6 +480,16 @@ impl NetworkOptions {
         self
     }
 
+    /// Get the network device the connection is bound to, if any.
+    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))
+    )]
+    pub fn bind_device(&self) -> Option<&str> {
+        self.bind_device.as_deref()
+    }
+
     /// Bind the outgoing TCP socket to a specific local address before connecting.
     /// Use `SocketAddr::new(ip, 0)` to let the OS pick the ephemeral port.
     /// This is useful for distributing connections across multiple local IPs
@@ -470,6 +502,27 @@ impl NetworkOptions {
     /// Get the configured bind address, if any.
     pub fn bind_addr(&self) -> Option<std::net::SocketAddr> {
         self.bind_addr
+    }
+
+    /// Install a custom [`Connector`] used to create the base byte stream to the
+    /// broker instead of the default `tokio::net` TCP socket.
+    ///
+    /// When set, the connector fully owns socket creation and the `proxy` setting
+    /// is bypassed. These `NetworkOptions` are handed to the connector, which may
+    /// honor the TCP-tuning options above (nodelay, buffer sizes, `bind_addr`,
+    /// `bind_device`) where they apply to its transport. TLS and WebSocket
+    /// transports still layer on top of the stream the connector returns.
+    ///
+    /// Not used for `Transport::Unix`, which always connects through a local
+    /// Unix domain socket.
+    pub fn set_connector(&mut self, connector: Arc<dyn Connector>) -> &mut Self {
+        self.connector = Some(connector);
+        self
+    }
+
+    /// Get the configured connector, if any.
+    pub fn connector(&self) -> Option<Arc<dyn Connector>> {
+        self.connector.clone()
     }
 }
 

--- a/rumqttc/src/v5/eventloop.rs
+++ b/rumqttc/src/v5/eventloop.rs
@@ -316,25 +316,24 @@ async fn network_connect(options: &MqttOptions) -> Result<Network, ConnectionErr
         _ => options.broker_address(),
     };
 
-    let tcp_stream: Box<dyn AsyncReadWrite> = {
+    let addr = format!("{domain}:{port}");
+    let network_options = options.network_options();
+
+    // A custom connector, if installed, fully owns socket creation and takes
+    // precedence over the proxy setting and the default tokio socket.
+    let tcp_stream: Box<dyn AsyncReadWrite> = if let Some(connector) = network_options.connector() {
+        connector.connect(&addr, &network_options).await?
+    } else {
         #[cfg(feature = "proxy")]
-        match options.proxy() {
-            Some(proxy) => {
-                proxy
-                    .connect(&domain, port, options.network_options())
-                    .await?
-            }
-            None => {
-                let addr = format!("{domain}:{port}");
-                let tcp = socket_connect(addr, options.network_options()).await?;
-                Box::new(tcp)
+        {
+            match options.proxy() {
+                Some(proxy) => proxy.connect(&domain, port, network_options).await?,
+                None => Box::new(socket_connect(addr, network_options).await?),
             }
         }
         #[cfg(not(feature = "proxy"))]
         {
-            let addr = format!("{domain}:{port}");
-            let tcp = socket_connect(addr, options.network_options()).await?;
-            Box::new(tcp)
+            Box::new(socket_connect(addr, network_options).await?)
         }
     };
 

--- a/rumqttc/tests/turmoil.rs
+++ b/rumqttc/tests/turmoil.rs
@@ -1,0 +1,231 @@
+//! Demonstrates running the MQTT client over a simulated network via a custom
+//! [`Connector`]. Both the client and a minimal MQTT broker run as turmoil
+//! hosts, so no real sockets are used — the connect/subscribe/deliver round-trip
+//! is exercised entirely inside the simulation, for both the v4 and v5 clients.
+
+use std::io;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::{Bytes, BytesMut};
+use rumqttc::{async_trait, AsyncReadWrite, Connector, NetworkOptions};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use turmoil::net::{TcpListener, TcpStream};
+
+const MAX_SIZE: usize = 10 * 1024;
+const TOPIC: &str = "hello/world";
+const PAYLOAD: &[u8] = &[1, 2, 3, 4];
+
+/// A [`Connector`] that dials the broker over turmoil's simulated network
+/// instead of the default `tokio::net` TCP socket.
+struct TurmoilConnector;
+
+#[async_trait]
+impl Connector for TurmoilConnector {
+    async fn connect(
+        &self,
+        addr: &str,
+        _network_options: &NetworkOptions,
+    ) -> io::Result<Box<dyn AsyncReadWrite>> {
+        let stream = TcpStream::connect(addr).await?;
+        Ok(Box::new(stream))
+    }
+}
+
+fn network_options_with_connector() -> NetworkOptions {
+    let mut network_options = NetworkOptions::new();
+    network_options.set_connector(Arc::new(TurmoilConnector));
+    network_options
+}
+
+// ---------------------------------------------------------------------------
+// MQTT v4
+// ---------------------------------------------------------------------------
+
+mod v4 {
+    use super::*;
+    use rumqttc::mqttbytes::v4::{
+        ConnAck, ConnectReturnCode, Packet, Publish, SubAck, SubscribeReasonCode,
+    };
+    use rumqttc::mqttbytes::{Error, QoS};
+    use rumqttc::{AsyncClient, Event, Incoming, MqttOptions};
+
+    async fn send(stream: &mut TcpStream, packet: Packet) -> io::Result<()> {
+        let mut buf = BytesMut::new();
+        packet
+            .write(&mut buf, MAX_SIZE)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        stream.write_all(&buf).await
+    }
+
+    /// A minimal MQTT v4 broker: acks CONNECT, answers SUBSCRIBE with a SUBACK
+    /// and then delivers one publish, and replies to pings.
+    pub async fn run_broker() -> Result<(), BoxError> {
+        let listener = TcpListener::bind(("0.0.0.0", 1883)).await?;
+        loop {
+            let (mut stream, _) = listener.accept().await?;
+            let mut read = BytesMut::new();
+            let mut chunk = [0u8; 1024];
+
+            loop {
+                match Packet::read(&mut read, MAX_SIZE) {
+                    Ok(Packet::Connect(_)) => {
+                        send(
+                            &mut stream,
+                            Packet::ConnAck(ConnAck::new(ConnectReturnCode::Success, false)),
+                        )
+                        .await?;
+                    }
+                    Ok(Packet::Subscribe(subscribe)) => {
+                        let suback = SubAck::new(
+                            subscribe.pkid,
+                            vec![SubscribeReasonCode::Success(QoS::AtLeastOnce)],
+                        );
+                        send(&mut stream, Packet::SubAck(suback)).await?;
+
+                        let mut publish = Publish::new(TOPIC, QoS::AtLeastOnce, PAYLOAD);
+                        publish.pkid = 1;
+                        send(&mut stream, Packet::Publish(publish)).await?;
+                    }
+                    Ok(Packet::PingReq) => send(&mut stream, Packet::PingResp).await?,
+                    Ok(_) => {}
+                    Err(Error::InsufficientBytes(_)) => {
+                        let n = stream.read(&mut chunk).await?;
+                        if n == 0 {
+                            break;
+                        }
+                        read.extend_from_slice(&chunk[..n]);
+                    }
+                    Err(e) => return Err(Box::new(e)),
+                }
+            }
+        }
+    }
+
+    pub async fn run_client() -> Result<(), BoxError> {
+        let mut mqttoptions = MqttOptions::new("turmoil-client-v4", "broker", 1883);
+        mqttoptions.set_keep_alive(Duration::from_secs(5));
+
+        let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+        eventloop.set_network_options(network_options_with_connector());
+
+        client.subscribe(TOPIC, QoS::AtLeastOnce).await?;
+
+        loop {
+            if let Event::Incoming(Incoming::Publish(publish)) = eventloop.poll().await? {
+                assert_eq!(publish.topic, TOPIC);
+                assert_eq!(&publish.payload[..], PAYLOAD);
+                return Ok(());
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MQTT v5
+// ---------------------------------------------------------------------------
+
+mod v5 {
+    use super::*;
+    use rumqttc::v5::mqttbytes::v5::{
+        ConnAck, ConnectReturnCode, Packet, PingResp, Publish, SubAck, SubscribeReasonCode,
+    };
+    use rumqttc::v5::mqttbytes::{Error, QoS};
+    use rumqttc::v5::{AsyncClient, Event, MqttOptions};
+
+    async fn send(stream: &mut TcpStream, packet: Packet) -> io::Result<()> {
+        let mut buf = BytesMut::new();
+        packet
+            .write(&mut buf, None)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        stream.write_all(&buf).await
+    }
+
+    /// A minimal MQTT v5 broker mirroring the v4 one.
+    pub async fn run_broker() -> Result<(), BoxError> {
+        let listener = TcpListener::bind(("0.0.0.0", 1883)).await?;
+        loop {
+            let (mut stream, _) = listener.accept().await?;
+            let mut read = BytesMut::new();
+            let mut chunk = [0u8; 1024];
+
+            loop {
+                match Packet::read(&mut read, None) {
+                    Ok(Packet::Connect(..)) => {
+                        let connack = ConnAck {
+                            session_present: false,
+                            code: ConnectReturnCode::Success,
+                            properties: None,
+                        };
+                        send(&mut stream, Packet::ConnAck(connack)).await?;
+                    }
+                    Ok(Packet::Subscribe(subscribe)) => {
+                        let suback = SubAck {
+                            pkid: subscribe.pkid,
+                            return_codes: vec![SubscribeReasonCode::Success(QoS::AtLeastOnce)],
+                            properties: None,
+                        };
+                        send(&mut stream, Packet::SubAck(suback)).await?;
+
+                        let publish = Publish {
+                            dup: false,
+                            qos: QoS::AtLeastOnce,
+                            retain: false,
+                            topic: Bytes::from_static(TOPIC.as_bytes()),
+                            pkid: 1,
+                            payload: Bytes::from_static(PAYLOAD),
+                            properties: None,
+                        };
+                        send(&mut stream, Packet::Publish(publish)).await?;
+                    }
+                    Ok(Packet::PingReq(_)) => send(&mut stream, Packet::PingResp(PingResp)).await?,
+                    Ok(_) => {}
+                    Err(Error::InsufficientBytes(_)) => {
+                        let n = stream.read(&mut chunk).await?;
+                        if n == 0 {
+                            break;
+                        }
+                        read.extend_from_slice(&chunk[..n]);
+                    }
+                    Err(e) => return Err(Box::new(e)),
+                }
+            }
+        }
+    }
+
+    pub async fn run_client() -> Result<(), BoxError> {
+        let mut mqttoptions = MqttOptions::new("turmoil-client-v5", "broker", 1883);
+        mqttoptions.set_keep_alive(Duration::from_secs(5));
+        mqttoptions.set_network_options(network_options_with_connector());
+
+        let (client, mut eventloop) = AsyncClient::new(mqttoptions, 10);
+
+        client.subscribe(TOPIC, QoS::AtLeastOnce).await?;
+
+        loop {
+            if let Event::Incoming(Packet::Publish(publish)) = eventloop.poll().await? {
+                assert_eq!(&publish.topic[..], TOPIC.as_bytes());
+                assert_eq!(&publish.payload[..], PAYLOAD);
+                return Ok(());
+            }
+        }
+    }
+}
+
+type BoxError = Box<dyn std::error::Error>;
+
+#[test]
+fn v4_connect_and_receive_over_turmoil() {
+    let mut sim = turmoil::Builder::new().build();
+    sim.host("broker", v4::run_broker);
+    sim.client("client", v4::run_client());
+    sim.run().unwrap();
+}
+
+#[test]
+fn v5_connect_and_receive_over_turmoil() {
+    let mut sim = turmoil::Builder::new().build();
+    sim.host("broker", v5::run_broker);
+    sim.client("client", v5::run_client());
+    sim.run().unwrap();
+}


### PR DESCRIPTION
Introduce a `Connector` trait that supplies the base byte stream to the broker, replacing the default `tokio::net` TCP socket. This lets the client run over arbitrary transports — most usefully a simulated network such as [turmoil](https://github.com/tokio-rs/turmoil) for deterministic testing.

The connector is installed on `NetworkOptions` (the seam shared by the v4 and v5 event loops). When set, it fully owns socket creation and the `proxy` setting is bypassed. The configured `NetworkOptions` are handed to `Connector::connect`, so an implementation can honor the low-level TCP settings (nodelay, send/recv buffer sizes, `bind_addr`, `bind_device`) where they apply to its transport; getters for these were added so they are readable by connector implementations. TLS/WebSocket transports still layer on top of the stream the connector returns.

The API is always available (no cargo feature); `async-trait` is a regular dependency.

Includes a turmoil-based integration test running the client and a minimal in-simulation broker over the connector.

<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.