### PR TITLE
feat: add Multipath TCP support via NetworkOptions::set_mptcp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,6 +2232,7 @@ dependencies = [
  "rustls-pemfile",
  "rustls-webpki 0.102.8",
  "serde",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tokio-native-tls",

--- a/rumqttc/CHANGELOG.md
+++ b/rumqttc/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `NetworkOptions::set_mptcp` to opt the outgoing connection onto Multipath TCP
+  (`IPPROTO_MPTCP`, RFC 8684) on Linux, with a silent fallback to plain TCP when
+  the kernel lacks MPTCP support.
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/rumqttc/Cargo.toml
+++ b/rumqttc/Cargo.toml
@@ -52,6 +52,11 @@ async-http-proxy = { version = "1.2.5", features = ["runtime-tokio", "basic-auth
 tokio-stream = "0.1.16"
 fixedbitset = "0.5.7"
 
+# Multipath TCP support (NetworkOptions::set_mptcp) needs IPPROTO_MPTCP, which
+# is Linux-only, so socket2 is only pulled in on Linux.
+[target.'cfg(target_os = "linux")'.dependencies]
+socket2 = "0.5"
+
 [dev-dependencies]
 bincode = "1.3.3"
 color-backtrace = "0.6.1"

--- a/rumqttc/src/eventloop.rs
+++ b/rumqttc/src/eventloop.rs
@@ -326,10 +326,7 @@ pub(crate) async fn socket_connect(
     let mut last_err = None;
 
     for addr in addrs {
-        let socket = match addr {
-            SocketAddr::V4(_) => TcpSocket::new_v4()?,
-            SocketAddr::V6(_) => TcpSocket::new_v6()?,
-        };
+        let socket = new_tcp_socket(addr, &network_options)?;
 
         socket.set_nodelay(network_options.tcp_nodelay)?;
 
@@ -371,6 +368,47 @@ pub(crate) async fn socket_connect(
             "could not resolve to any address",
         )
     }))
+}
+
+/// Create the outgoing TCP socket for `addr`.
+///
+/// On Linux, when `NetworkOptions::set_mptcp(true)` is set, this creates a
+/// Multipath TCP (`IPPROTO_MPTCP`) socket. MPTCP negotiates down to plain TCP
+/// with a non-MPTCP peer, and if the kernel lacks MPTCP support the creation
+/// fails and we fall back to a plain socket — so it can never make a
+/// connection fail.
+fn new_tcp_socket(addr: SocketAddr, network_options: &NetworkOptions) -> io::Result<TcpSocket> {
+    #[cfg(target_os = "linux")]
+    if network_options.mptcp {
+        if let Ok(socket) = new_mptcp_socket(addr) {
+            return Ok(socket);
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    let _ = network_options;
+
+    match addr {
+        SocketAddr::V4(_) => TcpSocket::new_v4(),
+        SocketAddr::V6(_) => TcpSocket::new_v6(),
+    }
+}
+
+/// Create an `IPPROTO_MPTCP` socket and hand its fd to tokio's `TcpSocket`.
+#[cfg(target_os = "linux")]
+fn new_mptcp_socket(addr: SocketAddr) -> io::Result<TcpSocket> {
+    use std::os::fd::{FromRawFd, IntoRawFd};
+
+    use socket2::{Domain, Protocol, Socket, Type};
+
+    let domain = match addr {
+        SocketAddr::V4(_) => Domain::IPV4,
+        SocketAddr::V6(_) => Domain::IPV6,
+    };
+    let socket = Socket::new(domain, Type::STREAM, Some(Protocol::MPTCP))?;
+    socket.set_nonblocking(true)?;
+    // SAFETY: `into_raw_fd` transfers sole ownership of a valid, open,
+    // non-blocking socket fd, which `TcpSocket` takes ownership of.
+    Ok(unsafe { TcpSocket::from_raw_fd(socket.into_raw_fd()) })
 }
 
 async fn network_connect(
@@ -508,5 +546,30 @@ async fn mqtt_connect(
         Incoming::ConnAck(connack) if connack.code == ConnectReturnCode::Success => Ok(connack),
         Incoming::ConnAck(connack) => Err(ConnectionError::ConnectionRefused(connack.code)),
         packet => Err(ConnectionError::NotConnAck(packet)),
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn mptcp_connect_or_fallback_reaches_a_plain_tcp_listener() {
+        // A plain-TCP listener: an MPTCP client negotiates down to TCP against
+        // a non-MPTCP peer, and on a kernel without MPTCP support socket_connect
+        // falls back to a plain socket — either way the connection must succeed.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let mut network_options = NetworkOptions::new();
+        network_options.set_mptcp(true);
+
+        let accept = tokio::spawn(async move { listener.accept().await.map(|_| ()) });
+        let stream = socket_connect(addr.to_string(), network_options).await;
+        assert!(
+            stream.is_ok(),
+            "mptcp connect (or plain-TCP fallback) must succeed: {stream:?}"
+        );
+        accept.await.unwrap().unwrap();
     }
 }

--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -403,6 +403,9 @@ pub struct NetworkOptions {
     /// Optional local address to bind the outgoing TCP socket to.
     /// Use `SocketAddr::new(ip, 0)` to let the OS pick the ephemeral port.
     bind_addr: Option<std::net::SocketAddr>,
+    /// Use Multipath TCP (`IPPROTO_MPTCP`) for the outgoing connection.
+    #[cfg(target_os = "linux")]
+    mptcp: bool,
 }
 
 impl Default for NetworkOptions {
@@ -421,6 +424,8 @@ impl NetworkOptions {
             #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
             bind_device: None,
             bind_addr: None,
+            #[cfg(target_os = "linux")]
+            mptcp: false,
         }
     }
 
@@ -470,6 +475,20 @@ impl NetworkOptions {
     /// Get the configured bind address, if any.
     pub fn bind_addr(&self) -> Option<std::net::SocketAddr> {
         self.bind_addr
+    }
+
+    /// Use Multipath TCP (RFC 8684) for the outgoing connection.
+    ///
+    /// The socket is created with `IPPROTO_MPTCP` instead of `IPPROTO_TCP`.
+    /// MPTCP negotiates transparently down to regular TCP against a peer that
+    /// does not support it, and if the running kernel lacks MPTCP support the
+    /// client silently falls back to a plain TCP socket — so enabling this is
+    /// always safe. Linux only.
+    #[cfg(target_os = "linux")]
+    #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
+    pub fn set_mptcp(&mut self, mptcp: bool) -> &mut Self {
+        self.mptcp = mptcp;
+        self
     }
 }
 


### PR DESCRIPTION

MPTCP lets a single MQTT session survive a path failure by moving traffic to
another subflow, instead of stalling until the client reconnects.

### Safety of the flag

- MPTCP negotiates transparently **down to regular TCP** against a peer that
  doesn't support it.
- If the running **kernel lacks MPTCP** support, socket creation fails and the
  client **silently falls back to a plain TCP socket**.

So enabling the option can never make a connection fail — the socket protocol
is the only thing that changes; `nodelay` / buffers / `bind_device` /
`bind_addr` and the connect path are untouched.

### Scope

- One change site: `socket_connect` (shared by the v4 and v5 event loops), so
  both protocol versions are covered.
- `IPPROTO_MPTCP` is Linux-only, so the field, the `set_mptcp` setter, and the
  `socket2` dependency are all gated to `target_os = "linux"` (mirroring the
  existing `set_bind_device` gating).
- New dependency: `socket2` (Linux target only), used solely to create the
  `IPPROTO_MPTCP` socket, whose fd is handed to tokio's `TcpSocket`.

### Tests

A hermetic Linux-only test (`mptcp_connect_or_fallback_reaches_a_plain_tcp_listener`)
asserts that an `mptcp(true)` connect succeeds against a plain-TCP listener —
covering both the negotiate-down and the kernel-fallback paths. `cargo test -p
rumqttc` passes; `cargo fmt --check` and `cargo clippy` are clean (no new
warnings).
