### PR TITLE
fix(rumqttd): avoid poisoning will_handlers mutex on stale will send

### DIFF
--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Deprecated
 ### Removed
-### Fixed 
+### Fixed
+- Stop poisoning the `will_handlers` mutex when a stale will send fails on the ws listener
 ### Security
 
 

--- a/rumqttd/src/server/broker.rs
+++ b/rumqttd/src/server/broker.rs
@@ -535,13 +535,17 @@ async fn remote<P: Protocol>(
         client_id = format!("{tenant_id}.{client_id}");
     }
 
-    if let Some(sender) = will_handlers.lock().unwrap().remove(&client_id) {
+    let previous_will_handler = will_handlers.lock().unwrap().remove(&client_id);
+    if let Some(sender) = previous_will_handler {
         let awaiting_will = if clean_session {
             AwaitingWill::Fire
         } else {
             AwaitingWill::Cancel
         };
-        sender.try_send(awaiting_will).unwrap();
+        // The previous connection's will task may have already exited on its own,
+        // in which case this send has nowhere to go. That's fine, just drop it
+        // instead of unwrapping and poisoning `will_handlers`.
+        let _ = sender.try_send(awaiting_will);
     }
 
     let (will_tx, will_rx) = flume::bounded::<AwaitingWill>(1);


### PR DESCRIPTION
Fixes #1062.

`remote()` holds the `will_handlers` mutex guard through the whole `if let Some(sender) = will_handlers.lock().unwrap().remove(...) { ... }` block (a common Rust temporary-lifetime gotcha), then unwraps `sender.try_send(...)`. When the previous connection's will task has already exited, `try_send` returns `Disconnected` and the unwrap panics while the guard is still alive, poisoning the mutex for every later connection on that listener.

Split the lock/remove from the send so the guard is dropped first, and stopped unwrapping the send since a disconnected receiver just means there's nothing to notify.

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

- Bug fix (non-breaking change which fixes an issue)
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [x] Formatted with `cargo fmt`
- [x] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.
