### PR TITLE
feat(rumqttd): add topic ACL enforcement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2244,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "rumqttd"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-tungstenite 0.25.1",
  "axum",

--- a/rumqttd/CHANGELOG.md
+++ b/rumqttd/CHANGELOG.md
@@ -8,11 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `ClientIdentity`, `AclAction`, and `ConnectionSettings::set_acl_handler` for broker topic authorization.
 ### Changed
+- Broker ACL decisions now follow authenticated identities through remote connections.
 ### Deprecated
 ### Removed
 ### Fixed 
 ### Security
+- Enforce ACL checks for client publishes, subscriptions, unsubscriptions, and will messages before storage or delivery.
+- Local broker links remain explicitly trusted for internal bridge, console, and application integration traffic.
 
 
 ---

--- a/rumqttd/Cargo.toml
+++ b/rumqttd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rumqttd"
-version = "0.20.0"
+version = "0.21.0"
 publish = true
 description = "rumqttd is a high performance MQTT broker written in Rust which is light weight and embeddable"
 keywords = ["mqtt", "broker", "iot", "kafka", "nats"]

--- a/rumqttd/README.md
+++ b/rumqttd/README.md
@@ -17,6 +17,29 @@ cargo run --release -- -c rumqttd.toml
 
 Example config file is provided on the root of the repo.
 
+## Topic authorization
+
+Embedded applications can install a synchronous ACL handler on each server
+configuration. The handler receives the authenticated client identity, action,
+and topic or filter:
+
+```rust
+use rumqttd::{AclAction, ClientIdentity, ServerSettings};
+
+server_settings.set_acl_handler(|identity: &ClientIdentity, action, topic| {
+    identity.username.as_deref() == Some("publisher")
+        && matches!(action, AclAction::Publish)
+        && topic.starts_with("devices/")
+});
+```
+
+The `username` field is populated only after configured authentication
+succeeds. With authentication disabled, base ACL decisions on `client_id` or
+`tenant_id` instead.
+
+ACLs apply to client publishes, subscriptions, unsubscriptions, and will
+messages. Broker-internal local links remain trusted and bypass remote ACLs.
+
 
 #### Building the docker image
 

