### PR TITLE
Fixed deserialization error on zero-length disconnect packet

### DIFF
--- a/rumqttc/src/v5/mqttbytes/v5/mod.rs
+++ b/rumqttc/src/v5/mqttbytes/v5/mod.rs
@@ -70,6 +70,9 @@ impl Packet {
             return match packet_type {
                 PacketType::PingReq => Ok(Packet::PingReq(PingReq)),
                 PacketType::PingResp => Ok(Packet::PingResp(PingResp)),
+                PacketType::Disconnect => Ok(Packet::Disconnect(Disconnect::new(
+                    DisconnectReasonCode::NormalDisconnection,
+                ))),
                 _ => Err(Error::PayloadRequired),
             };
         }
@@ -527,4 +530,23 @@ mod test {
     pub const USER_PROP_KEY: &str = "property";
     #[allow(dead_code)]
     pub const USER_PROP_VAL: &str = "a value thats really long............................................................................................................";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::BytesMut;
+
+    #[test]
+    fn zero_length_disconnect_round_trips_through_packet() {
+        let packet = Packet::Disconnect(Disconnect::new(DisconnectReasonCode::NormalDisconnection));
+
+        let mut buf = BytesMut::new();
+        packet.write(&mut buf, Some(4096 * 4096)).unwrap();
+        assert_eq!(&buf[..], &[0xE0, 0x00]);
+
+        let parsed = Packet::read(&mut buf, Some(4096 * 4096))
+            .expect("zero-length DISCONNECT must round-trip through Packet::read");
+        assert_eq!(parsed, packet);
+    }
 }


### PR DESCRIPTION
<!--
Thank you for this Pull Request. Please describe your changes above.

Read `CONTRIBUTING.md` if you are contributing for the first time.
-->

## Type of change

<!-- Uncomment the most relevant line that fits your changes. -->

Bug fix (non-breaking change which fixes an issue)
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
<!-- - Miscellaneous (related to maintenance) -->

## Checklist:

- [x] Formatted with `cargo fmt`
- [ ] Make an entry to `CHANGELOG.md` if it's relevant to the users of the library. If it's not relevant mention why.

I am not sure if an entry should be added to CHANGELOG.md

## Summary

A success Disconnect packed can not be read back because the decoder does not allow zero length disconnect packet.

Mqtt Specs states on "3.14.2.1 Disconnect Reason Code" that "The Reason Code and Property Length can be omitted if the Reason Code is 0x00 (Normal disconnecton) and there are no Properties. In this case the DISCONNECT has a Remaining Length of 0."