--- a/rumqttd/src/acl.rs
+++ b/rumqttd/src/acl.rs
@@ -1,0 +1,90 @@
+use std::fmt;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct AclHandler(Arc<dyn Fn(&ClientIdentity, AclAction, &str) -> bool + Send + Sync>);
+
+impl AclHandler {
+    pub fn new<F>(acl_fn: F) -> Self
+    where
+        F: Fn(&ClientIdentity, AclAction, &str) -> bool + Send + Sync + 'static,
+    {
+        Self(Arc::new(acl_fn))
+    }
+
+    pub fn allows(&self, identity: &ClientIdentity, action: AclAction, topic: &str) -> bool {
+        (self.0)(identity, action, topic)
+    }
+}
+
+impl fmt::Debug for AclHandler {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("AclHandler(..)")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientIdentity {
+    pub client_id: String,
+    /// Username accepted by the configured authentication mechanism.
+    pub username: Option<String>,
+    pub tenant_id: Option<String>,
+}
+
+impl ClientIdentity {
+    pub fn unauthenticated(client_id: impl Into<String>, tenant_id: Option<String>) -> Self {
+        Self {
+            client_id: client_id.into(),
+            username: None,
+            tenant_id,
+        }
+    }
+    pub fn authenticated(
+        client_id: impl Into<String>,
+        username: impl Into<String>,
+        tenant_id: Option<String>,
+    ) -> Self {
+        Self {
+            client_id: client_id.into(),
+            username: Some(username.into()),
+            tenant_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AclAction {
+    Publish,
+    Subscribe,
+    Unsubscribe,
+    Will,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AclAction, ClientIdentity};
+
+    #[test]
+    fn authenticated_identity_preserves_verified_username() {
+        let identity =
+            ClientIdentity::authenticated("client-1", "user-1", Some("tenant-1".to_owned()));
+
+        assert_eq!(identity.client_id, "client-1");
+        assert_eq!(identity.username.as_deref(), Some("user-1"));
+        assert_eq!(identity.tenant_id.as_deref(), Some("tenant-1"));
+    }
+
+    #[test]
+    fn unauthenticated_identity_does_not_claim_username() {
+        let identity = ClientIdentity::unauthenticated("client-1", None);
+
+        assert_eq!(identity.username, None);
+    }
+
+    #[test]
+    fn acl_actions_distinguish_topic_operations() {
+        assert_ne!(AclAction::Publish, AclAction::Subscribe);
+        assert_ne!(AclAction::Subscribe, AclAction::Unsubscribe);
+        assert_ne!(AclAction::Unsubscribe, AclAction::Will);
+    }
+}

--- a/rumqttd/src/lib.rs
+++ b/rumqttd/src/lib.rs
@@ -26,7 +26,9 @@ use segments::Storage;
 pub use server::{Broker, LinkType, Server};
 
 pub use self::router::shared_subs::Strategy;
+pub use acl::{AclAction, AclHandler, ClientIdentity};
 
+pub mod acl;
 mod link;
 pub mod protocol;
 mod router;
@@ -117,7 +119,6 @@ pub struct ServerSettings {
     pub next_connection_delay_ms: u64,
     pub connections: ConnectionSettings,
 }
-
 impl ServerSettings {
     pub fn set_auth_handler<F, O>(&mut self, auth_fn: F)
     where
@@ -126,6 +127,13 @@ impl ServerSettings {
         O::IntoFuture: Send,
     {
         self.connections.set_auth_handler(auth_fn)
+    }
+
+    pub fn set_acl_handler<F>(&mut self, acl_fn: F)
+    where
+        F: Fn(&ClientIdentity, AclAction, &str) -> bool + Send + Sync + 'static,
+    {
+        self.connections.set_acl_handler(acl_fn)
     }
 }
 
@@ -141,7 +149,6 @@ pub struct BridgeConfig {
     #[serde(default)]
     pub transport: Transport,
 }
-
 #[derive(Serialize, Deserialize, Clone)]
 pub struct ConnectionSettings {
     pub connection_timeout_ms: u16,
@@ -150,10 +157,11 @@ pub struct ConnectionSettings {
     pub auth: Option<HashMap<String, String>>,
     #[serde(skip)]
     pub external_auth: Option<AuthHandler>,
+    #[serde(skip)]
+    pub external_acl: Option<AclHandler>,
     #[serde(default)]
     pub dynamic_filters: bool,
 }
-
 impl ConnectionSettings {
     pub fn set_auth_handler<F, O>(&mut self, auth_fn: F)
     where
@@ -166,8 +174,14 @@ impl ConnectionSettings {
             Box::pin(auth)
         }));
     }
-}
 
+    pub fn set_acl_handler<F>(&mut self, acl_fn: F)
+    where
+        F: Fn(&ClientIdentity, AclAction, &str) -> bool + Send + Sync + 'static,
+    {
+        self.external_acl = Some(AclHandler::new(acl_fn));
+    }
+}
 impl fmt::Debug for ConnectionSettings {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ConnectionSettings")
@@ -176,6 +190,7 @@ impl fmt::Debug for ConnectionSettings {
             .field("max_inflight_count", &self.max_inflight_count)
             .field("auth", &self.auth)
             .field("external_auth", &self.external_auth.is_some())
+            .field("external_acl", &self.external_acl.is_some())
             .field("dynamic_filters", &self.dynamic_filters)
             .finish()
     }

--- a/rumqttd/src/link/local.rs
+++ b/rumqttd/src/link/local.rs
@@ -8,6 +8,7 @@ use crate::router::{
     Connection, Event, Notification, ShadowRequest,
 };
 use crate::ConnectionId;
+use crate::{AclHandler, ClientIdentity};
 use bytes::Bytes;
 use flume::{Receiver, RecvError, RecvTimeoutError, SendError, Sender, TrySendError};
 use parking_lot::lock_api::MutexGuard;
@@ -36,10 +37,11 @@ pub enum LinkError {
     Elapsed(#[from] tokio::time::error::Elapsed),
 }
 
-// used to build LinkTx and LinkRx
 pub struct LinkBuilder<'a> {
     tenant_id: Option<String>,
     client_id: &'a str,
+    identity: Option<ClientIdentity>,
+    acl_handler: Option<AclHandler>,
     router_tx: Sender<(ConnectionId, Event)>,
     // true by default
     clean_session: bool,
@@ -55,6 +57,8 @@ impl<'a> LinkBuilder<'a> {
     pub fn new(client_id: &'a str, router_tx: Sender<(ConnectionId, Event)>) -> Self {
         LinkBuilder {
             client_id,
+            identity: None,
+            acl_handler: None,
             router_tx,
             tenant_id: None,
             clean_session: true,
@@ -67,6 +71,16 @@ impl<'a> LinkBuilder<'a> {
 
     pub fn tenant_id(mut self, tenant_id: Option<String>) -> Self {
         self.tenant_id = tenant_id;
+        self
+    }
+
+    pub fn identity(mut self, identity: ClientIdentity) -> Self {
+        self.identity = Some(identity);
+        self
+    }
+
+    pub fn acl_handler(mut self, handler: Option<AclHandler>) -> Self {
+        self.acl_handler = handler;
         self
     }
 
@@ -99,14 +113,18 @@ impl<'a> LinkBuilder<'a> {
     }
 
     pub fn build(self) -> Result<(LinkTx, LinkRx, Notification), LinkError> {
-        // Connect to router
-        // Local connections to the router shall have access to all subscriptions
+        // Local links are broker-internal and intentionally bypass remote ACLs.
+        let identity = self.identity.unwrap_or_else(|| {
+            ClientIdentity::unauthenticated(self.client_id.to_owned(), self.tenant_id.clone())
+        });
         let mut connection = Connection::new(
             self.tenant_id,
             self.client_id.to_owned(),
             self.clean_session,
             self.dynamic_filters,
+            identity,
         );
+        connection.acl_handler(self.acl_handler);
 
         connection
             .last_will(self.last_will, self.last_will_properties)

--- a/rumqttd/src/link/remote.rs
+++ b/rumqttd/src/link/remote.rs
@@ -4,7 +4,7 @@ use crate::link::network::Network;
 use crate::local::LinkBuilder;
 use crate::protocol::{ConnAck, Connect, ConnectReturnCode, Login, Packet, Protocol};
 use crate::router::{Event, Notification};
-use crate::{ConnectionId, ConnectionSettings};
+use crate::{ClientIdentity, ConnectionId, ConnectionSettings};
 
 use flume::{RecvError, SendError, Sender, TrySendError};
 use std::cmp::min;
@@ -68,14 +68,23 @@ impl<P: Protocol> RemoteLink<P> {
         connect_packet: Packet,
         dynamic_filters: bool,
         assigned_client_id: Option<String>,
+        auth_configured: bool,
+        acl_handler: Option<crate::AclHandler>,
     ) -> Result<RemoteLink<P>, Error> {
-        let Packet::Connect(connect, props, lastwill, lastwill_props, _) = connect_packet else {
+        let Packet::Connect(connect, props, lastwill, lastwill_props, login) = connect_packet
+        else {
             return Err(Error::NotConnectPacket(connect_packet));
         };
 
         // Register this connection with the router. Router replys with ack which if ok will
         // start the link. Router can sometimes reject the connection (ex max connection limit)
         let client_id = assigned_client_id.as_ref().unwrap_or(&connect.client_id);
+        let identity = if auth_configured {
+            let username = login.ok_or(Error::InvalidAuth)?.username;
+            ClientIdentity::authenticated(client_id.to_owned(), username, tenant_id.clone())
+        } else {
+            ClientIdentity::unauthenticated(client_id.to_owned(), tenant_id.clone())
+        };
         let clean_session = connect.clean_session;
 
         let topic_alias_max = props.as_ref().and_then(|p| p.topic_alias_max);
@@ -92,9 +101,10 @@ impl<P: Protocol> RemoteLink<P> {
         // The Server delays publishing the Client’s Will Message until
         // the Will Delay Interval has passed or the Session ends, whichever happens first
         let will_delay_interval = min(session_expiry, delay_interval);
-
         let (link_tx, link_rx, notification) = LinkBuilder::new(client_id, router_tx)
             .tenant_id(tenant_id)
+            .identity(identity)
+            .acl_handler(acl_handler)
             .clean_session(clean_session)
             .last_will(lastwill)
             .last_will_properties(lastwill_props)
@@ -282,6 +292,7 @@ mod tests {
             max_inflight_count: 0,
             auth: None,
             external_auth: None,
+            external_acl: None,
             dynamic_filters: false,
         }
     }

--- a/rumqttd/src/router/connection.rs
+++ b/rumqttd/src/router/connection.rs
@@ -1,7 +1,10 @@
 use slab::Slab;
 
 use crate::protocol::LastWillProperties;
-use crate::Filter;
+use crate::{
+    acl::{AclAction, AclHandler, ClientIdentity},
+    Filter,
+};
 use crate::{protocol::LastWill, Topic};
 use std::collections::{HashMap, HashSet};
 
@@ -9,10 +12,13 @@ use super::ConnectionEvents;
 
 /// Used to register a new connection with the router
 /// Connection messages encompasses a handle for router to
-/// communicate with this connection
 #[derive(Debug)]
 pub struct Connection {
     pub client_id: String,
+    /// Authenticated identity used for ACL decisions.
+    pub identity: ClientIdentity,
+    /// Optional topic authorization policy for this connection.
+    pub(crate) acl_handler: Option<AclHandler>,
     /// Id of client's organisation/tenant and the prefix associated with tenant's MQTT topic
     pub tenant_prefix: Option<String>,
     /// Dynamically create subscription filters incase they didn't exist during a publish
@@ -42,6 +48,7 @@ impl Connection {
         client_id: String,
         clean: bool,
         dynamic_filters: bool,
+        identity: ClientIdentity,
     ) -> Connection {
         // Change client id to -> tenant_id.client_id and derive topic path prefix
         // to validate topics
@@ -56,6 +63,8 @@ impl Connection {
 
         Connection {
             client_id,
+            identity,
+            acl_handler: None,
             tenant_prefix,
             dynamic_filters,
             clean,
@@ -85,6 +94,18 @@ impl Connection {
         self.last_will = will;
         self.last_will_properties = props;
         self
+    }
+
+    pub fn acl_handler(&mut self, handler: Option<AclHandler>) -> &mut Self {
+        self.acl_handler = handler;
+        self
+    }
+
+    pub fn allows(&self, action: AclAction, topic: &str) -> bool {
+        match &self.acl_handler {
+            Some(handler) => handler.allows(&self.identity, action, topic),
+            None => true,
+        }
     }
 }
 
@@ -138,5 +159,33 @@ impl BrokerAliases {
         self.broker_topic_aliases
             .insert(topic.to_owned(), alias_to_use);
         Some(alias_to_use)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Connection;
+    use crate::{AclAction, AclHandler, ClientIdentity};
+
+    #[test]
+    fn connection_keeps_acl_identity() {
+        let identity =
+            ClientIdentity::authenticated("client-1", "user-1", Some("tenant-1".to_owned()));
+        let connection =
+            Connection::new(None, "client-1".to_owned(), true, false, identity.clone());
+
+        assert_eq!(connection.identity, identity);
+    }
+
+    #[test]
+    fn connection_applies_publish_acl() {
+        let identity = ClientIdentity::unauthenticated("client-1", None);
+        let mut connection = Connection::new(None, "client-1".to_owned(), true, false, identity);
+        connection.acl_handler(Some(AclHandler::new(|_, action, topic| {
+            action == AclAction::Publish && topic == "allowed/topic"
+        })));
+
+        assert!(connection.allows(AclAction::Publish, "allowed/topic"));
+        assert!(!connection.allows(AclAction::Publish, "denied/topic"));
     }
 }

--- a/rumqttd/src/router/routing.rs
+++ b/rumqttd/src/router/routing.rs
@@ -100,8 +100,16 @@ pub struct Router {
     cache: Option<VecDeque<Packet>>,
     /// Shared subscriptions map <group-name, group>
     shared_subscriptions: HashMap<String, SharedGroup>,
-    /// Will messages per client_id
-    last_wills: HashMap<String, (LastWill, Option<LastWillProperties>)>,
+    /// Will message and authorization context per client.
+    last_wills: HashMap<
+        String,
+        (
+            LastWill,
+            Option<LastWillProperties>,
+            Option<AclHandler>,
+            ClientIdentity,
+        ),
+    >,
 }
 
 impl Router {
@@ -350,7 +358,12 @@ impl Router {
         if let Some(will) = connection.last_will.take() {
             self.last_wills.insert(
                 client_id.clone(),
-                (will, connection.last_will_properties.take()),
+                (
+                    will,
+                    connection.last_will_properties.take(),
+                    connection.acl_handler.clone(),
+                    connection.identity.clone(),
+                ),
             );
         }
 
@@ -557,27 +570,28 @@ impl Router {
 
         for packet in packets.drain(0..) {
             match packet {
-                Packet::Publish(publish, properties) => {
+                Packet::Publish(mut publish, mut properties) => {
                     let span = tracing::error_span!("publish", topic = ?publish.topic, pkid = publish.pkid);
                     let _guard = span.enter();
 
                     let qos = publish.qos;
                     let pkid = publish.pkid;
 
+                    if let Err(e) =
+                        authorize_publish(id, &mut publish, &mut properties, &mut self.connections)
+                    {
+                        error!(reason = ?e, "Publish is not authorized");
+                        disconnect = true;
+                        if let RouterError::Disconnect(code) = e {
+                            disconnect_reason = Some(code);
+                        }
+                        break;
+                    }
+
                     // Prepare acks for the above publish
                     // If any of the publish in the batch results in force flush,
-                    // set global force flush flag. Force flush is triggered when the
-                    // router is in instant ack more or connection data is from a replica
-                    //
-                    // TODO: handle multiple offsets
-                    //
-                    // The problem with multiple offsets is that when using replication with the current
-                    // architecture, a single publish might get appended to multiple commit logs, resulting in
-                    // multiple offsets (see `append_to_commitlog` function), meaning replicas will need to
-                    // coordinate using multiple offsets, and we don't have any idea how to do so right now.
-                    // Currently as we don't have replication, we just use a single offset, even when appending to
-                    // multiple commit logs.
-
+                    // set global force flush flag. Force flush is triggered when
+                    // the router is in instant ack mode or connection data is from a replica
                     match qos {
                         QoS::AtLeastOnce => {
                             let puback = PubAck {
@@ -615,6 +629,7 @@ impl Router {
                         &mut self.datalog,
                         &mut self.notifications,
                         &mut self.connections,
+                        false,
                     ) {
                         Ok(_offset) => {
                             // Even if one of the data in the batch is appended to commitlog,
@@ -649,8 +664,17 @@ impl Router {
                     let mut return_codes = Vec::new();
                     let pkid = subscribe.pkid;
                     // let len = s.len();
+                    let subscription_id = props.as_ref().and_then(|p| p.id);
+                    if subscription_id == Some(0) {
+                        error!("Subscription identifier can't be 0");
+                        disconnect = true;
+                        disconnect_reason = Some(DisconnectReasonCode::ProtocolError);
+                    }
 
                     for f in &mut subscribe.filters {
+                        if disconnect {
+                            break;
+                        }
                         let span =
                             tracing::info_span!("subscribe", topic = f.path, pkid = subscribe.pkid);
                         let _guard = span.enter();
@@ -660,9 +684,14 @@ impl Router {
 
                         if let Err(e) = validate_subscription(connection, f) {
                             warn!(reason = ?e,"Subscription cannot be validated: {}", e);
-
                             disconnect = true;
                             break;
+                        }
+
+                        if !self.connections[id].allows(AclAction::Subscribe, &f.path) {
+                            warn!("Subscription is not authorized: {}", f.path);
+                            return_codes.push(SubscribeReasonCode::Failure);
+                            continue;
                         }
 
                         let mut filter = f.path.clone();
@@ -672,15 +701,6 @@ impl Router {
                             group = Some(grp);
                             filter = filter_path;
                         };
-
-                        let subscription_id = props.as_ref().and_then(|p| p.id);
-
-                        if subscription_id == Some(0) {
-                            error!("Subscription identifier can't be 0");
-                            disconnect = true;
-                            disconnect_reason = Some(DisconnectReasonCode::ProtocolError);
-                            break;
-                        }
 
                         let (idx, cursor) = self.datalog.next_native_offset(&filter);
 
@@ -708,57 +728,63 @@ impl Router {
                     force_ack = true;
                 }
                 Packet::Unsubscribe(unsubscribe, _) => {
-                    let connection = self.connections.get_mut(id).unwrap();
                     let pkid = unsubscribe.pkid;
+                    let mut reasons = Vec::with_capacity(unsubscribe.filters.len());
+
                     for filter in &unsubscribe.filters {
                         let span = tracing::info_span!("unsubscribe", topic = filter, pkid);
                         let _guard = span.enter();
 
-                        debug!("Removing subscription on filter {}", filter);
-                        if let Some(connection_ids) = self.subscription_map.get_mut(filter) {
-                            let removed = connection_ids.remove(&id);
-                            if !removed {
-                                continue;
-                            }
-
-                            let meter = &mut self.ibufs.get_mut(id).unwrap().meter;
-                            meter.unregister_subscription(filter);
-
-                            if !connection.subscriptions.remove(filter) {
-                                warn!(
-                                    pkid = unsubscribe.pkid,
-                                    "Unsubscribe failed as filter was not subscribed previously"
-                                );
-                                continue;
-                            }
-
-                            // Remove connections from all groups
-                            // discard empty group ( group with no client )
-                            // note: can we do this in better way?
-                            self.shared_subscriptions.retain(|_, group| {
-                                group.remove_client(&client_id);
-                                !group.is_empty()
-                            });
-
-                            if let Some(broker_aliases) = connection.broker_topic_aliases.as_mut() {
-                                broker_aliases.remove_alias(filter);
-                            }
-
-                            // remove the subscription id
-                            connection.subscription_ids.remove(filter);
-
-                            let unsuback = UnsubAck {
-                                pkid,
-                                // reasons are used in MQTTv5
-                                reasons: vec![UnsubAckReason::Success],
-                            };
-                            let ackslog = self.ackslog.get_mut(id).unwrap();
-                            ackslog.unsuback(unsuback);
-                            self.scheduler.untrack(id, filter);
-                            self.datalog.remove_waiters_for_id(id, filter);
-                            force_ack = true;
+                        if !self.connections[id].allows(AclAction::Unsubscribe, filter) {
+                            warn!("Unsubscribe is not authorized: {}", filter);
+                            reasons.push(UnsubAckReason::NotAuthorized);
+                            continue;
                         }
+
+                        debug!("Removing subscription on filter {}", filter);
+                        let Some(connection_ids) = self.subscription_map.get_mut(filter) else {
+                            reasons.push(UnsubAckReason::NoSubscriptionExisted);
+                            continue;
+                        };
+
+                        if !connection_ids.remove(&id) {
+                            reasons.push(UnsubAckReason::NoSubscriptionExisted);
+                            continue;
+                        }
+
+                        let meter = &mut self.ibufs.get_mut(id).unwrap().meter;
+                        meter.unregister_subscription(filter);
+
+                        if !self.connections[id].subscriptions.remove(filter) {
+                            warn!(
+                                pkid = unsubscribe.pkid,
+                                "Unsubscribe failed as filter was not subscribed previously"
+                            );
+                            reasons.push(UnsubAckReason::NoSubscriptionExisted);
+                            continue;
+                        }
+
+                        self.shared_subscriptions.retain(|_, group| {
+                            group.remove_client(&client_id);
+                            !group.is_empty()
+                        });
+
+                        if let Some(broker_aliases) =
+                            self.connections[id].broker_topic_aliases.as_mut()
+                        {
+                            broker_aliases.remove_alias(filter);
+                        }
+
+                        self.connections[id].subscription_ids.remove(filter);
+                        self.scheduler.untrack(id, filter);
+                        self.datalog.remove_waiters_for_id(id, filter);
+                        reasons.push(UnsubAckReason::Success);
                     }
+
+                    let unsuback = UnsubAck { pkid, reasons };
+                    let ackslog = self.ackslog.get_mut(id).unwrap();
+                    ackslog.unsuback(unsuback);
+                    force_ack = true;
                 }
                 Packet::PubAck(puback, _) => {
                     let span = tracing::info_span!("puback", pkid = puback.pkid);
@@ -826,6 +852,7 @@ impl Router {
                         &mut self.datalog,
                         &mut self.notifications,
                         &mut self.connections,
+                        true,
                     ) {
                         Ok(_offset) => {
                             // Even if one of the data in the batch is appended to commitlog,
@@ -1100,9 +1127,20 @@ impl Router {
         #[cfg(feature = "validate-tenant-prefix")]
         let tenant_prefix = tenant_id.map(|id| format!("/tenants/{id}/"));
 
-        let Some((will, will_props)) = self.last_wills.remove(&client_id) else {
+        let Some((will, will_props, acl_handler, identity)) = self.last_wills.remove(&client_id)
+        else {
             return;
         };
+
+        if let Some(handler) = acl_handler {
+            let Ok(topic) = std::str::from_utf8(&will.topic) else {
+                return;
+            };
+            if !handler.allows(&identity, AclAction::Will, topic) {
+                warn!("Will publication is not authorized: {}", topic);
+                return;
+            }
+        }
 
         let publish = Publish {
             dup: false,
@@ -1183,6 +1221,24 @@ impl Router {
         }
     }
 }
+fn authorize_publish(
+    id: ConnectionId,
+    publish: &mut Publish,
+    properties: &mut Option<PublishProperties>,
+    connections: &mut Slab<Connection>,
+) -> Result<(), RouterError> {
+    let connection = connections.get_mut(id).unwrap();
+    if let Some(alias) = properties.as_ref().and_then(|p| p.topic_alias) {
+        validate_and_set_topic_alias(publish, connection, alias)?;
+    }
+
+    let topic = std::str::from_utf8(&publish.topic)?;
+    if !connection.allows(AclAction::Publish, topic) {
+        return Err(RouterError::Disconnect(DisconnectReasonCode::NotAuthorized));
+    }
+
+    Ok(())
+}
 
 fn append_to_commitlog(
     id: ConnectionId,
@@ -1191,6 +1247,7 @@ fn append_to_commitlog(
     datalog: &mut DataLog,
     notifications: &mut VecDeque<(ConnectionId, DataRequest)>,
     connections: &mut Slab<Connection>,
+    recheck_acl: bool,
 ) -> Result<Offset, RouterError> {
     let connection = connections.get_mut(id).unwrap();
 
@@ -1215,6 +1272,9 @@ fn append_to_commitlog(
     };
 
     let topic = std::str::from_utf8(&publish.topic)?;
+    if recheck_acl && !connection.allows(AclAction::Publish, topic) {
+        return Err(RouterError::Disconnect(DisconnectReasonCode::NotAuthorized));
+    }
 
     // Ensure that only clients associated with a tenant can publish to tenant's topic
     #[cfg(feature = "validate-tenant-prefix")]
@@ -1755,6 +1815,195 @@ fn extract_group(filter: &str) -> Option<(String, String)> {
         s.split_once('/')
             .map(|(group, path)| (group.to_string(), path.to_string()))
     })
+}
+
+#[cfg(test)]
+mod acl_tests {
+    use super::*;
+    use crate::protocol::{Filter as TopicFilter, RetainForwardRule, Subscribe, Unsubscribe};
+    use crate::router::Ack;
+    use bytes::Bytes;
+    use std::collections::HashSet;
+
+    fn router() -> Router {
+        Router::new(
+            0,
+            RouterConfig {
+                max_connections: 1,
+                max_segment_size: 1024,
+                max_segment_count: 1,
+                initialized_filters: Some(vec!["will/topic".to_owned()]),
+                ..RouterConfig::default()
+            },
+        )
+    }
+
+    fn add_will(router: &mut Router, handler: AclHandler) {
+        router.last_wills.insert(
+            "client-1".to_owned(),
+            (
+                LastWill {
+                    topic: Bytes::from_static(b"will/topic"),
+                    message: Bytes::from_static(b"payload"),
+                    qos: QoS::AtMostOnce,
+                    retain: false,
+                },
+                None,
+                Some(handler),
+                ClientIdentity::authenticated("client-1", "user-1", None),
+            ),
+        );
+    }
+
+    fn connected_router(handler: AclHandler) -> (Router, ConnectionId) {
+        let mut router = router();
+        let identity = ClientIdentity::authenticated("client-1", "user-1", None);
+        let mut connection = Connection::new(None, "client-1".to_owned(), true, false, identity);
+        connection.acl_handler(Some(handler));
+        let id = router.connections.insert(connection);
+        let incoming = Incoming::new("client-1".to_owned());
+        let (outgoing, _rx) = Outgoing::new("client-1".to_owned());
+
+        assert_eq!(router.ibufs.insert(incoming), id);
+        assert_eq!(router.obufs.insert(outgoing), id);
+        assert_eq!(router.ackslog.insert(AckLog::new()), id);
+        assert_eq!(
+            router.scheduler.add(Tracker::new("client-1".to_owned())),
+            id
+        );
+        (router, id)
+    }
+
+    #[cfg(not(feature = "validate-tenant-prefix"))]
+    fn publish_will(router: &mut Router) {
+        router.handle_last_will("client-1".to_owned());
+    }
+
+    #[cfg(feature = "validate-tenant-prefix")]
+    fn publish_will(router: &mut Router) {
+        router.handle_last_will("client-1".to_owned(), None);
+    }
+
+    #[test]
+    fn denied_will_does_not_reach_commit_log() {
+        let mut router = router();
+        add_will(
+            &mut router,
+            AclHandler::new(|_, action, _| action != AclAction::Will),
+        );
+
+        publish_will(&mut router);
+
+        assert_eq!(router.datalog.native[0].log.entries(), 0);
+    }
+
+    #[test]
+    fn allowed_will_reaches_commit_log() {
+        let mut router = router();
+        add_will(
+            &mut router,
+            AclHandler::new(|identity, action, topic| {
+                identity.client_id == "client-1"
+                    && action == AclAction::Will
+                    && topic == "will/topic"
+            }),
+        );
+
+        publish_will(&mut router);
+
+        assert_eq!(router.datalog.native[0].log.entries(), 1);
+    }
+
+    #[test]
+    fn denied_publish_is_rejected_before_commit_log() {
+        let mut router = router();
+        let identity = ClientIdentity::authenticated("client-1", "user-1", None);
+        let mut connection = Connection::new(None, "client-1".to_owned(), true, false, identity);
+        connection.acl_handler(Some(AclHandler::new(|_, _, _| false)));
+        let id = router.connections.insert(connection);
+        let mut publish = Publish {
+            dup: false,
+            qos: QoS::AtMostOnce,
+            pkid: 0,
+            retain: false,
+            topic: Bytes::from_static(b"will/topic"),
+            payload: Bytes::from_static(b"payload"),
+        };
+
+        let result = authorize_publish(id, &mut publish, &mut None, &mut router.connections);
+
+        assert!(matches!(
+            result,
+            Err(RouterError::Disconnect(DisconnectReasonCode::NotAuthorized))
+        ));
+        assert_eq!(router.datalog.native[0].log.entries(), 0);
+    }
+
+    #[test]
+    fn denied_subscribe_returns_failure_without_state_change() {
+        let (mut router, id) = connected_router(AclHandler::new(|_, action, _| {
+            action != AclAction::Subscribe
+        }));
+        let filter = TopicFilter {
+            path: "denied/topic".to_owned(),
+            qos: QoS::AtMostOnce,
+            nolocal: false,
+            preserve_retain: false,
+            retain_forward_rule: RetainForwardRule::Never,
+        };
+        router.ibufs[id].buffer.lock().push_back(Packet::Subscribe(
+            Subscribe {
+                pkid: 1,
+                filters: vec![filter],
+            },
+            None,
+        ));
+
+        router.handle_device_payload(id);
+
+        assert!(router.connections[id].subscriptions.is_empty());
+        let ack = router.ackslog[id].readv().back().cloned().unwrap();
+        match ack {
+            Ack::SubAck(suback) => {
+                assert_eq!(suback.return_codes, vec![SubscribeReasonCode::Failure]);
+            }
+            _ => panic!("expected suback"),
+        }
+    }
+
+    #[test]
+    fn denied_unsubscribe_returns_not_authorized_without_state_change() {
+        let (mut router, id) = connected_router(AclHandler::new(|_, action, _| {
+            action != AclAction::Unsubscribe
+        }));
+        let filter = "topic".to_owned();
+        router.connections[id].subscriptions.insert(filter.clone());
+        router
+            .subscription_map
+            .insert(filter.clone(), HashSet::from([id]));
+        router.ibufs[id]
+            .buffer
+            .lock()
+            .push_back(Packet::Unsubscribe(
+                Unsubscribe {
+                    pkid: 1,
+                    filters: vec![filter.clone()],
+                },
+                None,
+            ));
+
+        router.handle_device_payload(id);
+
+        assert!(router.connections[id].subscriptions.contains(&filter));
+        assert!(router.subscription_map[&filter].contains(&id));
+        let ack = router.ackslog[id].readv().back().cloned().unwrap();
+        match ack {
+            Ack::UnsubAck(unsuback) => {
+                assert_eq!(unsuback.reasons, vec![UnsubAckReason::NotAuthorized]);
+            }
+            _ => panic!("expected unsuback"),
+        }
+    }
 }
 // #[cfg(test)]
 // #[allow(non_snake_case)]

--- a/rumqttd/src/server/broker.rs
+++ b/rumqttd/src/server/broker.rs
@@ -505,6 +505,8 @@ async fn remote<P: Protocol>(
     );
 
     let dynamic_filters = config.dynamic_filters;
+    let auth_configured = config.auth.is_some() || config.external_auth.is_some();
+    let acl_handler = config.external_acl.clone();
 
     let connect_packet = match mqtt_connect(config, &mut network).await {
         Ok(p) => p,
@@ -550,7 +552,6 @@ async fn remote<P: Protocol>(
         .unwrap()
         .insert(client_id.clone(), will_tx);
 
-    // Start the link
     let mut link = match RemoteLink::new(
         router_tx.clone(),
         tenant_id.clone(),
@@ -558,6 +559,8 @@ async fn remote<P: Protocol>(
         connect_packet,
         dynamic_filters,
         assigned_client_id,
+        auth_configured,
+        acl_handler,
     )
     .await
     {


### PR DESCRIPTION
## What

Add optional topic-level ACL enforcement to the embedded `rumqttd` broker.

## Why

Embedded broker users need per-client authorization for publish, subscribe, unsubscribe, and will-message topics without changing clients that do not configure ACLs.

## How

- Add `ClientIdentity`, `AclAction`, and `ConnectionSettings::set_acl_handler`.
- Thread authenticated identity and ACL handlers through remote connections.
- Reject unauthorized publishes before acknowledgements or commit-log writes.
- Return per-filter subscription/unsubscription authorization results.
- Check delayed will messages before commit-log insertion.
- Keep broker-internal local links explicitly trusted.
- Bump `rumqttd` to `0.21.0` for the public `ConnectionSettings` field change.
- Document the API and add router-level ACL regression tests.

## Testing

- `cargo test -p rumqttd`
- `cargo test -p rumqttd --features validate-tenant-prefix`

Both pass: 37 passed, 2 ignored.